### PR TITLE
refactor(chips): remove unused erase_4k/32k/64k feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,8 +422,6 @@ Example chip definition:
         wrsr_wren: true,
         fast_read: true,
         quad_io: true,
-        erase_4k: true,
-        erase_64k: true,
     ),
     voltage: (min: 2700, max: 3600),
     erase_blocks: [

--- a/chips/vendors/amic.ron
+++ b/chips/vendors/amic.ron
@@ -220,7 +220,7 @@
             name: "A25LQ032/A25LQ32A",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -234,7 +234,7 @@
             name: "A25LQ16",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -248,7 +248,7 @@
             name: "A25LQ64",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -261,7 +261,7 @@
             name: "A25L010",
             device_id: 0x3011,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -273,7 +273,7 @@
             name: "A25L016",
             device_id: 0x3015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -285,7 +285,7 @@
             name: "A25L020",
             device_id: 0x3012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -297,7 +297,7 @@
             name: "A25L032",
             device_id: 0x3016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -312,7 +312,7 @@
             name: "A25L040",
             device_id: 0x3013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -324,7 +324,7 @@
             name: "A25L080",
             device_id: 0x3014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -336,7 +336,7 @@
             name: "A25L512",
             device_id: 0x3010,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),

--- a/chips/vendors/atmel.ron
+++ b/chips/vendors/atmel.ron
@@ -10,7 +10,7 @@
             name: "AT25DF021",
             device_id: 0x4300,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -23,7 +23,7 @@
             name: "AT25DF021A",
             device_id: 0x4301,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -36,7 +36,7 @@
             name: "AT25DF041A",
             device_id: 0x4401,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -49,7 +49,7 @@
             name: "AT25DF081",
             device_id: 0x4502,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -62,7 +62,7 @@
             name: "AT25DF081A",
             device_id: 0x4501,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -75,7 +75,7 @@
             name: "AT25DF161",
             device_id: 0x4602,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -88,7 +88,7 @@
             name: "AT25DF321",
             device_id: 0x4700,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -101,7 +101,7 @@
             name: "AT25DF321A",
             device_id: 0x4701,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -114,7 +114,7 @@
             name: "AT25DF641(A)",
             device_id: 0x4800,
             total_size: MiB(8),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -127,7 +127,7 @@
             name: "AT25DL081",
             device_id: 0x4503,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -140,7 +140,7 @@
             name: "AT25DL161",
             device_id: 0x4603,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -176,7 +176,7 @@
             name: "AT25F512B",
             device_id: 0x6500,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -222,7 +222,7 @@
             name: "AT25FS010",
             device_id: 0x6601,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -235,7 +235,7 @@
             name: "AT25FS040",
             device_id: 0x6604,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -249,7 +249,7 @@
             name: "AT25SF041",
             device_id: 0x8401,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -262,7 +262,7 @@
             name: "AT25SF081",
             device_id: 0x8501,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -275,7 +275,7 @@
             name: "AT25SF128A",
             device_id: 0x8901,
             total_size: MiB(16),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2500, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -288,7 +288,7 @@
             name: "AT25SF161",
             device_id: 0x8601,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2500, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -301,7 +301,7 @@
             name: "AT25SF321",
             device_id: 0x8701,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2500, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -315,7 +315,7 @@
             name: "AT25SL128A",
             device_id: 0x4218,
             total_size: MiB(16),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -328,7 +328,7 @@
             name: "AT25DQ161",
             device_id: 0x8600,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -340,7 +340,7 @@
             name: "AT26DF041",
             device_id: 0x4400,
             total_size: KiB(512),
-            features: (erase_4k: true),
+            features: (),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x50, regions: [(size: KiB(2), count: 256)]),
@@ -352,7 +352,7 @@
             name: "AT26DF081A",
             device_id: 0x4501,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -367,7 +367,7 @@
             name: "AT26DF161",
             device_id: 0x4600,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -380,7 +380,7 @@
             name: "AT26DF161A",
             device_id: 0x4601,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -393,7 +393,7 @@
             name: "AT26F004",
             device_id: 0x0400,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),

--- a/chips/vendors/boya.ron
+++ b/chips/vendors/boya.ron
@@ -9,7 +9,7 @@
             name: "BY25Q128FS",
             device_id: 0x4118,
             total_size: MiB(16),
-            features: (otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),

--- a/chips/vendors/eon.ron
+++ b/chips/vendors/eon.ron
@@ -10,7 +10,7 @@
             name: "EN25Q40",
             device_id: 0x3013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -23,7 +23,7 @@
             name: "EN25Q80",
             device_id: 0x3014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -36,7 +36,7 @@
             name: "EN25Q16",
             device_id: 0x3015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -50,7 +50,7 @@
             name: "EN25Q32",
             device_id: 0x3016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -64,7 +64,7 @@
             name: "EN25Q64",
             device_id: 0x3017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -78,7 +78,7 @@
             name: "EN25Q128",
             device_id: 0x3018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -94,7 +94,7 @@
             name: "EN25QH16",
             device_id: 0x7015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -108,7 +108,7 @@
             name: "EN25QH32",
             device_id: 0x7016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -123,7 +123,7 @@
             name: "EN25QH64",
             device_id: 0x7017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -138,7 +138,7 @@
             name: "EN25QH128",
             device_id: 0x7018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -153,7 +153,7 @@
             name: "EN25B05",
             device_id: 0x2010,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xC7, regions: [(size: KiB(64), count: 1)]),
@@ -163,7 +163,7 @@
             name: "EN25B05T",
             device_id: 0x2010,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xC7, regions: [(size: KiB(64), count: 1)]),
@@ -254,7 +254,7 @@
             name: "EN25F05",
             device_id: 0x3110,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -269,7 +269,7 @@
             name: "EN25F10",
             device_id: 0x3111,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -284,7 +284,7 @@
             name: "EN25F16",
             device_id: 0x3115,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -296,7 +296,7 @@
             name: "EN25F20",
             device_id: 0x3112,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -310,7 +310,7 @@
             name: "EN25F32",
             device_id: 0x3116,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -322,7 +322,7 @@
             name: "EN25F40",
             device_id: 0x3113,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -336,7 +336,7 @@
             name: "EN25F64",
             device_id: 0x3117,
             total_size: MiB(8),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -348,7 +348,7 @@
             name: "EN25F80",
             device_id: 0x3114,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -362,7 +362,7 @@
             name: "EN25P05",
             device_id: 0x2010,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(32), count: 2)]),
@@ -373,7 +373,7 @@
             name: "EN25P10",
             device_id: 0x2011,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_32k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(32), count: 4)]),
