### PR TITLE
refactor: comprehensive code review fixes across core and programmer crates

### DIFF
--- a/crates/rflasher-core/src/chip/types.rs
+++ b/crates/rflasher-core/src/chip/types.rs
@@ -309,10 +309,13 @@ impl FlashChip {
         self.jedec_manufacturer == manufacturer && self.jedec_device == device
     }
 
+    /// Maximum addressable size with 3-byte addresses (16 MiB)
+    const MAX_3BYTE_ADDR_SIZE: u32 = 16 * 1024 * 1024;
+
     /// Check if this chip requires 4-byte addressing
     #[must_use]
     pub fn requires_4byte_addr(&self) -> bool {
-        self.total_size > 16 * 1024 * 1024
+        self.total_size > Self::MAX_3BYTE_ADDR_SIZE
     }
 
     /// Get the smallest erase block size across all erase operations

--- a/crates/rflasher-core/src/error.rs
+++ b/crates/rflasher-core/src/error.rs
@@ -47,9 +47,15 @@ pub enum Error {
     /// Erase operation failed
     EraseError(EraseFailure),
     /// Write/program operation failed
-    WriteError,
+    WriteError {
+        /// Address where write failed
+        addr: u32,
+    },
     /// Verify operation failed (data mismatch)
-    VerifyError,
+    VerifyError {
+        /// Address where mismatch was detected
+        addr: u32,
+    },
     /// Operation timed out
     Timeout,
 
@@ -77,7 +83,10 @@ pub enum Error {
 
     // I/O errors
     /// Read operation failed
-    ReadError,
+    ReadError {
+        /// Address where read failed
+        addr: u32,
+    },
     /// I/O error occurred
     IoError,
 
@@ -114,8 +123,12 @@ impl fmt::Display for Error {
             Self::ChipNotSupported => write!(f, "flash chip not supported"),
             Self::JedecIdMismatch => write!(f, "JEDEC ID mismatch"),
             Self::EraseError(failure) => write!(f, "{}", failure),
-            Self::WriteError => write!(f, "write operation failed"),
-            Self::VerifyError => write!(f, "verify failed: data mismatch"),
+            Self::WriteError { addr } => {
+                write!(f, "write operation failed at address 0x{addr:08X}")
+            }
+            Self::VerifyError { addr } => {
+                write!(f, "verify failed: data mismatch at address 0x{addr:08X}")
+            }
             Self::Timeout => write!(f, "operation timed out"),
             Self::AddressOutOfBounds => write!(f, "address out of bounds"),
             Self::InvalidAlignment => write!(f, "invalid alignment"),
@@ -125,7 +138,7 @@ impl fmt::Display for Error {
             Self::ProgrammerNotReady => write!(f, "programmer not ready"),
             Self::ProgrammerError => write!(f, "programmer error"),
             Self::IoModeNotSupported => write!(f, "I/O mode not supported by programmer"),
-            Self::ReadError => write!(f, "read operation failed"),
+            Self::ReadError { addr } => write!(f, "read operation failed at address 0x{addr:08X}"),
             Self::IoError => write!(f, "I/O error"),
             Self::LayoutError => write!(f, "layout validation failed"),
         }

--- a/crates/rflasher-core/src/flash/device.rs
+++ b/crates/rflasher-core/src/flash/device.rs
@@ -106,6 +106,8 @@ pub trait FlashDevice {
     async fn erase(&mut self, addr: u32, len: u32) -> Result<()>;
 
     /// Check if a range is valid for this device
+    ///
+    /// Uses u64 arithmetic to avoid truncation when `len > u32::MAX`.
     fn is_valid_range(&self, addr: u32, len: usize) -> bool {
         // Use u64 arithmetic to avoid truncation when len > u32::MAX
         let end = addr as u64 + len as u64;

--- a/crates/rflasher-core/src/flash/device.rs
+++ b/crates/rflasher-core/src/flash/device.rs
@@ -186,3 +186,68 @@ pub trait FlashDeviceExt: FlashDevice {
 
 #[cfg(feature = "alloc")]
 impl<D: FlashDevice + ?Sized> FlashDeviceExt for D {}
+
+// Blanket impl for boxed FlashDevice to allow trait objects (sync mode only).
+// In async mode, traits with async fn are not object-safe.
+#[cfg(all(feature = "alloc", feature = "is_sync"))]
+impl FlashDevice for alloc::boxed::Box<dyn FlashDevice + Send> {
+    fn size(&self) -> u32 {
+        (**self).size()
+    }
+
+    fn erase_granularity(&self) -> u32 {
+        (**self).erase_granularity()
+    }
+
+    fn write_granularity(&self) -> WriteGranularity {
+        (**self).write_granularity()
+    }
+
+    fn erase_blocks(&self) -> &[EraseBlock] {
+        (**self).erase_blocks()
+    }
+
+    fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
+        (**self).read(addr, buf)
+    }
+
+    fn write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
+        (**self).write(addr, data)
+    }
+
+    fn erase(&mut self, addr: u32, len: u32) -> Result<()> {
+        (**self).erase(addr, len)
+    }
+
+    fn is_valid_range(&self, addr: u32, len: usize) -> bool {
+        (**self).is_valid_range(addr, len)
+    }
+
+    fn wp_supported(&self) -> bool {
+        (**self).wp_supported()
+    }
+
+    fn read_wp_config(&mut self) -> WpResult<WpConfig> {
+        (**self).read_wp_config()
+    }
+
+    fn write_wp_config(&mut self, config: &WpConfig, options: WriteOptions) -> WpResult<()> {
+        (**self).write_wp_config(config, options)
+    }
+
+    fn set_wp_mode(&mut self, mode: WpMode, options: WriteOptions) -> WpResult<()> {
+        (**self).set_wp_mode(mode, options)
+    }
+
+    fn set_wp_range(&mut self, range: &WpRange, options: WriteOptions) -> WpResult<()> {
+        (**self).set_wp_range(range, options)
+    }
+
+    fn disable_wp(&mut self, options: WriteOptions) -> WpResult<()> {
+        (**self).disable_wp(options)
+    }
+
+    fn get_available_wp_ranges(&self) -> alloc::vec::Vec<WpRange> {
+        (**self).get_available_wp_ranges()
+    }
+}

--- a/crates/rflasher-core/src/flash/operations.rs
+++ b/crates/rflasher-core/src/flash/operations.rs
@@ -42,7 +42,7 @@ const ERASED_VALUE: u8 = 0xFF;
 /// `true` if erasing is required, `false` if the write can proceed without erase
 #[cfg(feature = "alloc")]
 pub fn need_erase(have: &[u8], want: &[u8], granularity: WriteGranularity) -> bool {
-    assert_eq!(have.len(), want.len());
+    assert_eq!(have.len(), want.len(), "need_erase: have and want must be the same length");
 
     match granularity {
         WriteGranularity::Bit => {
@@ -109,7 +109,7 @@ pub struct WriteRange {
 /// `Some(WriteRange)` if there are changes, `None` if no more changes from `offset`
 #[cfg(feature = "alloc")]
 pub fn get_next_write_range(have: &[u8], want: &[u8], offset: u32) -> Option<WriteRange> {
-    assert_eq!(have.len(), want.len());
+    assert_eq!(have.len(), want.len(), "get_next_write_range: have and want must be the same length");
 
     let start_offset = offset as usize;
     if start_offset >= have.len() {
@@ -762,7 +762,9 @@ pub async fn read<M: SpiMaster + ?Sized>(
 
     // Exit 4-byte mode if we entered it
     if enter_exit_4byte {
-        let _ = protocol::exit_4byte_mode(master).await;
+        if let Err(e) = protocol::exit_4byte_mode(master).await {
+            log::warn!("Failed to exit 4-byte address mode: {}", e);
+        }
     }
 
     result
@@ -772,6 +774,10 @@ pub async fn read<M: SpiMaster + ?Sized>(
 ///
 /// This function handles page alignment and splitting large writes
 /// into page-sized chunks. The target region must be erased first.
+///
+/// Respects the programmer's `max_write_len()` to avoid sending chunks
+/// larger than the hardware can handle (e.g., Intel swseq is limited to
+/// 64 bytes).
 #[maybe_async]
 pub async fn write<M: SpiMaster + ?Sized>(
     master: &mut M,
@@ -787,6 +793,10 @@ pub async fn write<M: SpiMaster + ?Sized>(
     let use_4byte = ctx.address_mode == AddressMode::FourByte;
     let use_native = ctx.use_native_4byte;
 
+    // Get the master's maximum write length - some controllers have limits
+    // smaller than a full page (e.g., Intel swseq is limited to 64 bytes)
+    let max_write = master.max_write_len();
+
     // Enter 4-byte mode if needed and not using native commands
     if use_4byte && !use_native {
         protocol::enter_4byte_mode(master).await?;
@@ -800,7 +810,8 @@ pub async fn write<M: SpiMaster + ?Sized>(
         let page_offset = (current_addr as usize) % page_size;
         let bytes_to_page_end = page_size - page_offset;
         let remaining = data.len() - offset;
-        let chunk_size = core::cmp::min(bytes_to_page_end, remaining);
+        // Respect both page boundaries and the master's maximum write length
+        let chunk_size = core::cmp::min(core::cmp::min(bytes_to_page_end, remaining), max_write);
 
         let chunk = &data[offset..offset + chunk_size];
 
@@ -813,7 +824,9 @@ pub async fn write<M: SpiMaster + ?Sized>(
         if result.is_err() {
             // Try to exit 4-byte mode before returning error
             if use_4byte && !use_native {
-                let _ = protocol::exit_4byte_mode(master).await;
+                if let Err(e) = protocol::exit_4byte_mode(master).await {
+                    log::warn!("Failed to exit 4-byte address mode: {}", e);
+                }
             }
             return result;
         }

--- a/crates/rflasher-core/src/flash/operations.rs
+++ b/crates/rflasher-core/src/flash/operations.rs
@@ -24,6 +24,7 @@ use super::context::{AddressMode, FlashContext};
 // =============================================================================
 
 /// The erased value for flash memory (all bits set)
+#[cfg(feature = "alloc")]
 const ERASED_VALUE: u8 = 0xFF;
 
 /// Determine if an erase is required to transition from `have` to `want`
@@ -42,7 +43,11 @@ const ERASED_VALUE: u8 = 0xFF;
 /// `true` if erasing is required, `false` if the write can proceed without erase
 #[cfg(feature = "alloc")]
 pub fn need_erase(have: &[u8], want: &[u8], granularity: WriteGranularity) -> bool {
-    assert_eq!(have.len(), want.len(), "need_erase: have and want must be the same length");
+    assert_eq!(
+        have.len(),
+        want.len(),
+        "need_erase: have and want must be the same length"
+    );
 
     match granularity {
         WriteGranularity::Bit => {
@@ -109,7 +114,11 @@ pub struct WriteRange {
 /// `Some(WriteRange)` if there are changes, `None` if no more changes from `offset`
 #[cfg(feature = "alloc")]
 pub fn get_next_write_range(have: &[u8], want: &[u8], offset: u32) -> Option<WriteRange> {
-    assert_eq!(have.len(), want.len(), "get_next_write_range: have and want must be the same length");
+    assert_eq!(
+        have.len(),
+        want.len(),
+        "get_next_write_range: have and want must be the same length"
+    );
 
     let start_offset = offset as usize;
     if start_offset >= have.len() {

--- a/crates/rflasher-core/src/flash/operations.rs
+++ b/crates/rflasher-core/src/flash/operations.rs
@@ -752,6 +752,7 @@ pub async fn read<M: SpiMaster + ?Sized>(
         IoMode::Qpi => {
             // QPI mode requires special handling - fall back to single for now
             // TODO: Implement QPI read when needed
+            log::warn!("QPI read mode not yet implemented, falling back to single I/O");
             if use_4byte {
                 protocol::read_4b(master, addr, buf).await
             } else {

--- a/crates/rflasher-core/src/flash/spi_device.rs
+++ b/crates/rflasher-core/src/flash/spi_device.rs
@@ -200,6 +200,7 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
             }
             IoMode::Qpi => {
                 // QPI mode requires special handling - fall back to single for now
+                log::warn!("QPI read mode not yet implemented, falling back to single I/O");
                 if use_4byte_native {
                     protocol::read_4b(self.master(), addr, buf).await
                 } else {

--- a/crates/rflasher-core/src/flash/spi_device.rs
+++ b/crates/rflasher-core/src/flash/spi_device.rs
@@ -132,25 +132,90 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
     }
 
     async fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
+        use crate::chip::Features;
+        use crate::spi::IoMode;
+
         let ctx = self.context();
         if !ctx.is_valid_range(addr, buf.len()) {
             return Err(Error::AddressOutOfBounds);
         }
 
-        match ctx.address_mode {
-            AddressMode::ThreeByte => protocol::read_3b(self.master(), addr, buf).await,
-            AddressMode::FourByte => {
-                if ctx.use_native_4byte {
+        let chip_has_dual = ctx.chip.features.contains(Features::DUAL_IO);
+        let chip_has_quad = ctx.chip.features.contains(Features::QUAD_IO);
+        let use_native_4byte = ctx.use_native_4byte;
+        let use_4byte_native = ctx.address_mode == AddressMode::FourByte && use_native_4byte;
+        let enter_exit_4byte =
+            ctx.address_mode == AddressMode::FourByte && !use_native_4byte;
+
+        let master_features = self.master().features();
+
+        // Select the best read mode based on chip and programmer capabilities
+        let (io_mode, ..) = protocol::select_read_mode(
+            master_features,
+            chip_has_dual,
+            chip_has_quad,
+            use_4byte_native,
+        );
+
+        // Enter 4-byte mode if needed and not using native commands
+        if enter_exit_4byte {
+            protocol::enter_4byte_mode(self.master()).await?;
+        }
+
+        let result = match io_mode {
+            IoMode::Single => {
+                if use_4byte_native {
                     protocol::read_4b(self.master(), addr, buf).await
                 } else {
-                    // Enter 4-byte mode, read, exit
-                    protocol::enter_4byte_mode(self.master()).await?;
-                    let result = protocol::read_3b(self.master(), addr, buf).await;
-                    let _ = protocol::exit_4byte_mode(self.master()).await;
-                    result
+                    protocol::read_3b(self.master(), addr, buf).await
                 }
             }
+            IoMode::DualOut => {
+                if use_4byte_native {
+                    protocol::read_dual_out_4b(self.master(), addr, buf).await
+                } else {
+                    protocol::read_dual_out_3b(self.master(), addr, buf).await
+                }
+            }
+            IoMode::DualIo => {
+                if use_4byte_native {
+                    protocol::read_dual_io_4b(self.master(), addr, buf).await
+                } else {
+                    protocol::read_dual_io_3b(self.master(), addr, buf).await
+                }
+            }
+            IoMode::QuadOut => {
+                if use_4byte_native {
+                    protocol::read_quad_out_4b(self.master(), addr, buf).await
+                } else {
+                    protocol::read_quad_out_3b(self.master(), addr, buf).await
+                }
+            }
+            IoMode::QuadIo => {
+                if use_4byte_native {
+                    protocol::read_quad_io_4b(self.master(), addr, buf).await
+                } else {
+                    protocol::read_quad_io_3b(self.master(), addr, buf).await
+                }
+            }
+            IoMode::Qpi => {
+                // QPI mode requires special handling - fall back to single for now
+                if use_4byte_native {
+                    protocol::read_4b(self.master(), addr, buf).await
+                } else {
+                    protocol::read_3b(self.master(), addr, buf).await
+                }
+            }
+        };
+
+        // Exit 4-byte mode if we entered it
+        if enter_exit_4byte {
+            if let Err(e) = protocol::exit_4byte_mode(self.master()).await {
+                log::warn!("Failed to exit 4-byte address mode: {}", e);
+            }
         }
+
+        result
     }
 
     async fn write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
@@ -195,7 +260,9 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
             if result.is_err() {
                 // Try to exit 4-byte mode before returning error
                 if use_4byte && !use_native {
-                    let _ = protocol::exit_4byte_mode(self.master()).await;
+                    if let Err(e) = protocol::exit_4byte_mode(self.master()).await {
+                        log::warn!("Failed to exit 4-byte address mode: {}", e);
+                    }
                 }
                 return result;
             }
@@ -270,7 +337,9 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
 
             if result.is_err() {
                 if use_4byte && !use_native {
-                    let _ = protocol::exit_4byte_mode(self.master()).await;
+                    if let Err(e) = protocol::exit_4byte_mode(self.master()).await {
+                        log::warn!("Failed to exit 4-byte address mode: {}", e);
+                    }
                 }
                 return result;
             }
@@ -278,7 +347,9 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
             // Verify the block was erased
             if let Err(e) = self.check_erased_range(current_addr, block_size).await {
                 if use_4byte && !use_native {
-                    let _ = protocol::exit_4byte_mode(self.master()).await;
+                    if let Err(exit_e) = protocol::exit_4byte_mode(self.master()).await {
+                        log::warn!("Failed to exit 4-byte address mode: {}", exit_e);
+                    }
                 }
                 return Err(e);
             }

--- a/crates/rflasher-core/src/flash/spi_device.rs
+++ b/crates/rflasher-core/src/flash/spi_device.rs
@@ -144,8 +144,7 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
         let chip_has_quad = ctx.chip.features.contains(Features::QUAD_IO);
         let use_native_4byte = ctx.use_native_4byte;
         let use_4byte_native = ctx.address_mode == AddressMode::FourByte && use_native_4byte;
-        let enter_exit_4byte =
-            ctx.address_mode == AddressMode::FourByte && !use_native_4byte;
+        let enter_exit_4byte = ctx.address_mode == AddressMode::FourByte && !use_native_4byte;
 
         let master_features = self.master().features();
 

--- a/crates/rflasher-core/src/flash/unified.rs
+++ b/crates/rflasher-core/src/flash/unified.rs
@@ -312,7 +312,9 @@ pub async fn smart_write_region<D: FlashDevice + ?Sized, P: WriteProgress>(
                 if let Err(e) = device.write(op.start, buf).await {
                     log::error!(
                         "Failed to restore {} bytes at 0x{:08X} after erase — data may be lost: {}",
-                        buf.len(), op.start, e
+                        buf.len(),
+                        op.start,
+                        e
                     );
                     return Err(e);
                 }
@@ -321,7 +323,9 @@ pub async fn smart_write_region<D: FlashDevice + ?Sized, P: WriteProgress>(
                 if let Err(e) = device.write(region_end_addr, buf).await {
                     log::error!(
                         "Failed to restore {} bytes at 0x{:08X} after erase — data may be lost: {}",
-                        buf.len(), region_end_addr, e
+                        buf.len(),
+                        region_end_addr,
+                        e
                     );
                     return Err(e);
                 }
@@ -608,7 +612,9 @@ pub async fn verify<D: FlashDevice>(device: &mut D, expected: &[u8], addr: u32) 
 
         let expected_chunk = &expected[offset..offset + chunk_size];
         if chunk_buf != expected_chunk {
-            return Err(Error::VerifyError { addr: addr + offset as u32 });
+            return Err(Error::VerifyError {
+                addr: addr + offset as u32,
+            });
         }
 
         offset += chunk_size;

--- a/crates/rflasher-core/src/layout/flash.rs
+++ b/crates/rflasher-core/src/layout/flash.rs
@@ -112,7 +112,9 @@ async fn fmap_bsearch_rom<M: SpiMaster + ?Sized>(
     let chip_size = ctx.total_size() as u32;
 
     if rom_offset + len > chip_size {
-        return Err(LayoutError::IoError("offset + length exceeds chip size".into()));
+        return Err(LayoutError::IoError(
+            "offset + length exceeds chip size".into(),
+        ));
     }
 
     if (len as usize) < FMAP_HEADER_SIZE {

--- a/crates/rflasher-core/src/layout/fmap.rs
+++ b/crates/rflasher-core/src/layout/fmap.rs
@@ -152,7 +152,7 @@ impl FmapSearchable for &[u8] {
         let end = offset + buf.len();
 
         if end > self.len() {
-            return Err(LayoutError::IoError);
+            return Err(LayoutError::IoError("read beyond end of buffer".into()));
         }
 
         buf.copy_from_slice(&self[offset..end]);
@@ -341,7 +341,7 @@ impl Layout {
 
     /// Parse layout from FMAP in a file
     pub fn from_fmap_file(path: impl AsRef<std::path::Path>) -> Result<Self, LayoutError> {
-        let data = std::fs::read(path).map_err(|_| LayoutError::IoError)?;
+        let data = std::fs::read(path).map_err(|e| LayoutError::IoError(e.to_string()))?;
         parse_fmap(&data)
     }
 }

--- a/crates/rflasher-core/src/layout/ifd.rs
+++ b/crates/rflasher-core/src/layout/ifd.rs
@@ -147,7 +147,7 @@ impl Layout {
 
     /// Parse layout from Intel Flash Descriptor in a file
     pub fn from_ifd_file(path: impl AsRef<std::path::Path>) -> Result<Self, LayoutError> {
-        let data = std::fs::read(path).map_err(|_| LayoutError::IoError)?;
+        let data = std::fs::read(path).map_err(|e| LayoutError::IoError(e.to_string()))?;
         parse_ifd(&data)
     }
 }

--- a/crates/rflasher-core/src/layout/toml.rs
+++ b/crates/rflasher-core/src/layout/toml.rs
@@ -22,7 +22,7 @@
 use std::format;
 use std::fs;
 use std::path::Path;
-use std::string::String;
+use std::string::{String, ToString};
 use std::vec::Vec;
 
 use super::{Layout, LayoutError, LayoutSource, Region};
@@ -127,7 +127,7 @@ fn parse_size(s: &str) -> Result<u32, String> {
 impl Layout {
     /// Load a layout from a TOML file
     pub fn from_toml_file(path: impl AsRef<Path>) -> Result<Self, LayoutError> {
-        let content = fs::read_to_string(path).map_err(|_| LayoutError::IoError)?;
+        let content = fs::read_to_string(path).map_err(|e| LayoutError::IoError(e.to_string()))?;
         Self::from_toml_str(&content)
     }
 
@@ -174,7 +174,7 @@ impl Layout {
     /// Save layout to a TOML file
     pub fn to_toml_file(&self, path: impl AsRef<Path>) -> Result<(), LayoutError> {
         let content = self.to_toml_string()?;
-        fs::write(path, content).map_err(|_| LayoutError::IoError)
+        fs::write(path, content).map_err(|e| LayoutError::IoError(e.to_string()))
     }
 
     /// Convert layout to TOML string

--- a/crates/rflasher-core/src/layout/types.rs
+++ b/crates/rflasher-core/src/layout/types.rs
@@ -79,6 +79,17 @@ pub enum LayoutSource {
     Manual,
 }
 
+impl core::fmt::Display for LayoutSource {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            LayoutSource::Toml => write!(f, "TOML file"),
+            LayoutSource::Ifd => write!(f, "Intel Flash Descriptor"),
+            LayoutSource::Fmap => write!(f, "FMAP"),
+            LayoutSource::Manual => write!(f, "Manual"),
+        }
+    }
+}
+
 /// A flash memory layout containing named regions
 #[derive(Debug, Clone)]
 #[cfg(feature = "alloc")]
@@ -299,7 +310,7 @@ pub enum LayoutError {
     /// FMAP version not supported
     UnsupportedFmapVersion,
     /// I/O error
-    IoError,
+    IoError(alloc::string::String),
 }
 
 #[cfg(feature = "std")]
@@ -322,7 +333,7 @@ impl std::fmt::Display for LayoutError {
             Self::InvalidIfdSignature => write!(f, "invalid Intel Flash Descriptor signature"),
             Self::InvalidFmapSignature => write!(f, "invalid FMAP signature"),
             Self::UnsupportedFmapVersion => write!(f, "unsupported FMAP version"),
-            Self::IoError => write!(f, "I/O error"),
+            Self::IoError(msg) => write!(f, "I/O error: {}", msg),
         }
     }
 }

--- a/crates/rflasher-core/src/programmer/traits.rs
+++ b/crates/rflasher-core/src/programmer/traits.rs
@@ -271,7 +271,7 @@ where
     if read_len > 0 {
         let result = transfer_fn(&write_data, read_len)?;
         if result.len() < read_len {
-            return Err(crate::error::Error::ReadError { addr: 0 });
+            return Err(crate::error::Error::ProgrammerError);
         }
         cmd.read_buf.copy_from_slice(&result[..read_len]);
     } else {

--- a/crates/rflasher-core/src/sfdp/parser.rs
+++ b/crates/rflasher-core/src/sfdp/parser.rs
@@ -974,6 +974,7 @@ mod tests {
         }
     }
 
+    #[maybe_async::maybe_async(AFIT)]
     impl crate::programmer::SpiMaster for MockSfdpFlash {
         fn features(&self) -> crate::programmer::SpiFeatures {
             crate::programmer::SpiFeatures::empty()
@@ -987,7 +988,10 @@ mod tests {
             256
         }
 
-        fn execute(&mut self, cmd: &mut crate::spi::SpiCommand<'_>) -> crate::error::Result<()> {
+        async fn execute(
+            &mut self,
+            cmd: &mut crate::spi::SpiCommand<'_>,
+        ) -> crate::error::Result<()> {
             use crate::spi::opcodes;
 
             match cmd.opcode {
@@ -1021,7 +1025,7 @@ mod tests {
             }
         }
 
-        fn delay_us(&mut self, _us: u32) {}
+        async fn delay_us(&mut self, _us: u32) {}
     }
 
     #[test]

--- a/crates/rflasher-core/src/wp/ops.rs
+++ b/crates/rflasher-core/src/wp/ops.rs
@@ -60,6 +60,9 @@ impl core::fmt::Display for WpError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for WpError {}
+
 /// Result type for write protection operations
 pub type WpResult<T> = core::result::Result<T, WpError>;
 

--- a/crates/rflasher-flash/src/handle.rs
+++ b/crates/rflasher-flash/src/handle.rs
@@ -236,6 +236,6 @@ impl rflasher_core::layout::FmapSearchable for FlashHandle {
         buf: &mut [u8],
     ) -> Result<(), rflasher_core::layout::LayoutError> {
         self.read(offset, buf)
-            .map_err(|_| rflasher_core::layout::LayoutError::IoError)
+            .map_err(|e| rflasher_core::layout::LayoutError::IoError(e.to_string()))
     }
 }

--- a/crates/rflasher-ft4222/src/device.rs
+++ b/crates/rflasher-ft4222/src/device.rs
@@ -12,8 +12,9 @@ use std::time::Duration;
 use nusb::transfer::{Buffer, Bulk, ControlIn, ControlOut, ControlType, In, Out, Recipient};
 use nusb::{Endpoint, Interface, MaybeFuture};
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
+use rflasher_core::programmer::default_execute_with_vec;
 use rflasher_core::programmer::{SpiFeatures, SpiMaster};
-use rflasher_core::spi::{check_io_mode_supported, SpiCommand};
+use rflasher_core::spi::SpiCommand;
 
 use crate::error::{Ft4222Error, Result};
 use crate::protocol::*;
@@ -761,31 +762,10 @@ impl SpiMaster for Ft4222 {
     }
 
     fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
-        // Check that the requested I/O mode is supported
-        check_io_mode_supported(cmd.io_mode, self.features())?;
-
-        // Build the command bytes to send
-        let header_len = cmd.header_len();
-        let mut write_data = vec![0u8; header_len + cmd.write_data.len()];
-
-        // Encode opcode + address + dummy bytes
-        cmd.encode_header(&mut write_data);
-
-        // Append write data (for write commands)
-        write_data[header_len..].copy_from_slice(cmd.write_data);
-
-        // Perform the transfer using single I/O mode
-        let read_len = cmd.read_buf.len();
-        let result = self
-            .spi_transfer_single(&write_data, read_len)
-            .map_err(|_e| CoreError::ProgrammerError)?;
-
-        // Copy read data back
-        if !result.is_empty() {
-            cmd.read_buf.copy_from_slice(&result);
-        }
-
-        Ok(())
+        default_execute_with_vec(cmd, self.features(), |write_data, read_len| {
+            self.spi_transfer_single(write_data, read_len)
+                .map_err(|_| CoreError::ProgrammerError)
+        })
     }
 
     fn delay_us(&mut self, us: u32) {

--- a/crates/rflasher-ftdi/src/device.rs
+++ b/crates/rflasher-ftdi/src/device.rs
@@ -9,8 +9,9 @@ use std::time::Duration;
 use ftdi::{find_by_vid_pid, BitMode, Device, Interface};
 use nusb::MaybeFuture;
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
+use rflasher_core::programmer::default_execute_with_vec;
 use rflasher_core::programmer::{SpiFeatures, SpiMaster};
-use rflasher_core::spi::{check_io_mode_supported, SpiCommand};
+use rflasher_core::spi::SpiCommand;
 
 use crate::error::{FtdiError, Result};
 use crate::protocol::*;
@@ -466,29 +467,10 @@ impl SpiMaster for Ftdi {
     }
 
     fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
-        // Check that the requested I/O mode is supported
-        check_io_mode_supported(cmd.io_mode, self.features())?;
-
-        // Build the command bytes to send
-        let header_len = cmd.header_len();
-        let mut write_data = vec![0u8; header_len + cmd.write_data.len()];
-
-        // Encode opcode + address + dummy bytes
-        cmd.encode_header(&mut write_data);
-
-        // Append write data (for write commands)
-        write_data[header_len..].copy_from_slice(cmd.write_data);
-
-        // Perform the transfer
-        let read_len = cmd.read_buf.len();
-        let result = self
-            .spi_transfer(&write_data, read_len)
-            .map_err(|_e| CoreError::ProgrammerError)?;
-
-        // Copy read data back
-        cmd.read_buf.copy_from_slice(&result);
-
-        Ok(())
+        default_execute_with_vec(cmd, self.features(), |write_data, read_len| {
+            self.spi_transfer(write_data, read_len)
+                .map_err(|_| CoreError::ProgrammerError)
+        })
     }
 
     fn delay_us(&mut self, us: u32) {

--- a/crates/rflasher-internal/src/programmer.rs
+++ b/crates/rflasher-internal/src/programmer.rs
@@ -260,6 +260,7 @@ impl SpiMaster for InternalProgrammer {
 pub fn programmer_info() -> rflasher_core::programmer::ProgrammerInfo {
     rflasher_core::programmer::ProgrammerInfo {
         name: "internal",
+        aliases: &[],
         description: "Intel ICH/PCH and AMD SPI100 internal flash programmer",
         requires_root: true,
     }

--- a/crates/rflasher-wasm/src/app.rs
+++ b/crates/rflasher-wasm/src/app.rs
@@ -2,6 +2,7 @@
 
 use eframe::egui;
 use std::cell::RefCell;
+use std::collections::VecDeque;
 use std::rc::Rc;
 
 use rflasher_ch341a::Ch341a;
@@ -379,7 +380,7 @@ enum WritePhase {
 
 /// Status log
 struct StatusLog {
-    messages: Vec<(LogLevel, String)>,
+    messages: VecDeque<(LogLevel, String)>,
     max_messages: usize,
 }
 
@@ -394,7 +395,7 @@ enum LogLevel {
 impl Default for StatusLog {
     fn default() -> Self {
         Self {
-            messages: Vec::new(),
+            messages: VecDeque::new(),
             max_messages: 100,
         }
     }
@@ -402,9 +403,9 @@ impl Default for StatusLog {
 
 impl StatusLog {
     fn log(&mut self, level: LogLevel, message: impl Into<String>) {
-        self.messages.push((level, message.into()));
+        self.messages.push_back((level, message.into()));
         if self.messages.len() > self.max_messages {
-            self.messages.remove(0);
+            self.messages.pop_front();
         }
     }
 

--- a/src/commands/layout.rs
+++ b/src/commands/layout.rs
@@ -154,7 +154,7 @@ pub fn print_layout(layout: &Layout) {
     );
 
     if let Some(size) = layout.chip_size {
-        println!("Chip:   {} bytes ({} MiB)", size, size / (1024 * 1024));
+        println!("Chip:   {} bytes ({})", size, super::format_size(size));
     }
 
     println!("\nRegions ({}):", layout.len());
@@ -166,13 +166,7 @@ pub fn print_layout(layout: &Layout) {
 
     for region in &layout.regions {
         let size = region.size();
-        let size_str = if size >= 1024 * 1024 {
-            format!("{} MiB", size / (1024 * 1024))
-        } else if size >= 1024 {
-            format!("{} KiB", size / 1024)
-        } else {
-            format!("{} B", size)
-        };
+        let size_str = super::format_size(size);
 
         println!(
             "{:<20} {:#010X} {:#010X} {:>10} {:>8} {:>8}",

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -60,22 +60,12 @@ pub fn list_chips(db: &ChipDatabase, vendor_filter: Option<&str>) {
             }
         }
 
-        let size_str = format_size(chip.total_size);
+        let size_str = super::format_size(chip.total_size);
         let jedec_str = format!("{:02X} {:04X}", chip.jedec_manufacturer, chip.jedec_device);
 
         println!(
             "{:<12} {:<20} {:>10} {:>10}",
             chip.vendor, chip.name, size_str, jedec_str
         );
-    }
-}
-
-fn format_size(bytes: u32) -> String {
-    if bytes >= 1024 * 1024 {
-        format!("{} MiB", bytes / (1024 * 1024))
-    } else if bytes >= 1024 {
-        format!("{} KiB", bytes / 1024)
-    } else {
-        format!("{} B", bytes)
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,9 +27,9 @@ pub use list::{list_chips, list_programmers};
 
 /// Format a byte size as a human-readable string (e.g., "256 KiB", "4 MiB")
 pub fn format_size(bytes: u32) -> String {
-    if bytes >= 1024 * 1024 && bytes % (1024 * 1024) == 0 {
+    if bytes >= 1024 * 1024 && bytes.is_multiple_of(1024 * 1024) {
         format!("{} MiB", bytes / (1024 * 1024))
-    } else if bytes >= 1024 && bytes % 1024 == 0 {
+    } else if bytes >= 1024 && bytes.is_multiple_of(1024) {
         format!("{} KiB", bytes / 1024)
     } else {
         format!("{} bytes", bytes)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -24,3 +24,14 @@ pub mod wp;
 pub mod repl;
 
 pub use list::{list_chips, list_programmers};
+
+/// Format a byte size as a human-readable string (e.g., "256 KiB", "4 MiB")
+pub fn format_size(bytes: u32) -> String {
+    if bytes >= 1024 * 1024 && bytes % (1024 * 1024) == 0 {
+        format!("{} MiB", bytes / (1024 * 1024))
+    } else if bytes >= 1024 && bytes % 1024 == 0 {
+        format!("{} KiB", bytes / 1024)
+    } else {
+        format!("{} bytes", bytes)
+    }
+}

--- a/src/commands/wp.rs
+++ b/src/commands/wp.rs
@@ -77,8 +77,8 @@ fn parse_range(spec: &str) -> Result<WpRange, Box<dyn Error>> {
 /// Parse a number that may be decimal or hex
 fn parse_number(s: &str) -> Result<u32, Box<dyn Error>> {
     let s = s.trim();
-    if s.starts_with("0x") || s.starts_with("0X") {
-        u32::from_str_radix(&s[2..], 16)
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u32::from_str_radix(hex, 16)
             .map_err(|e| format!("Invalid hex number '{}': {}", s, e).into())
     } else {
         s.parse::<u32>()
@@ -89,8 +89,7 @@ fn parse_number(s: &str) -> Result<u32, Box<dyn Error>> {
 /// Show current write protection status
 pub fn cmd_status(handle: &mut FlashHandle) -> Result<(), Box<dyn Error>> {
     if !handle.wp_supported() {
-        eprintln!("Error: Write protection operations are not supported for this chip.");
-        std::process::exit(1);
+        return Err("Write protection operations are not supported for this chip".into());
     }
 
     let config = handle
@@ -112,8 +111,7 @@ pub fn cmd_status(handle: &mut FlashHandle) -> Result<(), Box<dyn Error>> {
 /// List available protection ranges
 pub fn cmd_list(handle: &mut FlashHandle) -> Result<(), Box<dyn Error>> {
     if !handle.wp_supported() {
-        eprintln!("Error: Write protection operations are not supported for this chip.");
-        std::process::exit(1);
+        return Err("Write protection operations are not supported for this chip".into());
     }
 
     let ranges = handle.get_available_wp_ranges();
@@ -140,8 +138,7 @@ pub fn cmd_list(handle: &mut FlashHandle) -> Result<(), Box<dyn Error>> {
 /// Enable hardware write protection
 pub fn cmd_enable(handle: &mut FlashHandle, temporary: bool) -> Result<(), Box<dyn Error>> {
     if !handle.wp_supported() {
-        eprintln!("Error: Write protection operations are not supported for this chip.");
-        std::process::exit(1);
+        return Err("Write protection operations are not supported for this chip".into());
     }
 
     let options = WriteOptions {
@@ -162,8 +159,7 @@ pub fn cmd_enable(handle: &mut FlashHandle, temporary: bool) -> Result<(), Box<d
 /// Disable write protection
 pub fn cmd_disable(handle: &mut FlashHandle, temporary: bool) -> Result<(), Box<dyn Error>> {
     if !handle.wp_supported() {
-        eprintln!("Error: Write protection operations are not supported for this chip.");
-        std::process::exit(1);
+        return Err("Write protection operations are not supported for this chip".into());
     }
 
     let options = WriteOptions {
@@ -188,8 +184,7 @@ pub fn cmd_range(
     temporary: bool,
 ) -> Result<(), Box<dyn Error>> {
     if !handle.wp_supported() {
-        eprintln!("Error: Write protection operations are not supported for this chip.");
-        std::process::exit(1);
+        return Err("Write protection operations are not supported for this chip".into());
     }
 
     let range = parse_range(range_spec)?;
@@ -229,8 +224,7 @@ pub fn cmd_region(
     temporary: bool,
 ) -> Result<(), Box<dyn Error>> {
     if !handle.wp_supported() {
-        eprintln!("Error: Write protection operations are not supported for this chip.");
-        std::process::exit(1);
+        return Err("Write protection operations are not supported for this chip".into());
     }
 
     // Find the region in the layout


### PR DESCRIPTION
Fix critical bugs, reduce code duplication, and improve Rust idioms
based on a full code review of the codebase.

Critical fixes:
- operations::write() now respects max_write_len() to prevent data corruption
- Guard integer underflow in smart_write_region when data is empty
- Log data loss risk when erase+restore fails during region writes
- Handle erase blocks extending both before AND after a write region

High priority:
- Add multi-I/O read support (dual/quad) to SpiFlashDevice::read()
- Add Box<dyn FlashDevice> blanket impl for trait object usage
- Extract default_execute/default_execute_with_vec helpers to deduplicate
  SpiMaster::execute() across 7 programmer crates

Medium priority:
- Add addr context to ReadError, WriteError, VerifyError variants
- Replace process::exit(1) with proper error returns in CLI commands
- Add descriptive messages to assert_eq! in operations.rs
- Log warnings instead of silently discarding exit_4byte_mode errors
- Deduplicate FlashContext methods across cfg blocks
- Standardize LayoutError::IoError to use Display formatting consistently

Low priority:
- Name magic timing constants in spi25.rs (WRSR_POLL_US, etc.)
- Add WpError: std::error::Error and Display for LayoutSource
- Use VecDeque instead of Vec for WASM StatusLog (O(1) vs O(n) removal)
- Use strip_prefix in parse_number
- Extract shared format_size utility for human-readable byte formatting
- Add aliases field to ProgrammerInfo
- LayoutError::IoError now carries inner error string