@@ -384,7 +384,7 @@
             name: "EN25P16",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 32)]),
@@ -394,7 +394,7 @@
             name: "EN25P20",
             device_id: 0x2012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 4)]),
@@ -405,7 +405,7 @@
             name: "EN25P32",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 64)]),
@@ -415,7 +415,7 @@
             name: "EN25P40",
             device_id: 0x2013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 8)]),
@@ -426,7 +426,7 @@
             name: "EN25P64",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),
@@ -436,7 +436,7 @@
             name: "EN25P80",
             device_id: 0x2014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 16)]),
@@ -447,7 +447,7 @@
             name: "EN25Q32(A/B)",
             device_id: 0x3016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -459,7 +459,7 @@
             name: "EN25Q80(A)",
             device_id: 0x3014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -472,7 +472,7 @@
             name: "EN25QH32B",
             device_id: 0x7016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -487,7 +487,7 @@
             name: "EN25QH64A",
             device_id: 0x7017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -502,7 +502,7 @@
             name: "EN25S10",
             device_id: 0x3811,
             total_size: KiB(128),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -515,7 +515,7 @@
             name: "EN25S16",
             device_id: 0x3815,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -529,7 +529,7 @@
             name: "EN25S20",
             device_id: 0x3812,
             total_size: KiB(256),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -542,7 +542,7 @@
             name: "EN25S32",
             device_id: 0x3816,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -556,7 +556,7 @@
             name: "EN25S40",
             device_id: 0x3813,
             total_size: KiB(512),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -570,7 +570,7 @@
             name: "EN25S64",
             device_id: 0x3817,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -584,7 +584,7 @@
             name: "EN25S80",
             device_id: 0x3814,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),

--- a/chips/vendors/esi.ron
+++ b/chips/vendors/esi.ron
@@ -9,7 +9,7 @@
             name: "ES25P16",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 32)]),
@@ -20,7 +20,7 @@
             name: "ES25P40",
             device_id: 0x2013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 8)]),
@@ -31,7 +31,7 @@
             name: "ES25P80",
             device_id: 0x2014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 16)]),

--- a/chips/vendors/esmt.ron
+++ b/chips/vendors/esmt.ron
@@ -10,7 +10,7 @@
             name: "F25L004A",
             device_id: 0x2013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -23,7 +23,7 @@
             name: "F25L008A",
             device_id: 0x2014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -36,7 +36,7 @@
             name: "F25L016A",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -49,7 +49,7 @@
             name: "F25L032A",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -63,7 +63,7 @@
             name: "F25D08QA",
             device_id: 0x3214,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, dual_io: true),
+            features: (wrsr_wren: true, dual_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -77,7 +77,7 @@
             name: "F49L004UA",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -90,7 +90,7 @@
             name: "F25L32PA",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (otp: true, erase_4k: true, erase_64k: true),
+            features: (otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),

--- a/chips/vendors/fudan.ron
+++ b/chips/vendors/fudan.ron
@@ -9,7 +9,7 @@
             name: "FM25F005",
             device_id: 0x3110,
             total_size: KiB(64),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -23,7 +23,7 @@
             name: "FM25F01",
             device_id: 0x3111,
             total_size: KiB(128),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -37,7 +37,7 @@
             name: "FM25F02(A)",
             device_id: 0x3112,
             total_size: KiB(256),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -51,7 +51,7 @@
             name: "FM25F04(A)",
             device_id: 0x3113,
             total_size: KiB(512),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -65,7 +65,7 @@
             name: "FM25Q02",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -79,7 +79,7 @@
             name: "FM25Q04",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -93,7 +93,7 @@
             name: "FM25Q08",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -107,7 +107,7 @@
             name: "FM25Q08A",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -121,7 +121,7 @@
             name: "FM25Q16",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -133,7 +133,7 @@
             name: "FM25Q32",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -145,7 +145,7 @@
             name: "FM25Q64",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -159,7 +159,7 @@
             name: "FM25Q128",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),

--- a/chips/vendors/gigadevice.ron
+++ b/chips/vendors/gigadevice.ron
@@ -10,7 +10,7 @@
             name: "GD25T80",
             device_id: 0x3114,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -26,7 +26,7 @@
             name: "GD25Q512",
             device_id: 0x4010,
             total_size: KiB(64),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -41,7 +41,7 @@
             name: "GD25Q10",
             device_id: 0x4011,
             total_size: KiB(128),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -56,7 +56,7 @@
             name: "GD25Q20",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -71,7 +71,7 @@
             name: "GD25Q40",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -86,7 +86,7 @@
             name: "GD25Q80",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -101,7 +101,7 @@
             name: "GD25Q16",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -116,7 +116,7 @@
             name: "GD25Q32",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -131,7 +131,7 @@
             name: "GD25Q64",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -146,7 +146,7 @@
             name: "GD25Q128",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -161,7 +161,7 @@
             name: "GD25Q256D",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -177,7 +177,7 @@
             name: "GD25VQ21B",
             device_id: 0x4212,
             total_size: KiB(256),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -191,7 +191,7 @@
             name: "GD25VQ40C",
             device_id: 0x4213,
             total_size: KiB(512),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -205,7 +205,7 @@
             name: "GD25VQ41B",
             device_id: 0x4213,
             total_size: KiB(512),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -220,7 +220,7 @@
             name: "GD25VQ80C",
             device_id: 0x4214,
             total_size: MiB(1),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -234,7 +234,7 @@
             name: "GD25VQ16C",
             device_id: 0x4215,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -250,7 +250,7 @@
             name: "GD25LQ20",
             device_id: 0x6012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -264,7 +264,7 @@
             name: "GD25LQ40",
             device_id: 0x6013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -278,7 +278,7 @@
             name: "GD25LQ80",
             device_id: 0x6014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -292,7 +292,7 @@
             name: "GD25LQ16",
             device_id: 0x6015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -306,7 +306,7 @@
             name: "GD25LQ32",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -320,7 +320,7 @@
             name: "GD25LQ64",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -334,7 +334,7 @@
             name: "GD25LQ128",
             device_id: 0x6018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -348,7 +348,7 @@
             name: "GD25LQ256D",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -364,7 +364,7 @@
             name: "GD25LF80E",
             device_id: 0x6314,
             total_size: MiB(1),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -378,7 +378,7 @@
             name: "GD25LF16E",
             device_id: 0x6315,
             total_size: MiB(2),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -392,7 +392,7 @@
             name: "GD25LF32E",
             device_id: 0x6316,
             total_size: MiB(4),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -406,7 +406,7 @@
             name: "GD25LF64E",
             device_id: 0x6317,
             total_size: MiB(8),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -420,7 +420,7 @@
             name: "GD25LF128E",
             device_id: 0x6318,
             total_size: MiB(16),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -436,7 +436,7 @@
             name: "GD25WQ80E",
             device_id: 0x6514,
             total_size: MiB(1),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -450,7 +450,7 @@
             name: "GD25LQ128C/GD25LQ128D/GD25LQ128E",
             device_id: 0x6018,
             total_size: MiB(16),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -463,7 +463,7 @@
             name: "GD25LQ256D/GD25LE256D/GD25LB256D/GD25LQ255E",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -475,7 +475,7 @@
             name: "GD25LQ256H/GD25LE256H/GD25LB256F",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -490,7 +490,7 @@
             name: "GD25LE255E",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -505,7 +505,7 @@
             name: "GD25LB256E/GD25LR256E",
             device_id: 0x6719,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -520,7 +520,7 @@
             name: "GD25LQ64(B)",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -533,7 +533,7 @@
             name: "GD25LB512ME/GD25LR512ME",
             device_id: 0x671A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -549,7 +549,7 @@
             name: "GD25LB512MF/GD25LR512MF",
             device_id: 0x601A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -564,7 +564,7 @@
             name: "GD55LB01GE",
             device_id: 0x671B,
             total_size: MiB(128),
-            features: (otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 32768)]),
@@ -579,7 +579,7 @@
             name: "GD55LB01GF",
             device_id: 0x601B,
             total_size: MiB(128),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 32768)]),
@@ -594,7 +594,7 @@
             name: "GD55LB02GE",
             device_id: 0x671C,
             total_size: MiB(256),
-            features: (otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 65536)]),
@@ -609,7 +609,7 @@
             name: "GD55LB02GF",
             device_id: 0x601C,
             total_size: MiB(256),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 65536)]),
@@ -624,7 +624,7 @@
             name: "GD25Q127C/GD25B127D",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -637,7 +637,7 @@
             name: "GD25Q128B/GD25B128B",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -650,7 +650,7 @@
             name: "GD25Q128C",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -663,7 +663,7 @@
             name: "GD25Q128E/GD25B128E/GD25R128E/GD25Q128H/GD25B128H",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -675,7 +675,7 @@
             name: "GD25Q16(B)",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -688,7 +688,7 @@
             name: "GD25Q20(B)",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -703,7 +703,7 @@
             name: "GD25Q256D/GD25B256D",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -719,7 +719,7 @@
             name: "GD25Q257D/GD25B257D",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -734,7 +734,7 @@
             name: "GD25Q256E/GD25B256E/GD25R256E",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -749,7 +749,7 @@
             name: "GD25Q32(B)",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -762,7 +762,7 @@
             name: "GD25Q40(B)",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -777,7 +777,7 @@
             name: "GD25Q64(B)",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -790,7 +790,7 @@
             name: "GD25Q80(B)",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -805,7 +805,7 @@
             name: "GD25B512ME/GD25R512ME",
             device_id: 0x471A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -822,7 +822,7 @@
             name: "GD25B512MF/GD25R512MF",
             device_id: 0x401A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -839,7 +839,7 @@
             name: "GD55B01GE",
             device_id: 0x471B,
             total_size: MiB(128),
-            features: (otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 32768)]),
@@ -854,7 +854,7 @@
             name: "GD55B01GF",
             device_id: 0x401B,
             total_size: MiB(128),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 32768)]),
@@ -869,7 +869,7 @@
             name: "GD55B02GE",
             device_id: 0x471C,
             total_size: MiB(256),
-            features: (otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 65536)]),
@@ -884,7 +884,7 @@
             name: "GD55B02GF",
             device_id: 0x401C,
             total_size: MiB(256),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 65536)]),

--- a/chips/vendors/intel.ron
+++ b/chips/vendors/intel.ron
@@ -9,7 +9,7 @@
             name: "25F160S33B8",
             device_id: 0x8911,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 32)]),
@@ -19,7 +19,7 @@
             name: "25F160S33T8",
             device_id: 0x8915,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 32)]),
@@ -29,7 +29,7 @@
             name: "25F320S33B8",
             device_id: 0x8912,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 64)]),
@@ -39,7 +39,7 @@
             name: "25F320S33T8",
             device_id: 0x8916,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 64)]),
@@ -49,7 +49,7 @@
             name: "25F640S33B8",
             device_id: 0x8913,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),
@@ -60,7 +60,7 @@
             name: "25F640S33T8",
             device_id: 0x8917,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),

--- a/chips/vendors/issi.ron
+++ b/chips/vendors/issi.ron
@@ -10,7 +10,7 @@
             name: "IS25LP016D",
             device_id: 0x6015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -23,7 +23,7 @@
             name: "IS25LP032",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -36,7 +36,7 @@
             name: "IS25LP064",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -49,7 +49,7 @@
             name: "IS25LP128",
             device_id: 0x6018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -62,7 +62,7 @@
             name: "IS25LP256",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
+            features: (wrsr_wren: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -76,7 +76,7 @@
             name: "IS25WP016D",
             device_id: 0x7015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -89,7 +89,7 @@
             name: "IS25WP032",
             device_id: 0x7016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -102,7 +102,7 @@
             name: "IS25WP064",
             device_id: 0x7017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -115,7 +115,7 @@
             name: "IS25WP128",
             device_id: 0x7018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -128,7 +128,7 @@
             name: "IS25WP256",
             device_id: 0x7019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
+            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),

--- a/chips/vendors/macronix.ron
+++ b/chips/vendors/macronix.ron
@@ -10,7 +10,7 @@
             name: "MX25L512",
             device_id: 0x2010,
             total_size: KiB(64),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -24,7 +24,7 @@
             name: "MX25L1005",
             device_id: 0x2011,
             total_size: KiB(128),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -38,7 +38,7 @@
             name: "MX25L2005",
             device_id: 0x2012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -53,7 +53,7 @@
             name: "MX25L4005",
             device_id: 0x2013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -67,7 +67,7 @@
             name: "MX25L8005",
             device_id: 0x2014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -81,7 +81,7 @@
             name: "MX25L1605",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -96,7 +96,7 @@
             name: "MX25L1605A",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -111,7 +111,7 @@
             name: "MX25L1605D",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -125,7 +125,7 @@
             name: "MX25L1635D",
             device_id: 0x2415,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -139,7 +139,7 @@
             name: "MX25L1635E",
             device_id: 0x2515,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -152,7 +152,7 @@
             name: "MX25L5121E",
             device_id: 0x2210,
             total_size: KiB(64),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -167,7 +167,7 @@
             name: "MX25L3205",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -181,7 +181,7 @@
             name: "MX25L3205D",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -195,7 +195,7 @@
             name: "MX25L3206E",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -210,7 +210,7 @@
             name: "MX25L3233F",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -225,7 +225,7 @@
             name: "MX25L3235D",
             device_id: 0x5E16,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -240,7 +240,7 @@
             name: "MX25L6405",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),
@@ -253,7 +253,7 @@
             name: "MX25L6405D",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),
@@ -266,7 +266,7 @@
             name: "MX25L6406E",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -280,7 +280,7 @@
             name: "MX25L6436E",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -295,7 +295,7 @@
             name: "MX25L6495F",
             device_id: 0x9517,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -310,7 +310,7 @@
             name: "MX25L12805D",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -324,7 +324,7 @@
             name: "MX25L12833F",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -339,7 +339,7 @@
             name: "MX25L25635F",
             device_id: 0x2019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -357,7 +357,7 @@
             name: "MX66L51235F",
             device_id: 0x201A,
             total_size: MiB(64),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -375,7 +375,7 @@
             name: "MX66L1G45G",
             device_id: 0x201B,
             total_size: MiB(128),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 32768)]),
@@ -394,7 +394,7 @@
             name: "MX25U8032E",
             device_id: 0x2534,
             total_size: MiB(1),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -409,7 +409,7 @@
             name: "MX25U1635E",
             device_id: 0x2535,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -424,7 +424,7 @@
             name: "MX25U3235E",
             device_id: 0x2536,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -439,7 +439,7 @@
             name: "MX25U6435E",
             device_id: 0x2537,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -454,7 +454,7 @@
             name: "MX25U12835F",
             device_id: 0x2538,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -469,7 +469,7 @@
             name: "MX25U25635F",
             device_id: 0x2539,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -487,7 +487,7 @@
             name: "MX25U51245G",
             device_id: 0x253A,
             total_size: MiB(64),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -507,7 +507,7 @@
             name: "MX25R3235F",
             device_id: 0x2816,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -522,7 +522,7 @@
             name: "MX25R6435F",
             device_id: 0x2817,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 1650, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -537,7 +537,7 @@
             name: "MX25L1005(C)/MX25L1006E",
             device_id: 0x2011,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -551,7 +551,7 @@
             name: "MX25L12833F/MX25L12835F/MX25L12845E/MX25L12865E/MX25L12873F",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -564,7 +564,7 @@
             name: "MX25L1605A/MX25L1606E/MX25L1608E",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -577,7 +577,7 @@
             name: "MX25L1605D/MX25L1608D/MX25L1673E",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -589,7 +589,7 @@
             name: "MX25L2005(C)/MX25L2006E",
             device_id: 0x2012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -604,7 +604,7 @@
             name: "MX25L25635F/MX25L25645G",
             device_id: 0x2019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -620,7 +620,7 @@
             name: "MX25L3205(A)",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(64), count: 64)]),
@@ -632,7 +632,7 @@
             name: "MX25L3205D/MX25L3208D",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -644,7 +644,7 @@
             name: "MX25L3206E/MX25L3208E",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -657,7 +657,7 @@
             name: "MX25L3233F/MX25L3273E",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -670,7 +670,7 @@
             name: "MX25L4005(A/C)/MX25L4006E",
             device_id: 0x2013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -685,7 +685,7 @@
             name: "MX25L512(E)/MX25V512(C)",
             device_id: 0x2010,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -700,7 +700,7 @@
             name: "MX25L6406E/MX25L6408E",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -713,7 +713,7 @@
             name: "MX25L6436E/MX25L6445E/MX25L6465E/MX25L6473E/MX25L6473F",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -726,7 +726,7 @@
             name: "MX25L8005/MX25L8006E/MX25L8008E/MX25V8005",
             device_id: 0x2014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -741,7 +741,7 @@
             name: "MX25U3235E/F",
             device_id: 0x2536,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -754,7 +754,7 @@
             name: "MX25U6435E/F",
             device_id: 0x2537,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -767,7 +767,7 @@
             name: "MX66L51235F/MX25L51245G",
             device_id: 0x201A,
             total_size: MiB(64),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),

--- a/chips/vendors/micron.ron
+++ b/chips/vendors/micron.ron
@@ -110,7 +110,7 @@
             name: "M25PE10",
             device_id: 0x8011,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -122,7 +122,7 @@
             name: "M25PE20",
             device_id: 0x8012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -134,7 +134,7 @@
             name: "M25PE40",
             device_id: 0x8013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -146,7 +146,7 @@
             name: "M25PE80",
             device_id: 0x8014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -158,7 +158,7 @@
             name: "M25PE16",
             device_id: 0x8015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -171,7 +171,7 @@
             name: "N25Q016",
             device_id: 0xBB15,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -184,7 +184,7 @@
             name: "N25Q032",
             device_id: 0xBA16,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -197,7 +197,7 @@
             name: "N25Q064",
             device_id: 0xBA17,
             total_size: MiB(8),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -210,7 +210,7 @@
             name: "N25Q128",
             device_id: 0xBA18,
             total_size: MiB(16),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -223,7 +223,7 @@
             name: "N25Q256",
             device_id: 0xBA19,
             total_size: MiB(32),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
+            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -236,7 +236,7 @@
             name: "N25Q512",
             device_id: 0xBA20,
             total_size: MiB(64),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
+            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16384)]),
@@ -250,7 +250,7 @@
             name: "MT25QL128",
             device_id: 0xBA18,
             total_size: MiB(16),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -263,7 +263,7 @@
             name: "MT25QL256",
             device_id: 0xBA19,
             total_size: MiB(32),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
+            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -276,7 +276,7 @@
             name: "MT25QL512",
             device_id: 0xBA20,
             total_size: MiB(64),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
+            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16384)]),
@@ -289,7 +289,7 @@
             name: "MT25QL01G",
             device_id: 0xBA21,
             total_size: MiB(128),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 32768)]),
@@ -306,7 +306,7 @@
             name: "MT25QU01G",
             device_id: 0xBB21,
             total_size: MiB(128),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 32768)]),
@@ -322,7 +322,7 @@
             name: "MT25QL02G",
             device_id: 0xBA22,
             total_size: MiB(256),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 65536)]),
@@ -338,7 +338,7 @@
             name: "MT25QU02G",
             device_id: 0xBB22,
             total_size: MiB(256),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 65536)]),
@@ -354,7 +354,7 @@
             name: "MT25QU128",
             device_id: 0xBB18,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -368,7 +368,7 @@
             name: "MT25QU256",
             device_id: 0xBB19,
             total_size: MiB(32),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -386,7 +386,7 @@
             name: "MT25QU512",
             device_id: 0xBB20,
             total_size: MiB(64),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),

--- a/chips/vendors/nantronics.ron
+++ b/chips/vendors/nantronics.ron
@@ -9,7 +9,7 @@
             name: "N25S10",
             device_id: 0x3011,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -24,7 +24,7 @@
             name: "N25S16",
             device_id: 0x3015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -37,7 +37,7 @@
             name: "N25S20",
             device_id: 0x3012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -52,7 +52,7 @@
             name: "N25S40",
             device_id: 0x3013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -67,7 +67,7 @@
             name: "N25S80",
             device_id: 0x3014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),

--- a/chips/vendors/pmc.ron
+++ b/chips/vendors/pmc.ron
@@ -9,7 +9,7 @@
             name: "Pm25LD010(C)",
             device_id: 0x0021,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -24,7 +24,7 @@
             name: "Pm25LD020(C)",
             device_id: 0x0022,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -39,7 +39,7 @@
             name: "Pm25LD040(C)",
             device_id: 0x007E,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -54,7 +54,7 @@
             name: "Pm25LD256C",
             device_id: 0x002F,
             total_size: KiB(32),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8)]),
@@ -68,7 +68,7 @@
             name: "Pm25LD512(C)",
             device_id: 0x0020,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -83,7 +83,7 @@
             name: "Pm25LQ016",
             device_id: 0x0045,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -97,7 +97,7 @@
             name: "Pm25LQ020",
             device_id: 0x0042,
             total_size: KiB(256),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -111,7 +111,7 @@
             name: "Pm25LQ032C",
             device_id: 0x0046,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -126,7 +126,7 @@
             name: "Pm25LQ040",
             device_id: 0x0043,
             total_size: KiB(512),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -140,7 +140,7 @@
             name: "Pm25LQ080",
             device_id: 0x0044,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -154,7 +154,7 @@
             name: "Pm25LV010",
             device_id: 0x007C,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 32)]),
@@ -167,7 +167,7 @@
             name: "Pm25LV010A",
             device_id: 0x007C,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 32)]),
@@ -180,7 +180,7 @@
             name: "Pm25LV016B",
             device_id: 0x0014,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 512)]),
@@ -192,7 +192,7 @@
             name: "Pm25LV020",
             device_id: 0x007D,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 64)]),
@@ -204,7 +204,7 @@
             name: "Pm25LV040",
             device_id: 0x007E,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 128)]),
@@ -217,7 +217,7 @@
             name: "Pm25LV080B",
             device_id: 0x0013,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 256)]),
@@ -231,7 +231,7 @@
             name: "Pm25LV512(A)",
             device_id: 0x007B,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 16)]),

--- a/chips/vendors/puya.ron
+++ b/chips/vendors/puya.ron
@@ -9,7 +9,7 @@
             name: "P25Q05H",
             device_id: 0x6010,
             total_size: KiB(64),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -23,7 +23,7 @@
             name: "P25Q06H",
             device_id: 0x4010,
             total_size: KiB(64),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -37,7 +37,7 @@
             name: "P25Q10H",
             device_id: 0x6011,
             total_size: KiB(128),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -51,7 +51,7 @@
             name: "P25Q11H",
             device_id: 0x4011,
             total_size: KiB(128),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -65,7 +65,7 @@
             name: "P25Q20H",
             device_id: 0x6012,
             total_size: KiB(256),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -79,7 +79,7 @@
             name: "P25Q21H",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -93,7 +93,7 @@
             name: "P25Q40H",
             device_id: 0x6013,
             total_size: KiB(512),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -107,7 +107,7 @@
             name: "P25Q40SH",
             device_id: 0x6013,
             total_size: KiB(512),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -121,7 +121,7 @@
             name: "P25Q80H",
             device_id: 0x6014,
             total_size: MiB(1),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -135,7 +135,7 @@
             name: "P25Q80SH",
             device_id: 0x6014,
             total_size: MiB(1),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -149,7 +149,7 @@
             name: "P25Q16H",
             device_id: 0x6015,
             total_size: MiB(2),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -163,7 +163,7 @@
             name: "P25Q16SH",
             device_id: 0x6015,
             total_size: MiB(2),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -177,7 +177,7 @@
             name: "P25Q32H",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -191,7 +191,7 @@
             name: "P25Q32SH",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -205,7 +205,7 @@
             name: "P25Q64H",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -219,7 +219,7 @@
             name: "P25Q64SH",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -233,7 +233,7 @@
             name: "P25Q128H",
             device_id: 0x6018,
             total_size: MiB(16),
-            features: (otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -247,7 +247,7 @@
             name: "PY25Q40HB",
             device_id: 0x2013,
             total_size: KiB(512),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -261,7 +261,7 @@
             name: "PY25Q80HB",
             device_id: 0x2014,
             total_size: MiB(1),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -275,7 +275,7 @@
             name: "PY25Q16HB",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -289,7 +289,7 @@
             name: "PY25Q32HB",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -303,7 +303,7 @@
             name: "PY25Q64HA",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -317,7 +317,7 @@
             name: "PY25F64HA",
             device_id: 0x2317,
             total_size: MiB(8),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -331,7 +331,7 @@
             name: "PY25Q128HA",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -345,7 +345,7 @@
             name: "PY25F128HA/PY25R128HA",
             device_id: 0x2318,
             total_size: MiB(16),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -359,7 +359,7 @@
             name: "PY25Q256HB",
             device_id: 0x2019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -376,7 +376,7 @@
             name: "PY25F256HB",
             device_id: 0x2319,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -393,7 +393,7 @@
             name: "PY25Q512HB",
             device_id: 0x201A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -410,7 +410,7 @@
             name: "PY25F512HB",
             device_id: 0x231A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -427,7 +427,7 @@
             name: "PY25Q01GHB",
             device_id: 0x201B,
             total_size: MiB(128),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 32768)]),

--- a/chips/vendors/sanyo.ron
+++ b/chips/vendors/sanyo.ron
@@ -9,7 +9,7 @@
             name: "LE25FU106B",
             device_id: 0x001D,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_32k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(2), count: 64)]),
@@ -21,7 +21,7 @@
             name: "LE25FU206",
             device_id: 0x0044,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 64)]),
@@ -33,7 +33,7 @@
             name: "LE25FU206A",
             device_id: 0x0612,
             total_size: KiB(256),
-            features: (erase_4k: true, erase_64k: true),
+            features: (),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -47,7 +47,7 @@
             name: "LE25FU406B",
             device_id: 0x001E,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 128)]),
@@ -60,7 +60,7 @@
             name: "LE25FU406C/LE25U40CMC",
             device_id: 0x0613,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -75,7 +75,7 @@
             name: "LE25FW106",
             device_id: 0x0015,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_32k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(2), count: 64)]),
@@ -88,7 +88,7 @@
             name: "LE25FW203A",
             device_id: 0x1600,
             total_size: KiB(256),
-            features: (erase_64k: true),
+            features: (),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 4)]),
@@ -99,7 +99,7 @@
             name: "LE25FW403A",
             device_id: 0x1100,
             total_size: KiB(512),
-            features: (erase_64k: true),
+            features: (),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 8)]),
@@ -110,7 +110,7 @@
             name: "LE25FW406A",
             device_id: 0x001A,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 128)]),
@@ -123,7 +123,7 @@
             name: "LE25FW418A",
             device_id: 0x0010,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(4), count: 128)]),
@@ -135,7 +135,7 @@
             name: "LE25FW806",
             device_id: 0x0026,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -148,7 +148,7 @@
             name: "LE25FW808",
             device_id: 0x0020,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD7, regions: [(size: KiB(8), count: 128)]),

--- a/chips/vendors/spansion.ron
+++ b/chips/vendors/spansion.ron
@@ -10,7 +10,7 @@
             name: "S25FL004A",
             device_id: 0x0212,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 8)]),
@@ -22,7 +22,7 @@
             name: "S25FL008A",
             device_id: 0x0213,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 16)]),
@@ -34,7 +34,7 @@
             name: "S25FL016A",
             device_id: 0x0214,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 32)]),
@@ -46,7 +46,7 @@
             name: "S25FL032A",
             device_id: 0x0215,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 64)]),
@@ -58,7 +58,7 @@
             name: "S25FL064A",
             device_id: 0x0216,
             total_size: MiB(8),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),
@@ -70,7 +70,7 @@
             name: "S25FL128S",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 256)]),
@@ -83,7 +83,7 @@
             name: "S25FL256",
             device_id: 0x0219,
             total_size: MiB(32),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, four_byte_enter: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, four_byte_enter: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -98,7 +98,7 @@
             name: "S25FL128L",
             device_id: 0x6018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, status_reg_3: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -112,7 +112,7 @@
             name: "S25FL256L",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, status_reg_3: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -131,7 +131,7 @@
             name: "S25FL116K",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, quad_io: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, otp: true, quad_io: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -145,7 +145,7 @@
             name: "S25FL132K",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, quad_io: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, otp: true, quad_io: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -159,7 +159,7 @@
             name: "S25FL164K",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, quad_io: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, otp: true, quad_io: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -173,7 +173,7 @@
             name: "S25FL032A/P",
             device_id: 0x0215,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 64)]),
@@ -184,7 +184,7 @@
             name: "S25FL064A/P",
             device_id: 0x0216,
             total_size: MiB(8),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),
@@ -195,7 +195,7 @@
             name: "S25FL116K/S25FL216K",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -220,7 +220,7 @@
             name: "S25FL127S-64kB",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 256)]),
@@ -233,7 +233,7 @@
             name: "S25FL128P......0",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(64), count: 256)]),
@@ -258,7 +258,7 @@
             name: "S25FL128S......0",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 256)]),
@@ -283,7 +283,7 @@
             name: "S25FL129P......0",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 256)]),
@@ -308,7 +308,7 @@
             name: "S25FL204K",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -322,7 +322,7 @@
             name: "S25FL208K",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -336,7 +336,7 @@
             name: "S25FL256S......0",
             device_id: 0x0219,
             total_size: MiB(32),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xDC, regions: [(size: KiB(64), count: 512)]),

--- a/chips/vendors/sst.ron
+++ b/chips/vendors/sst.ron
@@ -10,7 +10,7 @@
             name: "SST25VF512",
             device_id: 0x2548,
             total_size: KiB(64),
-            features: (wrsr_wren: false, erase_4k: true),
+            features: (wrsr_wren: false),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -22,7 +22,7 @@
             name: "SST25VF512A",
             device_id: 0x4800,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -34,7 +34,7 @@
             name: "SST25VF010",
             device_id: 0x2549,
             total_size: KiB(128),
-            features: (wrsr_wren: false, erase_4k: true),
+            features: (wrsr_wren: false),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -46,7 +46,7 @@
             name: "SST25VF010A",
             device_id: 0x4900,
             total_size: KiB(128),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -58,7 +58,7 @@
             name: "SST25VF020",
             device_id: 0x2543,
             total_size: KiB(256),
-            features: (wrsr_wren: false, erase_4k: true),
+            features: (wrsr_wren: false),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -70,7 +70,7 @@
             name: "SST25VF020B",
             device_id: 0x258C,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -83,7 +83,7 @@
             name: "SST25VF040",
             device_id: 0x258D,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -96,7 +96,7 @@
             name: "SST25VF040B",
             device_id: 0x258D,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -109,7 +109,7 @@
             name: "SST25VF080B",
             device_id: 0x258E,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -122,7 +122,7 @@
             name: "SST25VF016B",
             device_id: 0x2541,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -135,7 +135,7 @@
             name: "SST25VF032B",
             device_id: 0x254A,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -148,7 +148,7 @@
             name: "SST25VF064C",
             device_id: 0x254B,
             total_size: MiB(8),
-            features: (wrsr_wren: true, erase_4k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -162,7 +162,7 @@
             name: "SST26VF016B",
             device_id: 0x2601,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -175,7 +175,7 @@
             name: "SST26VF032",
             device_id: 0x2602,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -188,7 +188,7 @@
             name: "SST26VF064B",
             device_id: 0x2603,
             total_size: MiB(8),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true, quad_io: true),
+            features: (wrsr_wren: true, quad_io: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -201,7 +201,7 @@
             name: "SST25LF020A",
             device_id: 0x0043,
             total_size: KiB(256),
-            features: (erase_4k: true, erase_32k: true),
+            features: (),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -214,7 +214,7 @@
             name: "SST25LF040A",
             device_id: 0x0044,
             total_size: KiB(512),
-            features: (erase_4k: true, erase_32k: true),
+            features: (),
             voltage: (min: 3000, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -227,7 +227,7 @@
             name: "SST25LF080(A)",
             device_id: 0x0080,
             total_size: MiB(1),
-            features: (erase_4k: true, erase_32k: true),
+            features: (),
             voltage: (min: 3000, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -239,7 +239,7 @@
             name: "SST25VF010(A)",
             device_id: 0x0049,
             total_size: KiB(128),
-            features: (erase_4k: true, erase_32k: true),
+            features: (),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -254,7 +254,7 @@
             name: "SST25VF040B.REMS",
             device_id: 0x008D,
             total_size: KiB(512),
-            features: (erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -269,7 +269,7 @@
             name: "SST25VF512(A)",
             device_id: 0x0048,
             total_size: KiB(64),
-            features: (erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -284,7 +284,7 @@
             name: "SST25WF010",
             device_id: 0x2502,
             total_size: KiB(128),
-            features: (erase_4k: true, erase_32k: true),
+            features: (),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -297,7 +297,7 @@
             name: "SST25WF020",
             device_id: 0x2503,
             total_size: KiB(256),
-            features: (erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -311,7 +311,7 @@
             name: "SST25WF020A",
             device_id: 0x1612,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -324,7 +324,7 @@
             name: "SST25WF040",
             device_id: 0x2504,
             total_size: KiB(512),
-            features: (erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -338,7 +338,7 @@
             name: "SST25WF040B",
             device_id: 0x1613,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -351,7 +351,7 @@
             name: "SST25WF080",
             device_id: 0x2505,
             total_size: MiB(1),
-            features: (erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -366,7 +366,7 @@
             name: "SST25WF080B",
             device_id: 0x1614,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -380,7 +380,7 @@
             name: "SST25WF512",
             device_id: 0x2501,
             total_size: KiB(64),
-            features: (erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -393,7 +393,7 @@
             name: "SST26VF016",
             device_id: 0x2601,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, erase_4k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -403,7 +403,7 @@
             name: "SST26VF016B(A)",
             device_id: 0x2641,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, erase_4k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -414,7 +414,7 @@
             name: "SST26VF032B(A)",
             device_id: 0x2642,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, erase_4k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -424,7 +424,7 @@
             name: "SST26VF064B(A)",
             device_id: 0x2643,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, erase_4k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -435,7 +435,7 @@
             name: "SST26VF080A",
             device_id: 0x2618,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),

--- a/chips/vendors/winbond.ron
+++ b/chips/vendors/winbond.ron
@@ -10,7 +10,7 @@
             name: "W25Q16.V",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -25,7 +25,7 @@
             name: "W25Q32.V",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -40,7 +40,7 @@
             name: "W25Q64.V",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -55,7 +55,7 @@
             name: "W25Q128.V",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -70,7 +70,7 @@
             name: "W25Q256JV_Q",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_cmp: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_cmp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -87,7 +87,7 @@
             name: "W25Q512JV",
             device_id: 0x4020,
             total_size: MiB(64),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -106,7 +106,7 @@
             name: "W25Q16.W",
             device_id: 0x6015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -121,7 +121,7 @@
             name: "W25Q32.W",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -136,7 +136,7 @@
             name: "W25Q64.W",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -151,7 +151,7 @@
             name: "W25Q128.W",
             device_id: 0x6018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -166,7 +166,7 @@
             name: "W25Q256JW",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -185,7 +185,7 @@
             name: "W25Q32JV_M",
             device_id: 0x7016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -200,7 +200,7 @@
             name: "W25Q64JV_M",
             device_id: 0x7017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -215,7 +215,7 @@
             name: "W25Q128JV_M",
             device_id: 0x7018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -230,7 +230,7 @@
             name: "W25Q256JV_M",
             device_id: 0x7019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_cmp: true),
+            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_cmp: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -249,7 +249,7 @@
             name: "W25X10",
             device_id: 0x3011,
             total_size: KiB(128),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -262,7 +262,7 @@
             name: "W25X20",
             device_id: 0x3012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -275,7 +275,7 @@
             name: "W25X40",
             device_id: 0x3013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -288,7 +288,7 @@
             name: "W25X80",
             device_id: 0x3014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -301,7 +301,7 @@
             name: "W25X16",
             device_id: 0x3015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -314,7 +314,7 @@
             name: "W25X32",
             device_id: 0x3016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -327,7 +327,7 @@
             name: "W25X64",
             device_id: 0x3017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, erase_4k: true, erase_64k: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -340,7 +340,7 @@
             name: "W25P16",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 32)]),
@@ -351,7 +351,7 @@
             name: "W25P32",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 64)]),
@@ -362,7 +362,7 @@
             name: "W25P80",
             device_id: 0x2014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 16)]),
@@ -373,7 +373,7 @@
             name: "W25Q128.V..M",
             device_id: 0x7018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -386,7 +386,7 @@
             name: "W25Q128.JW.DTR",
             device_id: 0x8018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -399,7 +399,7 @@
             name: "W25Q16JV_M",
             device_id: 0x7015,
             total_size: MiB(2),
-            features: (otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -413,7 +413,7 @@
             name: "W25Q20.W",
             device_id: 0x5012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -427,7 +427,7 @@
             name: "W25Q256FV",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -440,7 +440,7 @@
             name: "W25Q256JW_DTR",
             device_id: 0x8019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 8192)]),
@@ -455,7 +455,7 @@
             name: "W25Q32BV/W25Q32CV/W25Q32DV",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -468,7 +468,7 @@
             name: "W25Q32FV",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -481,7 +481,7 @@
             name: "W25Q32JV",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -494,7 +494,7 @@
             name: "W25Q32JV-.M",
             device_id: 0x7016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -507,7 +507,7 @@
             name: "W25Q32BW/W25Q32CW/W25Q32DW",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -520,7 +520,7 @@
             name: "W25Q32FW",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -533,7 +533,7 @@
             name: "W25Q32JW...Q",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -546,7 +546,7 @@
             name: "W25Q32JW...M",
             device_id: 0x8016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -559,7 +559,7 @@
             name: "W25Q40.V",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -574,7 +574,7 @@
             name: "W25Q40BW",
             device_id: 0x5013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -589,7 +589,7 @@
             name: "W25Q40EW",
             device_id: 0x6013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -604,7 +604,7 @@
             name: "W25R512NW/W74M51NW",
             device_id: 0x6020,
             total_size: MiB(64),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -619,7 +619,7 @@
             name: "W25Q512NW-IM",
             device_id: 0x8020,
             total_size: MiB(64),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x21, regions: [(size: KiB(4), count: 16384)]),
@@ -634,7 +634,7 @@
             name: "W25Q64BV/W25Q64CV/W25Q64FV",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -647,7 +647,7 @@
             name: "W25Q64JV-.Q",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -660,7 +660,7 @@
             name: "W25Q64JV-.M",
             device_id: 0x7017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -673,7 +673,7 @@
             name: "W25Q64DW",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -686,7 +686,7 @@
             name: "W25Q64FW/W25Q64JW...Q",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -699,7 +699,7 @@
             name: "W25Q64JW...M",
             device_id: 0x8017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -712,7 +712,7 @@
             name: "W25Q80.V",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -727,7 +727,7 @@
             name: "W25Q80BW",
             device_id: 0x5014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -740,7 +740,7 @@
             name: "W25Q80EW",
             device_id: 0x6014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -753,7 +753,7 @@
             name: "W25X05",
             device_id: 0x3010,
             total_size: KiB(64),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),

--- a/chips/vendors/xmc.ron
+++ b/chips/vendors/xmc.ron
@@ -10,7 +10,7 @@
             name: "XM25QH64C",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -24,7 +24,7 @@
             name: "XM25QH128C",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -38,7 +38,7 @@
             name: "XM25QH256C",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -54,7 +54,7 @@
             name: "XM25QU64C",
             device_id: 0x4117,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -68,7 +68,7 @@
             name: "XM25QU128C",
             device_id: 0x4118,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -82,7 +82,7 @@
             name: "XM25QU256C",
             device_id: 0x4119,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),

--- a/chips/vendors/xtx.ron
+++ b/chips/vendors/xtx.ron
@@ -10,7 +10,7 @@
             name: "XT25F02E",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -24,7 +24,7 @@
             name: "XT25F04D",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -38,7 +38,7 @@
             name: "XT25F08B",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, status_reg_2: true, qe_sr2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -52,7 +52,7 @@
             name: "XT25F16B",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -66,7 +66,7 @@
             name: "XT25F32B",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -80,7 +80,7 @@
             name: "XT25F64B",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -94,7 +94,7 @@
             name: "XT25F128B",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, qpi: true, otp: true, erase_4k: true, erase_32k: true, erase_64k: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -108,7 +108,7 @@
             name: "XT25F16F",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -122,7 +122,7 @@
             name: "XT25F32F",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -136,7 +136,7 @@
             name: "XT25F64F",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -150,7 +150,7 @@
             name: "XT25F128F/XT25BF128F",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (otp: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),

--- a/chips/vendors/zetta.ron
+++ b/chips/vendors/zetta.ron
@@ -9,7 +9,7 @@
             name: "ZD25D20",
             device_id: 0x2012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -23,7 +23,7 @@
             name: "ZD25D40",
             device_id: 0x2013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -37,7 +37,7 @@
             name: "ZD25LQ64",
             device_id: 0x4317,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -51,7 +51,7 @@
             name: "ZD25LQ128",
             device_id: 0x4218,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true, erase_4k: true, erase_32k: true, erase_64k: true),
+            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),

--- a/crates/rflasher-chips-codegen/src/lib.rs
+++ b/crates/rflasher-chips-codegen/src/lib.rs
@@ -119,14 +119,6 @@ pub struct FeaturesDef {
     /// Supports AAI (Auto Address Increment) word program
     pub aai_word: bool,
 
-    // Erase behavior
-    /// Has 4KB sector erase
-    pub erase_4k: bool,
-    /// Has 32KB block erase
-    pub erase_32k: bool,
-    /// Has 64KB block erase
-    pub erase_64k: bool,
-
     // Status register features
     /// Has status register 2
     pub status_reg_2: bool,
@@ -200,15 +192,6 @@ impl FeaturesDef {
         }
         if self.aai_word {
             flags.push(quote!(Features::AAI_WORD));
-        }
-        if self.erase_4k {
-            flags.push(quote!(Features::ERASE_4K));
-        }
-        if self.erase_32k {
-            flags.push(quote!(Features::ERASE_32K));
-        }
-        if self.erase_64k {
-            flags.push(quote!(Features::ERASE_64K));
         }
         if self.status_reg_2 {
             flags.push(quote!(Features::STATUS_REG_2));

--- a/crates/rflasher-core/src/chip/database.rs
+++ b/crates/rflasher-core/src/chip/database.rs
@@ -94,9 +94,6 @@ struct FeaturesDef {
     sfdp: bool,
     write_byte: bool,
     aai_word: bool,
-    erase_4k: bool,
-    erase_32k: bool,
-    erase_64k: bool,
     status_reg_2: bool,
     status_reg_3: bool,
     qe_sr2: bool,
@@ -156,15 +153,6 @@ impl From<FeaturesDef> for Features {
         }
         if def.aai_word {
             f |= Features::AAI_WORD;
-        }
-        if def.erase_4k {
-            f |= Features::ERASE_4K;
-        }
-        if def.erase_32k {
-            f |= Features::ERASE_32K;
-        }
-        if def.erase_64k {
-            f |= Features::ERASE_64K;
         }
         if def.status_reg_2 {
             f |= Features::STATUS_REG_2;

--- a/crates/rflasher-core/src/chip/features.rs
+++ b/crates/rflasher-core/src/chip/features.rs
@@ -52,14 +52,6 @@ bitflags! {
         /// Supports AAI (Auto Address Increment) word program
         const AAI_WORD        = 1 << 15;
 
-        // Erase behavior
-        /// Has 4KB sector erase
-        const ERASE_4K        = 1 << 16;
-        /// Has 32KB block erase
-        const ERASE_32K       = 1 << 17;
-        /// Has 64KB block erase
-        const ERASE_64K       = 1 << 18;
-
         // Status register features
         /// Has status register 2
         const STATUS_REG_2    = 1 << 19;

--- a/crates/rflasher-core/src/sfdp/parser.rs
+++ b/crates/rflasher-core/src/sfdp/parser.rs
@@ -516,16 +516,6 @@ pub fn to_flash_chip(info: &SfdpInfo, jedec_manufacturer: u8, jedec_device: u16)
     // Sort by size (smallest first)
     erase_blocks.sort_by_key(|eb| eb.min_block_size());
 
-    // Set erase feature flags
-    for eb in &erase_blocks {
-        match eb.uniform_size() {
-            Some(4096) => features |= Features::ERASE_4K,
-            Some(32768) => features |= Features::ERASE_32K,
-            Some(65536) => features |= Features::ERASE_64K,
-            _ => {}
-        }
-    }
-
     // Determine write granularity
     let write_granularity = if params.write_granularity_64 {
         WriteGranularity::Page


### PR DESCRIPTION
The erase_4k, erase_32k, and erase_64k boolean flags were never used
in the codebase - they were only set but never checked. Erase capability
information is already fully captured by the erase_blocks structure,
which provides more detailed and accurate information including opcodes
and block counts.