### PR TITLE
Add Dediprog bulk read/write and WASM support with page-aligned smart write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,9 +2974,14 @@ name = "rflasher-dediprog"
 version = "0.1.0"
 dependencies = [
  "futures-lite",
+ "js-sys",
  "log",
+ "maybe-async",
  "nusb",
  "rflasher-core",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3134,6 +3139,7 @@ dependencies = [
  "rflasher-ch341a",
  "rflasher-ch347",
  "rflasher-core",
+ "rflasher-dediprog",
  "rflasher-ftdi",
  "rflasher-serprog",
  "wasm-bindgen",

--- a/crates/rflasher-core/src/flash/device.rs
+++ b/crates/rflasher-core/src/flash/device.rs
@@ -66,6 +66,23 @@ pub trait FlashDevice {
     /// while SPI chips may have multiple (4KB, 32KB, 64KB, chip erase).
     fn erase_blocks(&self) -> &[EraseBlock];
 
+    /// Get the page size in bytes for optimal write alignment.
+    ///
+    /// Writes aligned to this size can use hardware-accelerated bulk transfer
+    /// paths (e.g., Dediprog CMD_WRITE + USB bulk OUT). Writes smaller than
+    /// this or misaligned may fall back to slow byte-at-a-time SPI command
+    /// sequencing.
+    ///
+    /// The smart write algorithm coalesces write ranges to this boundary
+    /// to maximize use of the fast path. Writing page-aligned 0xFF bytes
+    /// to already-erased flash is harmless (no state change) but allows
+    /// the entire write to go through the bulk transfer path.
+    ///
+    /// Returns 1 if the device has no alignment preference.
+    fn page_size(&self) -> u32 {
+        1
+    }
+
     /// Read flash contents into the provided buffer
     ///
     /// # Arguments

--- a/crates/rflasher-core/src/flash/hybrid_device.rs
+++ b/crates/rflasher-core/src/flash/hybrid_device.rs
@@ -27,7 +27,9 @@ use crate::flash::operations::{map_to_4byte_erase_opcode, select_erase_block};
 use crate::programmer::{OpaqueMaster, SpiMaster};
 use crate::protocol;
 #[cfg(feature = "alloc")]
-use crate::wp::{self, RangeDecoder, WpBits, WpConfig, WpMode, WpRange, WpRegBitMap, WpResult, WriteOptions};
+use crate::wp::{
+    self, RangeDecoder, WpBits, WpConfig, WpMode, WpRange, WpRegBitMap, WpResult, WriteOptions,
+};
 use maybe_async::maybe_async;
 
 /// Flash device adapter for hybrid programmers (SpiMaster + OpaqueMaster)
@@ -106,6 +108,10 @@ impl<M: SpiMaster + OpaqueMaster> FlashDevice for HybridFlashDevice<M> {
 
     fn erase_blocks(&self) -> &[EraseBlock] {
         self.ctx.chip.erase_blocks()
+    }
+
+    fn page_size(&self) -> u32 {
+        self.ctx.page_size() as u32
     }
 
     // Write protection support (delegates to SpiMaster, same as SpiFlashDevice)

--- a/crates/rflasher-core/src/flash/hybrid_device.rs
+++ b/crates/rflasher-core/src/flash/hybrid_device.rs
@@ -1,0 +1,343 @@
+//! Hybrid flash device adapter
+//!
+//! This module provides `HybridFlashDevice`, an adapter for programmers that
+//! implement both `SpiMaster` (for probe, erase, status, write protection) and
+//! `OpaqueMaster` (for fast bulk read/write via hardware-accelerated paths).
+//!
+//! This is the natural fit for programmers like the Dediprog SF-series, which
+//! support generic SPI command pass-through (`CMD_TRANSCEIVE`) for arbitrary
+//! opcodes, but also have dedicated firmware commands (`CMD_READ`/`CMD_WRITE`)
+//! that handle SPI flash protocols internally with USB bulk transfers for
+//! dramatically higher throughput.
+//!
+//! # Architecture
+//!
+//! ```text
+//!   FlashDevice::read()  ──► OpaqueMaster::read()   (CMD_READ + bulk IN)
+//!   FlashDevice::write() ──► OpaqueMaster::write()   (CMD_WRITE + bulk OUT)
+//!   FlashDevice::erase() ──► SpiMaster (WREN + SE/BE + RDSR polling)
+//!   FlashDevice::wp_*()  ──► SpiMaster (status register access)
+//! ```
+
+use crate::chip::{EraseBlock, WriteGranularity};
+use crate::error::{Error, Result};
+use crate::flash::context::{AddressMode, FlashContext};
+use crate::flash::device::FlashDevice;
+use crate::flash::operations::{map_to_4byte_erase_opcode, select_erase_block};
+use crate::programmer::{OpaqueMaster, SpiMaster};
+use crate::protocol;
+#[cfg(feature = "alloc")]
+use crate::wp::{self, RangeDecoder, WpBits, WpConfig, WpMode, WpRange, WpRegBitMap, WpResult, WriteOptions};
+use maybe_async::maybe_async;
+
+/// Flash device adapter for hybrid programmers (SpiMaster + OpaqueMaster)
+///
+/// Uses `OpaqueMaster` for bulk read/write (fast path) and `SpiMaster` for
+/// everything else (probe, erase, status registers, write protection).
+///
+/// # Example
+///
+/// ```ignore
+/// use rflasher_core::flash::{HybridFlashDevice, probe};
+/// use rflasher_core::chip::ChipDatabase;
+/// use rflasher_dediprog::Dediprog;
+///
+/// let mut master = Dediprog::open().unwrap();
+/// let ctx = probe(&mut master, &db).unwrap();
+/// master.set_flash_size(ctx.total_size() as u32);
+/// let mut device = HybridFlashDevice::new(master, ctx);
+/// ```
+pub struct HybridFlashDevice<M: SpiMaster + OpaqueMaster> {
+    /// Owned master (implements both SpiMaster and OpaqueMaster)
+    master: M,
+    /// Flash chip context (from probing via SpiMaster)
+    ctx: FlashContext,
+}
+
+impl<M: SpiMaster + OpaqueMaster> HybridFlashDevice<M> {
+    /// Create a new hybrid flash device adapter
+    ///
+    /// # Arguments
+    /// * `master` - The programmer (must implement both SpiMaster and OpaqueMaster)
+    /// * `ctx` - Flash context with chip metadata (from probing via SpiMaster)
+    pub fn new(master: M, ctx: FlashContext) -> Self {
+        HybridFlashDevice { master, ctx }
+    }
+
+    /// Get a mutable reference to the underlying master
+    pub fn master(&mut self) -> &mut M {
+        &mut self.master
+    }
+
+    /// Get a reference to the flash context
+    pub fn context(&self) -> &FlashContext {
+        &self.ctx
+    }
+
+    /// Get a mutable reference to the flash context
+    pub fn context_mut(&mut self) -> &mut FlashContext {
+        &mut self.ctx
+    }
+
+    /// Consume the adapter and return the flash context
+    pub fn into_context(self) -> FlashContext {
+        self.ctx
+    }
+
+    /// Consume the adapter and return both the master and flash context
+    pub fn into_parts(self) -> (M, FlashContext) {
+        (self.master, self.ctx)
+    }
+}
+
+#[maybe_async(AFIT)]
+impl<M: SpiMaster + OpaqueMaster> FlashDevice for HybridFlashDevice<M> {
+    fn size(&self) -> u32 {
+        self.ctx.total_size() as u32
+    }
+
+    fn erase_granularity(&self) -> u32 {
+        self.ctx.chip.min_erase_size().unwrap_or(4096)
+    }
+
+    fn write_granularity(&self) -> WriteGranularity {
+        self.ctx.chip.write_granularity
+    }
+
+    fn erase_blocks(&self) -> &[EraseBlock] {
+        self.ctx.chip.erase_blocks()
+    }
+
+    // Write protection support (delegates to SpiMaster, same as SpiFlashDevice)
+    #[cfg(feature = "alloc")]
+    fn wp_supported(&self) -> bool {
+        true
+    }
+
+    #[cfg(feature = "alloc")]
+    async fn read_wp_config(&mut self) -> WpResult<WpConfig> {
+        HybridFlashDevice::read_wp_config(self).await
+    }
+
+    #[cfg(feature = "alloc")]
+    async fn write_wp_config(&mut self, config: &WpConfig, options: WriteOptions) -> WpResult<()> {
+        HybridFlashDevice::write_wp_config(self, config, options).await
+    }
+
+    #[cfg(feature = "alloc")]
+    async fn set_wp_mode(&mut self, mode: WpMode, options: WriteOptions) -> WpResult<()> {
+        HybridFlashDevice::set_wp_mode(self, mode, options).await
+    }
+
+    #[cfg(feature = "alloc")]
+    async fn set_wp_range(&mut self, range: &WpRange, options: WriteOptions) -> WpResult<()> {
+        HybridFlashDevice::set_wp_range(self, range, options).await
+    }
+
+    #[cfg(feature = "alloc")]
+    async fn disable_wp(&mut self, options: WriteOptions) -> WpResult<()> {
+        HybridFlashDevice::disable_wp(self, options).await
+    }
+
+    #[cfg(feature = "alloc")]
+    fn get_available_wp_ranges(&self) -> alloc::vec::Vec<WpRange> {
+        HybridFlashDevice::get_available_wp_ranges(self)
+    }
+
+    // =========================================================================
+    // Read/Write: use OpaqueMaster (fast bulk path)
+    // =========================================================================
+
+    async fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
+        let ctx = self.context();
+        if !ctx.is_valid_range(addr, buf.len()) {
+            return Err(Error::AddressOutOfBounds);
+        }
+
+        // OpaqueMaster::read handles alignment splitting internally
+        OpaqueMaster::read(&mut self.master, addr, buf).await
+    }
+
+    async fn write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
+        let ctx = self.context();
+        if !ctx.is_valid_range(addr, data.len()) {
+            return Err(Error::AddressOutOfBounds);
+        }
+
+        // OpaqueMaster::write handles alignment splitting internally
+        OpaqueMaster::write(&mut self.master, addr, data).await
+    }
+
+    // =========================================================================
+    // Erase: use SpiMaster (no bulk erase command on Dediprog)
+    // =========================================================================
+
+    async fn erase(&mut self, addr: u32, len: u32) -> Result<()> {
+        let ctx = self.context();
+        if !ctx.is_valid_range(addr, len as usize) {
+            return Err(Error::AddressOutOfBounds);
+        }
+
+        let erase_block = select_erase_block(ctx.chip.erase_blocks(), addr, len)
+            .ok_or(Error::InvalidAlignment)?;
+
+        let use_4byte = ctx.address_mode == AddressMode::FourByte;
+        let use_native = ctx.use_native_4byte;
+
+        let opcode = if use_4byte && use_native {
+            map_to_4byte_erase_opcode(erase_block.opcode)
+        } else {
+            erase_block.opcode
+        };
+
+        if use_4byte && !use_native {
+            protocol::enter_4byte_mode(self.master()).await?;
+        }
+
+        let mut current_addr = addr;
+        let end_addr = addr + len;
+        let max_block_size = erase_block.max_block_size();
+
+        let (poll_delay_us, timeout_us) = match max_block_size {
+            s if s <= 4096 => (10_000, 1_000_000),
+            s if s <= 32768 => (100_000, 4_000_000),
+            s if s <= 65536 => (100_000, 4_000_000),
+            _ => (500_000, 60_000_000),
+        };
+
+        while current_addr < end_addr {
+            let offset_in_layout = current_addr - addr;
+            let block_size = erase_block
+                .block_size_at_offset(offset_in_layout)
+                .unwrap_or(max_block_size);
+
+            let result = protocol::erase_block(
+                self.master(),
+                opcode,
+                current_addr,
+                use_4byte && use_native,
+                poll_delay_us,
+                timeout_us,
+            )
+            .await;
+
+            if result.is_err() {
+                if use_4byte && !use_native {
+                    let _ = protocol::exit_4byte_mode(self.master()).await;
+                }
+                return result;
+            }
+
+            current_addr += block_size;
+        }
+
+        if use_4byte && !use_native {
+            protocol::exit_4byte_mode(self.master()).await?;
+        }
+
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Write Protection Support (delegates to SpiMaster, identical to SpiFlashDevice)
+// =============================================================================
+
+impl<M: SpiMaster + OpaqueMaster> HybridFlashDevice<M> {
+    fn wp_bit_map(&self) -> WpRegBitMap {
+        let features = self.ctx.chip.features;
+        if features.contains(crate::chip::Features::WP_BP3) {
+            WpRegBitMap::winbond_with_bp3()
+        } else {
+            WpRegBitMap::winbond_standard()
+        }
+    }
+
+    fn wp_decoder(&self) -> RangeDecoder {
+        RangeDecoder::Spi25
+    }
+
+    /// Read current write protection bits
+    #[maybe_async]
+    pub async fn read_wp_bits(&mut self) -> WpResult<WpBits> {
+        let bit_map = self.wp_bit_map();
+        wp::read_wp_bits(&mut self.master, &bit_map).await
+    }
+
+    /// Read current write protection configuration
+    #[maybe_async]
+    pub async fn read_wp_config(&mut self) -> WpResult<WpConfig> {
+        let bit_map = self.wp_bit_map();
+        let decoder = self.wp_decoder();
+        let total_size = self.ctx.chip.total_size;
+        wp::read_wp_config(&mut self.master, &bit_map, total_size, decoder).await
+    }
+
+    /// Write write protection bits
+    #[maybe_async]
+    pub async fn write_wp_bits(&mut self, bits: &WpBits, options: WriteOptions) -> WpResult<()> {
+        let bit_map = self.wp_bit_map();
+        wp::write_wp_bits(&mut self.master, bits, &bit_map, options).await
+    }
+
+    /// Write write protection configuration
+    #[maybe_async]
+    pub async fn write_wp_config(
+        &mut self,
+        config: &WpConfig,
+        options: WriteOptions,
+    ) -> WpResult<()> {
+        let bit_map = self.wp_bit_map();
+        let decoder = self.wp_decoder();
+        let total_size = self.ctx.chip.total_size;
+        wp::write_wp_config(
+            &mut self.master,
+            config,
+            &bit_map,
+            total_size,
+            decoder,
+            options,
+        )
+        .await
+    }
+
+    /// Set write protection mode
+    #[maybe_async]
+    pub async fn set_wp_mode(&mut self, mode: WpMode, options: WriteOptions) -> WpResult<()> {
+        let bit_map = self.wp_bit_map();
+        wp::set_wp_mode(&mut self.master, mode, &bit_map, options).await
+    }
+
+    /// Set protected range
+    #[maybe_async]
+    pub async fn set_wp_range(&mut self, range: &WpRange, options: WriteOptions) -> WpResult<()> {
+        let bit_map = self.wp_bit_map();
+        let decoder = self.wp_decoder();
+        let total_size = self.ctx.chip.total_size;
+        wp::set_wp_range(
+            &mut self.master,
+            range,
+            &bit_map,
+            total_size,
+            decoder,
+            options,
+        )
+        .await
+    }
+
+    /// Disable all write protection
+    #[maybe_async]
+    pub async fn disable_wp(&mut self, options: WriteOptions) -> WpResult<()> {
+        let bit_map = self.wp_bit_map();
+        wp::disable_wp(&mut self.master, &bit_map, options).await
+    }
+
+    /// Get all available protection ranges
+    #[cfg(feature = "alloc")]
+    pub fn get_available_wp_ranges(&self) -> alloc::vec::Vec<WpRange> {
+        let bit_map = self.wp_bit_map();
+        let decoder = self.wp_decoder();
+        let total_size = self.ctx.chip.total_size;
+        wp::get_available_ranges(&bit_map, total_size, decoder)
+    }
+}

--- a/crates/rflasher-core/src/flash/mod.rs
+++ b/crates/rflasher-core/src/flash/mod.rs
@@ -38,6 +38,7 @@
 
 mod context;
 mod device;
+mod hybrid_device;
 mod opaque_device;
 mod operations;
 mod spi_device;
@@ -48,6 +49,7 @@ pub use context::FlashContext;
 pub use device::FlashDevice;
 #[cfg(feature = "alloc")]
 pub use device::FlashDeviceExt;
+pub use hybrid_device::HybridFlashDevice;
 pub use opaque_device::OpaqueFlashDevice;
 pub use spi_device::SpiFlashDevice;
 

--- a/crates/rflasher-core/src/flash/operations.rs
+++ b/crates/rflasher-core/src/flash/operations.rs
@@ -163,6 +163,64 @@ pub fn get_all_write_ranges(have: &[u8], want: &[u8]) -> Vec<WriteRange> {
     ranges
 }
 
+/// Coalesce write ranges to page boundaries for optimal write performance.
+///
+/// Hardware-accelerated programmers (like Dediprog) use fast bulk USB transfers
+/// for page-aligned writes, but fall back to slow byte-at-a-time SPI command
+/// sequencing (WREN + PP + RDSR polling per chunk) for sub-page or misaligned
+/// writes. This function aligns write ranges to `page_size` boundaries and
+/// merges overlapping/adjacent ranges so that all writes can use the fast path.
+///
+/// Writing page-aligned 0xFF bytes to already-erased flash is harmless (no
+/// state change in the flash cells) but allows the programmer's firmware to
+/// handle the entire write via its optimized bulk transfer path.
+///
+/// If `page_size` is 0 or 1, the input ranges are returned unchanged (no
+/// alignment benefit).
+///
+/// # Arguments
+/// * `ranges` - Write ranges from `get_all_write_ranges` (must be sorted by start)
+/// * `page_size` - Page size in bytes (typically 256 for SPI NOR flash)
+/// * `total_size` - Total flash/buffer size in bytes (for clamping)
+#[cfg(feature = "alloc")]
+pub fn coalesce_write_ranges(
+    ranges: &[WriteRange],
+    page_size: u32,
+    total_size: u32,
+) -> Vec<WriteRange> {
+    if ranges.is_empty() || page_size <= 1 {
+        return ranges.to_vec();
+    }
+
+    let mut result: Vec<WriteRange> = Vec::with_capacity(ranges.len());
+
+    for range in ranges {
+        // Align start down to page boundary
+        let aligned_start = (range.start / page_size) * page_size;
+        // Align end up to page boundary, clamped to total_size
+        let end = range.start + range.len;
+        let aligned_end = (end.div_ceil(page_size) * page_size).min(total_size);
+
+        // Merge with previous range if overlapping or adjacent
+        if let Some(last) = result.last_mut() {
+            let last_end = last.start + last.len;
+            if aligned_start <= last_end {
+                // Ranges overlap or are adjacent after alignment; merge
+                let merged_end = aligned_end.max(last_end);
+                last.len = merged_end - last.start;
+                continue;
+            }
+        }
+
+        result.push(WriteRange {
+            start: aligned_start,
+            len: aligned_end - aligned_start,
+        });
+    }
+
+    result
+}
+
 // =============================================================================
 // Optimal erase algorithm
 // =============================================================================
@@ -1099,6 +1157,173 @@ mod tests {
         assert_eq!(ranges[0], WriteRange { start: 0, len: 1 });
         assert_eq!(ranges[1], WriteRange { start: 3, len: 2 });
         assert_eq!(ranges[2], WriteRange { start: 7, len: 1 });
+    }
+
+    // =========================================================================
+    // Tests for coalesce_write_ranges
+    // =========================================================================
+
+    #[test]
+    fn test_coalesce_page_size_1_is_noop() {
+        let ranges = vec![
+            WriteRange { start: 1, len: 3 },
+            WriteRange { start: 10, len: 5 },
+        ];
+        let result = coalesce_write_ranges(&ranges, 1, 1024);
+        assert_eq!(result, ranges);
+    }
+
+    #[test]
+    fn test_coalesce_empty_ranges() {
+        let result = coalesce_write_ranges(&[], 256, 65536);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_coalesce_single_range_aligned() {
+        // Already page-aligned range should stay the same
+        let ranges = vec![WriteRange {
+            start: 256,
+            len: 512,
+        }];
+        let result = coalesce_write_ranges(&ranges, 256, 65536);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start, 256);
+        assert_eq!(result[0].len, 512);
+    }
+
+    #[test]
+    fn test_coalesce_single_range_unaligned() {
+        // Unaligned range should be padded to page boundaries
+        let ranges = vec![WriteRange {
+            start: 100,
+            len: 50,
+        }];
+        let result = coalesce_write_ranges(&ranges, 256, 65536);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start, 0); // Aligned down from 100
+        assert_eq!(result[0].len, 256); // Aligned up to cover byte 149
+    }
+
+    #[test]
+    fn test_coalesce_range_crossing_page_boundary() {
+        // Range crossing a page boundary should expand to cover both pages
+        let ranges = vec![WriteRange {
+            start: 200,
+            len: 100,
+        }]; // bytes 200-299, crosses page boundary at 256
+        let result = coalesce_write_ranges(&ranges, 256, 65536);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start, 0); // Aligned down from 200
+        assert_eq!(result[0].len, 512); // Two pages: 0-255, 256-511
+    }
+
+    #[test]
+    fn test_coalesce_merges_adjacent_after_alignment() {
+        // Two ranges in different pages that become adjacent after alignment
+        let ranges = vec![
+            WriteRange {
+                start: 100,
+                len: 10,
+            }, // In page 0 (0-255)
+            WriteRange {
+                start: 300,
+                len: 10,
+            }, // In page 1 (256-511)
+        ];
+        let result = coalesce_write_ranges(&ranges, 256, 65536);
+        // After alignment: [0, 256) and [256, 512) -> adjacent, merged to [0, 512)
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start, 0);
+        assert_eq!(result[0].len, 512);
+    }
+
+    #[test]
+    fn test_coalesce_preserves_gap_between_distant_ranges() {
+        // Two ranges far enough apart that they stay separate after alignment
+        let ranges = vec![
+            WriteRange {
+                start: 100,
+                len: 10,
+            }, // In page 0
+            WriteRange {
+                start: 600,
+                len: 10,
+            }, // In page 2 (512-767)
+        ];
+        let result = coalesce_write_ranges(&ranges, 256, 65536);
+        // After alignment: [0, 256) and [512, 768) -> gap at [256, 512), not merged
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].start, 0);
+        assert_eq!(result[0].len, 256);
+        assert_eq!(result[1].start, 512);
+        assert_eq!(result[1].len, 256);
+    }
+
+    #[test]
+    fn test_coalesce_clamps_to_total_size() {
+        // Range near end of flash should be clamped
+        let ranges = vec![WriteRange {
+            start: 1000,
+            len: 10,
+        }];
+        let result = coalesce_write_ranges(&ranges, 256, 1024);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start, 768); // Aligned down from 1000
+        assert_eq!(result[0].len, 1024 - 768); // Clamped to total_size
+    }
+
+    #[test]
+    fn test_coalesce_many_small_ranges_in_same_page() {
+        // Many small ranges in the same page -> one page write
+        let ranges = vec![
+            WriteRange { start: 10, len: 1 },
+            WriteRange { start: 50, len: 2 },
+            WriteRange { start: 100, len: 5 },
+            WriteRange { start: 200, len: 3 },
+        ];
+        let result = coalesce_write_ranges(&ranges, 256, 65536);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start, 0);
+        assert_eq!(result[0].len, 256);
+    }
+
+    #[test]
+    fn test_coalesce_typical_firmware_pattern() {
+        // Simulate: erased flash (0xFF) vs firmware with scattered 0xFF bytes.
+        // The byte-level comparison produces many small ranges broken by 0xFF matches.
+        // After coalescing to 256-byte pages, they should merge into fewer large ranges.
+        let ranges = vec![
+            WriteRange { start: 0, len: 100 }, // Data in page 0
+            WriteRange {
+                start: 105,
+                len: 150,
+            }, // More data in page 0 (gap was 0xFF)
+            WriteRange {
+                start: 256,
+                len: 200,
+            }, // Data in page 1
+            WriteRange {
+                start: 460,
+                len: 50,
+            }, // More data in page 1 (gap was 0xFF)
+            WriteRange {
+                start: 512,
+                len: 256,
+            }, // Full page 2
+            WriteRange {
+                start: 1024,
+                len: 10,
+            }, // Isolated write in page 4
+        ];
+        let result = coalesce_write_ranges(&ranges, 256, 65536);
+        // Pages 0,1,2 should merge into one range [0, 768)
+        // Page 4 is separate: [1024, 1280)
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].start, 0);
+        assert_eq!(result[0].len, 768); // 3 pages
+        assert_eq!(result[1].start, 1024);
+        assert_eq!(result[1].len, 256); // 1 page
     }
 
     // =========================================================================

--- a/crates/rflasher-core/src/flash/spi_device.rs
+++ b/crates/rflasher-core/src/flash/spi_device.rs
@@ -95,6 +95,10 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
         self.context().chip.erase_blocks()
     }
 
+    fn page_size(&self) -> u32 {
+        self.ctx.page_size() as u32
+    }
+
     // Write protection support
     #[cfg(feature = "alloc")]
     fn wp_supported(&self) -> bool {

--- a/crates/rflasher-core/src/flash/unified.rs
+++ b/crates/rflasher-core/src/flash/unified.rs
@@ -34,8 +34,13 @@ pub use crate::flash::operations::{
 /// The erased value for flash memory (all bits set)
 const ERASED_VALUE: u8 = 0xFF;
 
-/// Default read chunk size
-const READ_CHUNK_SIZE: usize = 4096;
+/// Default read chunk size for progress reporting.
+///
+/// Each chunk results in a separate `FlashDevice::read()` call, which for
+/// hardware-accelerated programmers (e.g. Dediprog) issues a new CMD_READ
+/// control transfer. Larger chunks amortize that overhead.
+/// 256 KiB gives ~64 progress updates for a 16 MiB flash.
+const READ_CHUNK_SIZE: usize = 256 * 1024;
 
 // =============================================================================
 // Unified operations

--- a/crates/rflasher-core/src/flash/unified.rs
+++ b/crates/rflasher-core/src/flash/unified.rs
@@ -13,7 +13,9 @@ use alloc::vec::Vec;
 
 use crate::error::{Error, Result};
 use crate::flash::device::FlashDevice;
-use crate::flash::operations::{plan_optimal_erase, plan_optimal_erase_region};
+use crate::flash::operations::{
+    coalesce_write_ranges, plan_optimal_erase, plan_optimal_erase_region,
+};
 use crate::layout::{Layout, LayoutError, Region};
 use maybe_async::maybe_async;
 
@@ -41,6 +43,16 @@ const ERASED_VALUE: u8 = 0xFF;
 /// control transfer. Larger chunks amortize that overhead.
 /// 256 KiB gives ~64 progress updates for a 16 MiB flash.
 const READ_CHUNK_SIZE: usize = 256 * 1024;
+
+/// Maximum size per `FlashDevice::write()` call during smart write.
+///
+/// After coalescing, write ranges can be very large (potentially the entire
+/// flash). Splitting them into sub-chunks ensures regular progress updates
+/// and keeps USB transfers manageable. Must be a multiple of the page size
+/// (256 bytes) so writes stay page-aligned for the bulk transfer path.
+///
+/// 256 KiB = 1024 pages, giving ~64 progress updates for a 16 MiB flash.
+const WRITE_CHUNK_SIZE: usize = 256 * 1024;
 
 // =============================================================================
 // Unified operations
@@ -108,6 +120,7 @@ pub async fn smart_write<D: FlashDevice + ?Sized, P: WriteProgress>(
     // Clone erase blocks to avoid borrow checker issues
     let erase_blocks: Vec<_> = device.erase_blocks().to_vec();
     let granularity = device.write_granularity();
+    let page_size = device.page_size();
 
     let mut stats = WriteStats::default();
 
@@ -176,9 +189,12 @@ pub async fn smart_write<D: FlashDevice + ?Sized, P: WriteProgress>(
         stats.flash_modified = true;
     }
 
-    // Step 4: Write bytes that differ
-    // Re-calculate write ranges after erasing
+    // Step 4: Write pages that differ
+    // Re-calculate write ranges after erasing, then coalesce to page boundaries
+    // so that hardware-accelerated programmers (like Dediprog) can use their fast
+    // bulk transfer path instead of slow byte-at-a-time SPI command sequencing.
     let write_ranges = get_all_write_ranges(&current, data);
+    let write_ranges = coalesce_write_ranges(&write_ranges, page_size, flash_size);
 
     if !write_ranges.is_empty() {
         let bytes_to_write: usize = write_ranges.iter().map(|r| r.len as usize).sum();
@@ -187,12 +203,22 @@ pub async fn smart_write<D: FlashDevice + ?Sized, P: WriteProgress>(
         let mut bytes_written = 0;
 
         for range in &write_ranges {
-            let write_data = &data[range.start as usize..(range.start + range.len) as usize];
-            device.write(range.start, write_data).await?;
+            // Split large ranges into sub-chunks for progress reporting.
+            // Each chunk stays page-aligned so the bulk transfer path is used.
+            let range_start = range.start as usize;
+            let range_end = range_start + range.len as usize;
+            let mut offset = range_start;
 
-            bytes_written += range.len as usize;
-            progress.write_progress(bytes_written);
-            stats.writes_performed += 1;
+            while offset < range_end {
+                let chunk_len = (range_end - offset).min(WRITE_CHUNK_SIZE);
+                device
+                    .write(offset as u32, &data[offset..offset + chunk_len])
+                    .await?;
+                offset += chunk_len;
+                bytes_written += chunk_len;
+                stats.writes_performed += 1;
+                progress.write_progress(bytes_written);
+            }
         }
 
         stats.bytes_written = bytes_written;
@@ -229,6 +255,7 @@ pub async fn smart_write_region<D: FlashDevice + ?Sized, P: WriteProgress>(
     let erase_blocks: Vec<_> = device.erase_blocks().to_vec();
     let granularity = device.write_granularity();
     // Safe: data.len() > 0 guaranteed by the early return above
+    let page_size = device.page_size();
     let region_end = addr + data.len() as u32 - 1;
 
     let mut stats = WriteStats::default();
@@ -348,8 +375,11 @@ pub async fn smart_write_region<D: FlashDevice + ?Sized, P: WriteProgress>(
         stats.flash_modified = true;
     }
 
-    // Step 4: Write changed bytes
+    // Step 4: Write pages that differ
+    // Coalesce to page boundaries so bulk transfer paths are used.
     let write_ranges = get_all_write_ranges(&current, data);
+    let data_len = data.len() as u32;
+    let write_ranges = coalesce_write_ranges(&write_ranges, page_size, data_len);
 
     if !write_ranges.is_empty() {
         let bytes_to_write: usize = write_ranges.iter().map(|r| r.len as usize).sum();
@@ -358,12 +388,21 @@ pub async fn smart_write_region<D: FlashDevice + ?Sized, P: WriteProgress>(
         let mut bytes_written = 0;
 
         for range in &write_ranges {
-            let write_data = &data[range.start as usize..(range.start + range.len) as usize];
-            device.write(addr + range.start, write_data).await?;
+            // Split large ranges into sub-chunks for progress reporting.
+            let range_start = range.start as usize;
+            let range_end = range_start + range.len as usize;
+            let mut offset = range_start;
 
-            bytes_written += range.len as usize;
-            progress.write_progress(bytes_written);
-            stats.writes_performed += 1;
+            while offset < range_end {
+                let chunk_len = (range_end - offset).min(WRITE_CHUNK_SIZE);
+                device
+                    .write(addr + offset as u32, &data[offset..offset + chunk_len])
+                    .await?;
+                offset += chunk_len;
+                bytes_written += chunk_len;
+                stats.writes_performed += 1;
+                progress.write_progress(bytes_written);
+            }
         }
 
         stats.bytes_written = bytes_written;

--- a/crates/rflasher-dediprog/Cargo.toml
+++ b/crates/rflasher-dediprog/Cargo.toml
@@ -7,10 +7,28 @@ description = "Dediprog SF100/SF200/SF600/SF700 USB programmer support for rflas
 
 [features]
 default = ["std"]
-std = ["rflasher-core/std", "nusb", "futures-lite"]
+std = ["rflasher-core/std", "is_sync", "nusb", "futures-lite"]
+# Sync mode - when enabled, async code is compiled as sync
+is_sync = ["rflasher-core/is_sync", "maybe-async/is_sync"]
+wasm = ["rflasher-core/std", "nusb", "web-sys", "wasm-bindgen", "wasm-bindgen-futures", "js-sys"]
 
 [dependencies]
 rflasher-core.workspace = true
 nusb = { workspace = true, optional = true }
 futures-lite = { version = "2", optional = true }
+maybe-async.workspace = true
 log.workspace = true
+
+# WASM dependencies (optional, only for wasm feature)
+web-sys = { version = "0.3", optional = true, features = [
+    "Navigator",
+    "Window",
+    "console",
+    "Usb",
+    "UsbDevice",
+    "UsbDeviceFilter",
+    "UsbDeviceRequestOptions",
+] }
+wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+js-sys = { version = "0.3", optional = true }

--- a/crates/rflasher-dediprog/src/device.rs
+++ b/crates/rflasher-dediprog/src/device.rs
@@ -2,18 +2,92 @@
 //!
 //! This module provides the main `Dediprog` struct that implements USB
 //! communication with Dediprog SF100/SF200/SF600/SF700 programmers.
+//!
+//! Uses `maybe_async` to support both sync and async modes from a single
+//! codebase:
+//! - With `is_sync` feature (native CLI): all async is stripped, blocking USB
+//! - Without `is_sync` (WASM): full async with WebUSB
 
 use std::time::Duration;
 
+use maybe_async::maybe_async;
 use nusb::transfer::{Buffer, Bulk, In, Out};
-use nusb::{Endpoint, Interface, MaybeFuture};
+use nusb::Endpoint;
+#[cfg(feature = "std")]
+use nusb::MaybeFuture;
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
-use rflasher_core::programmer::default_execute_with_vec;
 use rflasher_core::programmer::{OpaqueMaster, SpiFeatures, SpiMaster};
-use rflasher_core::spi::{opcodes, SpiCommand};
+use rflasher_core::spi::{check_io_mode_supported, opcodes, SpiCommand};
 
 use crate::error::{DediprogError, Result};
 use crate::protocol::*;
+
+// ---------------------------------------------------------------------------
+// Platform-specific endpoint wait macros
+// ---------------------------------------------------------------------------
+// These macros provide a uniform interface over nusb's blocking (native)
+// and async (WASM) completion APIs.
+
+/// Wait for the next completion on an endpoint, with timeout.
+/// In sync mode: blocks with the given timeout.
+/// In async mode: awaits indefinitely (timeout is ignored -- nusb's async
+/// API does not support timeouts natively).
+/// Returns `Option<Completion>`.
+macro_rules! ep_wait {
+    ($ep:expr, $timeout:expr) => {{
+        #[cfg(feature = "is_sync")]
+        {
+            $ep.wait_next_complete($timeout)
+        }
+        #[cfg(not(feature = "is_sync"))]
+        {
+            Some($ep.next_complete().await)
+        }
+    }};
+}
+
+/// Resolve an nusb `MaybeFuture` to its output.
+/// In sync mode: calls `.wait()` (blocking).
+/// In async mode: `.await`s the future.
+macro_rules! nusb_await {
+    ($expr:expr) => {{
+        #[cfg(feature = "is_sync")]
+        {
+            $expr.wait()
+        }
+        #[cfg(not(feature = "is_sync"))]
+        {
+            $expr.await
+        }
+    }};
+}
+
+/// Platform-aware sleep/delay.
+/// In sync mode: std::thread::sleep.
+/// In async mode (WASM): setTimeout-based delay.
+macro_rules! platform_sleep {
+    ($dur:expr) => {{
+        #[cfg(feature = "is_sync")]
+        {
+            std::thread::sleep($dur);
+        }
+        #[cfg(all(feature = "wasm", not(feature = "is_sync")))]
+        {
+            // Browser setTimeout resolution is 1 ms minimum.  For sub-ms
+            // durations we still yield via setTimeout(0) so the event loop
+            // (and UI) can run -- without this, tight polling loops
+            // (e.g. WIP status in slow_write) would busy-spin.
+            let ms = $dur.as_millis() as i32;
+            let promise = js_sys::Promise::new(&mut |resolve, _| {
+                let window = web_sys::window().unwrap();
+                window
+                    .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms)
+                    .unwrap();
+            });
+            let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+        }
+    }};
+}
 
 /// Configuration options for opening a Dediprog device
 #[derive(Debug, Clone)]
@@ -103,8 +177,10 @@ pub fn parse_options(options: &[(&str, &str)]) -> Result<DediprogConfig> {
 ///
 /// Supports SF100, SF200, SF600, SF600PG2, and SF700 programmers.
 pub struct Dediprog {
-    /// USB interface
-    interface: Interface,
+    /// USB interface handle (used for control transfers in native mode;
+    /// kept alive to maintain device claim in WASM mode)
+    #[allow(dead_code)] // In WASM, only accessed via iface() helper
+    interface: nusb::Interface,
     /// Bulk IN endpoint
     in_endpoint: u8,
     /// Bulk OUT endpoint
@@ -125,6 +201,18 @@ pub struct Dediprog {
     flash_size: Option<u32>,
 }
 
+impl Dediprog {
+    #[inline]
+    fn iface(&self) -> &nusb::Interface {
+        &self.interface
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Native-only methods (device enumeration, Drop)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "std")]
 impl Dediprog {
     /// Open the first available Dediprog device
     pub fn open() -> Result<Self> {
@@ -176,7 +264,7 @@ impl Dediprog {
         Self::try_open_device(device_info, &config)
     }
 
-    /// Try to open a specific USB device
+    /// Try to open a specific USB device (native/blocking)
     fn try_open_device(device_info: &nusb::DeviceInfo, config: &DediprogConfig) -> Result<Self> {
         log::info!(
             "Opening Dediprog at bus {} address {}",
@@ -208,59 +296,7 @@ impl Dediprog {
             flash_size: None,
         };
 
-        // Try to read device string (may need set_voltage first for old devices)
-        if dediprog.read_device_string().is_err() {
-            // Try set_voltage for old firmware and retry
-            dediprog.set_voltage_old()?;
-            dediprog.read_device_string()?;
-        }
-
-        // Update endpoints based on device type
-        if dediprog.device_type.is_sf600_class() {
-            dediprog.out_endpoint = BULK_OUT_EP_SF600;
-        }
-
-        // Determine protocol version
-        dediprog.protocol =
-            Protocol::from_device_firmware(dediprog.device_type, dediprog.firmware_version);
-
-        if dediprog.protocol == Protocol::Unknown {
-            return Err(DediprogError::FirmwareError(
-                "Unable to determine protocol version".to_string(),
-            ));
-        }
-
-        log::info!(
-            "Dediprog {}: firmware {:X}.{:X}.{:X}, protocol {:?}",
-            dediprog.device_type,
-            (dediprog.firmware_version >> 16) & 0xFF,
-            (dediprog.firmware_version >> 8) & 0xFF,
-            dediprog.firmware_version & 0xFF,
-            dediprog.protocol
-        );
-
-        // Initialize the device
-        dediprog.set_leds(Led::All)?;
-
-        // Set target, speed, and voltage
-        dediprog.set_target(config.target)?;
-        dediprog.set_spi_speed(config.spi_speed_index)?;
-        dediprog.set_voltage(config.voltage_mv)?;
-
-        // Leave standalone mode if SF600
-        if dediprog.device_type == DeviceType::SF600 {
-            dediprog.leave_standalone_mode()?;
-        }
-
-        // Determine multi-I/O support
-        if dediprog.device_type.is_sf600_class() && dediprog.protocol >= Protocol::V2 {
-            dediprog.max_io_mode = config.io_mode;
-        } else {
-            dediprog.max_io_mode = DpIoMode::Single;
-        }
-
-        dediprog.set_leds(Led::None)?;
-
+        dediprog.init_device(config)?;
         Ok(dediprog)
     }
 
@@ -280,11 +316,208 @@ impl Dediprog {
 
         Ok(devices)
     }
+}
+
+/// Information about a connected Dediprog device
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+pub struct DediprogDeviceInfo {
+    /// USB bus number
+    pub bus: u8,
+    /// USB device address
+    pub address: u8,
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for DediprogDeviceInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Dediprog at bus {} address {}", self.bus, self.address)
+    }
+}
+
+// Drop implementation only for sync mode (async requires explicit shutdown)
+#[cfg(feature = "is_sync")]
+impl Drop for Dediprog {
+    fn drop(&mut self) {
+        // Reset I/O mode
+        let _ = self.set_io_mode(DpIoMode::Single);
+        // Turn off voltage
+        let _ = self.set_voltage(0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WASM-only methods (WebUSB device picker, async open, shutdown)
+// ---------------------------------------------------------------------------
+
+#[cfg(all(feature = "wasm", not(feature = "is_sync")))]
+impl Dediprog {
+    /// Request a Dediprog device via the WebUSB permission prompt
+    ///
+    /// This must be called from a user gesture (e.g., button click) in the browser.
+    /// It shows the browser's device picker filtered to Dediprog devices.
+    #[cfg(target_arch = "wasm32")]
+    pub async fn request_device() -> Result<nusb::DeviceInfo> {
+        use wasm_bindgen::JsCast;
+        use wasm_bindgen_futures::JsFuture;
+        use web_sys::{UsbDevice, UsbDeviceFilter, UsbDeviceRequestOptions};
+
+        let usb = web_sys::window()
+            .ok_or(DediprogError::DeviceNotFound)?
+            .navigator()
+            .usb();
+
+        // Create filter for Dediprog devices (VID:0483 PID:DADA)
+        let filter = UsbDeviceFilter::new();
+        filter.set_vendor_id(DEDIPROG_USB_VENDOR);
+        filter.set_product_id(DEDIPROG_USB_PRODUCT);
+
+        let filters = js_sys::Array::new();
+        filters.push(&filter);
+
+        let options = UsbDeviceRequestOptions::new(&filters);
+
+        log::info!("Requesting Dediprog device via WebUSB picker...");
+
+        let device_promise = usb.request_device(&options);
+        let device_js = JsFuture::from(device_promise)
+            .await
+            .map_err(|e| DediprogError::OpenFailed(format!("WebUSB request failed: {:?}", e)))?;
+
+        let device: UsbDevice = device_js
+            .dyn_into()
+            .map_err(|_| DediprogError::OpenFailed("Failed to get USB device".to_string()))?;
+
+        log::info!(
+            "Dediprog device selected: VID={:04X} PID={:04X}",
+            device.vendor_id(),
+            device.product_id()
+        );
+
+        let device_info = nusb::device_info_from_webusb(device)
+            .await
+            .map_err(|e| DediprogError::OpenFailed(format!("Failed to get device info: {}", e)))?;
+
+        Ok(device_info)
+    }
+
+    /// Open a Dediprog device from a DeviceInfo (async, for WASM)
+    pub async fn open(device_info: nusb::DeviceInfo, config: DediprogConfig) -> Result<Self> {
+        log::info!(
+            "Opening Dediprog device VID={:04X} PID={:04X}",
+            device_info.vendor_id(),
+            device_info.product_id()
+        );
+
+        let device = device_info
+            .open()
+            .await
+            .map_err(|e| DediprogError::OpenFailed(e.to_string()))?;
+
+        let interface = device
+            .claim_interface(0)
+            .await
+            .map_err(|e| DediprogError::ClaimFailed(e.to_string()))?;
+
+        let mut dediprog = Self {
+            interface,
+            in_endpoint: BULK_IN_EP,
+            out_endpoint: BULK_OUT_EP_SF100,
+            device_type: DeviceType::Unknown,
+            firmware_version: 0,
+            device_string: String::new(),
+            protocol: Protocol::Unknown,
+            io_mode: DpIoMode::Single,
+            max_io_mode: config.io_mode,
+            flash_size: None,
+        };
+
+        dediprog.init_device(&config).await?;
+        Ok(dediprog)
+    }
+
+    /// Shutdown: turn off voltage and reset I/O mode (WASM equivalent of Drop)
+    pub async fn shutdown(&mut self) {
+        let _ = self.set_io_mode(DpIoMode::Single).await;
+        let _ = self.set_voltage(0).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared methods (sync or async via maybe_async)
+// ---------------------------------------------------------------------------
+
+// When all features are enabled simultaneously (e.g. --all-features in CI),
+// the mutually-exclusive open() methods are both excluded, making these shared
+// helpers appear unused. Allow dead_code for that configuration.
+#[cfg_attr(all(feature = "wasm", feature = "is_sync"), allow(dead_code))]
+impl Dediprog {
+    /// Initialize device after USB connection is established.
+    /// Shared between native and WASM paths.
+    #[maybe_async]
+    async fn init_device(&mut self, config: &DediprogConfig) -> Result<()> {
+        // Try to read device string (may need set_voltage first for old devices)
+        if self.read_device_string().await.is_err() {
+            // Try set_voltage for old firmware and retry
+            self.set_voltage_old().await?;
+            self.read_device_string().await?;
+        }
+
+        // Update endpoints based on device type
+        if self.device_type.is_sf600_class() {
+            self.out_endpoint = BULK_OUT_EP_SF600;
+        }
+
+        // Determine protocol version
+        self.protocol = Protocol::from_device_firmware(self.device_type, self.firmware_version);
+
+        if self.protocol == Protocol::Unknown {
+            return Err(DediprogError::FirmwareError(
+                "Unable to determine protocol version".to_string(),
+            ));
+        }
+
+        log::info!(
+            "Dediprog {}: firmware {:X}.{:X}.{:X}, protocol {:?}",
+            self.device_type,
+            (self.firmware_version >> 16) & 0xFF,
+            (self.firmware_version >> 8) & 0xFF,
+            self.firmware_version & 0xFF,
+            self.protocol
+        );
+
+        // Initialize the device
+        self.set_leds(Led::All).await?;
+
+        // Set target, speed, and voltage
+        self.set_target(config.target).await?;
+        self.set_spi_speed(config.spi_speed_index).await?;
+        self.set_voltage(config.voltage_mv).await?;
+
+        // Leave standalone mode if SF600
+        if self.device_type == DeviceType::SF600 {
+            self.leave_standalone_mode().await?;
+        }
+
+        // Determine multi-I/O support
+        if self.device_type.is_sf600_class() && self.protocol >= Protocol::V2 {
+            self.max_io_mode = config.io_mode;
+        } else {
+            self.max_io_mode = DpIoMode::Single;
+        }
+
+        self.set_leds(Led::None).await?;
+
+        Ok(())
+    }
 
     /// Read the device string and parse device type/firmware
-    fn read_device_string(&mut self) -> Result<()> {
+    #[maybe_async]
+    async fn read_device_string(&mut self) -> Result<()> {
         let mut buf = [0u8; 33];
-        let len = self.control_read(Command::ReadProgInfo, 0, 0, &mut buf)?;
+        let len = self
+            .control_read(Command::ReadProgInfo, 0, 0, &mut buf)
+            .await?;
 
         if len < 16 {
             return Err(DediprogError::InvalidResponse(
@@ -350,28 +583,34 @@ impl Dediprog {
     }
 
     /// Read the device ID (serial number from sticker)
-    fn read_device_id(&mut self) -> Result<u32> {
+    #[maybe_async]
+    #[allow(dead_code)] // Only called from native open_with_config
+    async fn read_device_id(&mut self) -> Result<u32> {
         if self.device_type >= DeviceType::SF600PG2 {
             // Newer protocol for SF600PG2/SF700
             let out = [0x00, 0x00, 0x00, 0x02, 0x00, 0x00];
-            self.control_write_raw(0x71, 0, 0, &out)?;
+            self.control_write_raw(0x71, 0, 0, &out).await?;
 
             let mut buf = [0u8; 512];
-            let len = self.bulk_read(&mut buf)?;
+            let len = self.bulk_read(&mut buf).await?;
             if len >= 3 {
                 return Ok((buf[2] as u32) << 16 | (buf[1] as u32) << 8 | (buf[0] as u32));
             }
         } else if self.device_type.is_sf600_class() {
             // SF600 uses CMD_READ_EEPROM
             let mut buf = [0u8; 16];
-            let len = self.control_read(Command::ReadEeprom, 0, 0, &mut buf)?;
+            let len = self
+                .control_read(Command::ReadEeprom, 0, 0, &mut buf)
+                .await?;
             if len >= 3 {
                 return Ok((buf[0] as u32) << 16 | (buf[1] as u32) << 8 | (buf[2] as u32));
             }
         } else {
             // SF100/SF200 use a different request
             let mut buf = [0u8; 3];
-            let len = self.control_read_raw(REQTYPE_OTHER_IN, 0x07, 0, 0xEF00, &mut buf)?;
+            let len = self
+                .control_read_raw(REQTYPE_OTHER_IN, 0x07, 0, 0xEF00, &mut buf)
+                .await?;
             if len >= 3 {
                 return Ok((buf[0] as u32) << 16 | (buf[1] as u32) << 8 | (buf[2] as u32));
             }
@@ -383,10 +622,12 @@ impl Dediprog {
     }
 
     /// Set voltage for old firmware (< 6.0.0)
-    fn set_voltage_old(&mut self) -> Result<()> {
+    #[maybe_async]
+    async fn set_voltage_old(&mut self) -> Result<()> {
         let mut buf = [0u8; 1];
-        let ret =
-            self.control_read_raw(REQTYPE_OTHER_IN, Command::SetVoltage as u8, 0, 0, &mut buf)?;
+        let ret = self
+            .control_read_raw(REQTYPE_OTHER_IN, Command::SetVoltage as u8, 0, 0, &mut buf)
+            .await?;
         if ret != 1 || buf[0] != 0x6f {
             return Err(DediprogError::InvalidResponse(
                 "Unexpected response to set_voltage".to_string(),
@@ -396,11 +637,13 @@ impl Dediprog {
     }
 
     /// Set the LED state
-    fn set_leds(&mut self, led: Led) -> Result<()> {
+    #[maybe_async]
+    async fn set_leds(&mut self, led: Led) -> Result<()> {
         if self.protocol >= Protocol::V2 {
             // New protocol: value contains LED state
             let leds = ((led as u8) ^ 7) as u16;
-            self.control_write(Command::SetIoLed, leds << 8, 0, &[])?;
+            self.control_write(Command::SetIoLed, leds << 8, 0, &[])
+                .await?;
         } else {
             // Old protocol: index contains LED state
             let leds = if self.firmware_version < firmware_version(5, 0, 0) {
@@ -411,19 +654,23 @@ impl Dediprog {
                 led as u8
             };
             let target_leds = leds ^ 7;
-            self.control_write(Command::SetIoLed, 0x9, target_leds as u16, &[])?;
+            self.control_write(Command::SetIoLed, 0x9, target_leds as u16, &[])
+                .await?;
         }
         Ok(())
     }
 
     /// Set the target flash
-    fn set_target(&mut self, target: Target) -> Result<()> {
-        self.control_write(Command::SetTarget, target as u16, 0, &[])?;
+    #[maybe_async]
+    async fn set_target(&mut self, target: Target) -> Result<()> {
+        self.control_write(Command::SetTarget, target as u16, 0, &[])
+            .await?;
         Ok(())
     }
 
     /// Set the SPI clock speed
-    fn set_spi_speed(&mut self, speed_index: usize) -> Result<()> {
+    #[maybe_async]
+    async fn set_spi_speed(&mut self, speed_index: usize) -> Result<()> {
         if self.device_type < DeviceType::SF600PG2
             && self.firmware_version < firmware_version(5, 0, 0)
         {
@@ -436,12 +683,14 @@ impl Dediprog {
         })?;
 
         log::debug!("Setting SPI speed to {}", speed.name);
-        self.control_write(Command::SetSpiClk, speed.value as u16, 0, &[])?;
+        self.control_write(Command::SetSpiClk, speed.value as u16, 0, &[])
+            .await?;
         Ok(())
     }
 
     /// Set the SPI voltage
-    fn set_voltage(&mut self, millivolt: u16) -> Result<()> {
+    #[maybe_async]
+    async fn set_voltage(&mut self, millivolt: u16) -> Result<()> {
         let selector = voltage_selector(millivolt)
             .ok_or_else(|| DediprogError::InvalidParameter(format!("voltage: {}", millivolt)))?;
 
@@ -453,32 +702,36 @@ impl Dediprog {
 
         if selector == 0 {
             // Delay before turning off voltage
-            std::thread::sleep(Duration::from_millis(200));
+            platform_sleep!(Duration::from_millis(200));
         }
 
-        self.control_write(Command::SetVcc, selector, 0, &[])?;
+        self.control_write(Command::SetVcc, selector, 0, &[])
+            .await?;
 
         if selector != 0 {
             // Delay after turning on voltage
-            std::thread::sleep(Duration::from_millis(200));
+            platform_sleep!(Duration::from_millis(200));
         }
 
         Ok(())
     }
 
     /// Leave standalone mode (SF600 only)
-    fn leave_standalone_mode(&mut self) -> Result<()> {
+    #[maybe_async]
+    async fn leave_standalone_mode(&mut self) -> Result<()> {
         if self.device_type != DeviceType::SF600 {
             return Ok(());
         }
 
         log::debug!("Leaving standalone mode");
-        self.control_write(Command::SetStandalone, StandaloneMode::Leave as u16, 0, &[])?;
+        self.control_write(Command::SetStandalone, StandaloneMode::Leave as u16, 0, &[])
+            .await?;
         Ok(())
     }
 
     /// Set the I/O mode for multi-I/O operations
-    fn set_io_mode(&mut self, mode: DpIoMode) -> Result<()> {
+    #[maybe_async]
+    async fn set_io_mode(&mut self, mode: DpIoMode) -> Result<()> {
         if !self.device_type.is_sf600_class() {
             return Ok(());
         }
@@ -488,13 +741,15 @@ impl Dediprog {
         }
 
         log::trace!("Setting I/O mode to {:?}", mode);
-        self.control_write(Command::IoMode, mode as u16, 0, &[])?;
+        self.control_write(Command::IoMode, mode as u16, 0, &[])
+            .await?;
         self.io_mode = mode;
         Ok(())
     }
 
     /// USB control read
-    fn control_read(
+    #[maybe_async]
+    async fn control_read(
         &mut self,
         cmd: Command,
         value: u16,
@@ -502,38 +757,44 @@ impl Dediprog {
         buf: &mut [u8],
     ) -> Result<usize> {
         self.control_read_raw(REQTYPE_EP_IN, cmd as u8, value, index, buf)
+            .await
     }
 
     /// USB control read (raw)
-    fn control_read_raw(
+    #[maybe_async]
+    async fn control_read_raw(
         &mut self,
-        request_type: u8,
+        #[allow(unused_variables)] request_type: u8,
         request: u8,
         value: u16,
         index: u16,
         buf: &mut [u8],
     ) -> Result<usize> {
+        // On WASM/WebUSB, Chrome validates the `index` field as an endpoint
+        // address when recipient is Endpoint, rejecting Dediprog's
+        // protocol-specific index values with IndexSizeError.  The firmware
+        // dispatches on bRequest only, so Device works fine.
+        #[cfg(feature = "is_sync")]
         let recipient = if request_type & 0x03 == 0x02 {
             nusb::transfer::Recipient::Endpoint
         } else {
             nusb::transfer::Recipient::Other
         };
+        #[cfg(not(feature = "is_sync"))]
+        let recipient = nusb::transfer::Recipient::Device;
 
-        let data = self
-            .interface
-            .control_in(
-                nusb::transfer::ControlIn {
-                    control_type: nusb::transfer::ControlType::Vendor,
-                    recipient,
-                    request,
-                    value,
-                    index,
-                    length: buf.len() as u16,
-                },
-                Duration::from_secs(5),
-            )
-            .wait()
-            .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
+        let data = nusb_await!(self.iface().control_in(
+            nusb::transfer::ControlIn {
+                control_type: nusb::transfer::ControlType::Vendor,
+                recipient,
+                request,
+                value,
+                index,
+                length: buf.len() as u16,
+            },
+            Duration::from_secs(5),
+        ))
+        .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
 
         let len = data.len().min(buf.len());
         buf[..len].copy_from_slice(&data[..len]);
@@ -541,40 +802,54 @@ impl Dediprog {
     }
 
     /// USB control write
-    fn control_write(&mut self, cmd: Command, value: u16, index: u16, data: &[u8]) -> Result<()> {
-        self.control_write_raw(cmd as u8, value, index, data)
+    #[maybe_async]
+    async fn control_write(
+        &mut self,
+        cmd: Command,
+        value: u16,
+        index: u16,
+        data: &[u8],
+    ) -> Result<()> {
+        self.control_write_raw(cmd as u8, value, index, data).await
     }
 
     /// USB control write (raw)
-    fn control_write_raw(
+    #[maybe_async]
+    async fn control_write_raw(
         &mut self,
         request: u8,
         value: u16,
         index: u16,
         data: &[u8],
     ) -> Result<()> {
-        self.interface
-            .control_out(
-                nusb::transfer::ControlOut {
-                    control_type: nusb::transfer::ControlType::Vendor,
-                    recipient: nusb::transfer::Recipient::Endpoint,
-                    request,
-                    value,
-                    index,
-                    data,
-                },
-                Duration::from_secs(5),
-            )
-            .wait()
-            .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
+        // See control_read_raw for rationale on the recipient override.
+        #[cfg(feature = "is_sync")]
+        let recipient = nusb::transfer::Recipient::Endpoint;
+        #[cfg(not(feature = "is_sync"))]
+        let recipient = nusb::transfer::Recipient::Device;
+
+        nusb_await!(self.iface().control_out(
+            nusb::transfer::ControlOut {
+                control_type: nusb::transfer::ControlType::Vendor,
+                recipient,
+                request,
+                value,
+                index,
+                data,
+            },
+            Duration::from_secs(5),
+        ))
+        .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
 
         Ok(())
     }
 
     /// Bulk read
-    fn bulk_read(&mut self, buf: &mut [u8]) -> Result<usize> {
+    #[maybe_async]
+    #[allow(dead_code)] // Only called from read_device_id (native path)
+    async fn bulk_read(&mut self, buf: &mut [u8]) -> Result<usize> {
         let mut in_ep: Endpoint<Bulk, In> = self
-            .interface
+            .iface()
             .endpoint(self.in_endpoint)
             .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
 
@@ -583,11 +858,13 @@ impl Dediprog {
         let mut in_buf = Buffer::new(request_len);
         in_buf.set_requested_len(request_len);
 
-        let completion = in_ep.transfer_blocking(in_buf, Duration::from_secs(5));
-        let data = completion
-            .into_result()
+        in_ep.submit(in_buf);
+        let completion = ep_wait!(in_ep, Duration::from_secs(5)).ok_or(DediprogError::Timeout)?;
+        completion
+            .status
             .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
 
+        let data = &completion.buffer[..];
         let len = data.len().min(buf.len());
         buf[..len].copy_from_slice(&data[..len]);
         Ok(len)
@@ -595,27 +872,30 @@ impl Dediprog {
 
     /// Bulk write
     #[allow(dead_code)]
-    fn bulk_write(&mut self, data: &[u8]) -> Result<()> {
+    #[maybe_async]
+    async fn bulk_write(&mut self, data: &[u8]) -> Result<()> {
         let mut out_ep: Endpoint<Bulk, Out> = self
-            .interface
+            .iface()
             .endpoint(self.out_endpoint)
             .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
 
         let mut out_buf = Buffer::new(data.len());
         out_buf.extend_from_slice(data);
 
-        let completion = out_ep.transfer_blocking(out_buf, Duration::from_secs(5));
+        out_ep.submit(out_buf);
+        let completion = ep_wait!(out_ep, Duration::from_secs(5)).ok_or(DediprogError::Timeout)?;
         completion
-            .into_result()
+            .status
             .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
 
         Ok(())
     }
 
     /// Send a transceive command (generic SPI command)
-    fn spi_transceive(&mut self, write_data: &[u8], read_len: usize) -> Result<Vec<u8>> {
+    #[maybe_async]
+    async fn spi_transceive(&mut self, write_data: &[u8], read_len: usize) -> Result<Vec<u8>> {
         // Set to single I/O mode for generic commands
-        self.set_io_mode(DpIoMode::Single)?;
+        self.set_io_mode(DpIoMode::Single).await?;
 
         // Build command
         let (value, index) = if self.protocol >= Protocol::V2 {
@@ -627,7 +907,8 @@ impl Dediprog {
         };
 
         // Send command
-        self.control_write(Command::Transceive, value, index, write_data)?;
+        self.control_write(Command::Transceive, value, index, write_data)
+            .await?;
 
         if read_len == 0 {
             return Ok(Vec::new());
@@ -640,21 +921,24 @@ impl Dediprog {
         while total_read < read_len {
             let to_read = (read_len - total_read).min(64);
 
-            let data = self
-                .interface
-                .control_in(
-                    nusb::transfer::ControlIn {
-                        control_type: nusb::transfer::ControlType::Vendor,
-                        recipient: nusb::transfer::Recipient::Endpoint,
-                        request: Command::Transceive as u8,
-                        value: 0,
-                        index: 0,
-                        length: to_read as u16,
-                    },
-                    Duration::from_secs(5),
-                )
-                .wait()
-                .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
+            // See control_read_raw for rationale on the recipient override.
+            #[cfg(feature = "is_sync")]
+            let recipient = nusb::transfer::Recipient::Endpoint;
+            #[cfg(not(feature = "is_sync"))]
+            let recipient = nusb::transfer::Recipient::Device;
+
+            let data = nusb_await!(self.iface().control_in(
+                nusb::transfer::ControlIn {
+                    control_type: nusb::transfer::ControlType::Vendor,
+                    recipient,
+                    request: Command::Transceive as u8,
+                    value: 0,
+                    index: 0,
+                    length: to_read as u16,
+                },
+                Duration::from_secs(5),
+            ))
+            .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
 
             let len = data.len().min(to_read);
             buf[total_read..total_read + len].copy_from_slice(&data[..len]);
@@ -701,6 +985,7 @@ impl Dediprog {
     ///
     /// Returns the command packet size. The packet is written into `cmd_buf`.
     /// `value` and `idx` are the USB control transfer wValue/wIndex fields.
+    #[allow(clippy::too_many_arguments)]
     fn prepare_rw_cmd(
         &self,
         cmd_buf: &mut [u8; MAX_CMD_SIZE],
@@ -790,7 +1075,8 @@ impl Dediprog {
     /// Start and len MUST be 512-byte aligned. Uses a single large URB so the
     /// kernel handles all USB scheduling internally -- avoids per-packet
     /// userspace round-trips through nusb's epoll background thread.
-    fn bulk_read_flash(&mut self, start: u32, buf: &mut [u8]) -> Result<()> {
+    #[maybe_async]
+    async fn bulk_read_flash(&mut self, start: u32, buf: &mut [u8]) -> Result<()> {
         let len = buf.len();
         if len == 0 {
             return Ok(());
@@ -799,7 +1085,7 @@ impl Dediprog {
         let count = (len / BULK_CHUNK_SIZE) as u16;
 
         // Set I/O mode for reads (single for now, can add multi-IO later)
-        self.set_io_mode(DpIoMode::Single)?;
+        self.set_io_mode(DpIoMode::Single).await?;
 
         // Build and send the CMD_READ command packet
         let mut cmd_buf = [0u8; MAX_CMD_SIZE];
@@ -815,13 +1101,12 @@ impl Dediprog {
             count,
         )?;
 
-        self.control_write_raw(Command::Read as u8, value, idx, &cmd_buf[..cmd_len])?;
+        self.control_write_raw(Command::Read as u8, value, idx, &cmd_buf[..cmd_len])
+            .await?;
 
         // Submit a single large bulk IN transfer for the entire read.
-        // The kernel splits this into 512-byte TDs internally and handles all
-        // USB scheduling without any per-packet userspace round-trips.
         let mut in_ep: Endpoint<Bulk, In> = self
-            .interface
+            .iface()
             .endpoint(self.in_endpoint)
             .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
 
@@ -829,13 +1114,11 @@ impl Dediprog {
         in_ep.submit(xfer_buf);
 
         // Scale timeout with transfer size: 10 s base + ~30 us per byte
-        // (accommodates the slowest SPI speed of 375 kHz ≈ 47 KiB/s)
-        let timeout =
+        // (accommodates the slowest SPI speed of 375 kHz ~ 47 KiB/s)
+        let _timeout =
             Duration::from_secs(ASYNC_TIMEOUT_SECS) + Duration::from_micros(len as u64 * 30);
 
-        let result = in_ep
-            .wait_next_complete(timeout)
-            .ok_or(DediprogError::Timeout)?;
+        let result = ep_wait!(in_ep, _timeout).ok_or(DediprogError::Timeout)?;
         result
             .status
             .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
@@ -857,7 +1140,8 @@ impl Dediprog {
     /// USB buffer with each 256-byte page padded to 512 bytes (0xFF fill),
     /// then submits it as one large URB. The firmware reads 512 bytes at a
     /// time and handles WREN, page program, and WIP polling internally.
-    fn bulk_write_flash(&mut self, start: u32, data: &[u8]) -> Result<()> {
+    #[maybe_async]
+    async fn bulk_write_flash(&mut self, start: u32, data: &[u8]) -> Result<()> {
         const PAGE_SIZE: usize = 256;
         let len = data.len();
         if len == 0 {
@@ -867,7 +1151,7 @@ impl Dediprog {
         let count = (len / PAGE_SIZE) as u16;
 
         // Writes always use single I/O
-        self.set_io_mode(DpIoMode::Single)?;
+        self.set_io_mode(DpIoMode::Single).await?;
 
         // Build and send the CMD_WRITE command packet
         let mut cmd_buf = [0u8; MAX_CMD_SIZE];
@@ -883,12 +1167,13 @@ impl Dediprog {
             count,
         )?;
 
-        self.control_write_raw(Command::Write as u8, value, idx, &cmd_buf[..cmd_len])?;
+        self.control_write_raw(Command::Write as u8, value, idx, &cmd_buf[..cmd_len])
+            .await?;
 
         // Build a single padded buffer: for each 256-byte page, write 256 data + 256 0xFF.
         // The firmware consumes 512 bytes per page and handles the SPI protocol internally.
         let mut out_ep: Endpoint<Bulk, Out> = self
-            .interface
+            .iface()
             .endpoint(self.out_endpoint)
             .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
 
@@ -906,12 +1191,10 @@ impl Dediprog {
 
         // Scale timeout with transfer size: 10 s base + 10 ms per page
         // (accommodates worst-case page-program time of typical NOR flash)
-        let timeout =
+        let _timeout =
             Duration::from_secs(ASYNC_TIMEOUT_SECS) + Duration::from_millis(count as u64 * 10);
 
-        let result = out_ep
-            .wait_next_complete(timeout)
-            .ok_or(DediprogError::Timeout)?;
+        let result = ep_wait!(out_ep, _timeout).ok_or(DediprogError::Timeout)?;
         result
             .status
             .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
@@ -921,13 +1204,14 @@ impl Dediprog {
 
     /// Slow read via SPI transceive (for unaligned head/tail residuals).
     /// Reads up to 16 bytes per USB control transfer using standard READ (0x03).
-    fn slow_read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
+    #[maybe_async]
+    async fn slow_read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
         let mut offset = 0usize;
         while offset < buf.len() {
             let chunk_len = (buf.len() - offset).min(16);
             let a = addr + offset as u32;
             let cmd = [opcodes::READ, (a >> 16) as u8, (a >> 8) as u8, a as u8];
-            let result = self.spi_transceive(&cmd, chunk_len)?;
+            let result = self.spi_transceive(&cmd, chunk_len).await?;
             buf[offset..offset + chunk_len].copy_from_slice(&result[..chunk_len]);
             offset += chunk_len;
         }
@@ -936,7 +1220,8 @@ impl Dediprog {
 
     /// Slow write via SPI transceive (for unaligned head/tail residuals).
     /// Sends individual WREN + PP + RDSR poll sequences, max 11 bytes data per transfer.
-    fn slow_write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
+    #[maybe_async]
+    async fn slow_write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
         let max_write = 16 - 5; // 11 bytes per transceive (16 - 1 opcode - 3 addr - 1 margin)
         let mut offset = 0usize;
 
@@ -949,7 +1234,7 @@ impl Dediprog {
             let chunk_len = remaining.min(max_write).min(to_page_end);
 
             // WREN
-            self.spi_transceive(&[opcodes::WREN], 0)?;
+            self.spi_transceive(&[opcodes::WREN], 0).await?;
 
             // Page Program: [PP, addr_hi, addr_mid, addr_lo, data...]
             let mut cmd = Vec::with_capacity(4 + chunk_len);
@@ -958,19 +1243,20 @@ impl Dediprog {
             cmd.push((a >> 8) as u8);
             cmd.push(a as u8);
             cmd.extend_from_slice(&data[offset..offset + chunk_len]);
-            self.spi_transceive(&cmd, 0)?;
+            self.spi_transceive(&cmd, 0).await?;
 
             // Poll RDSR until WIP clears (bit 0)
-            let timeout = std::time::Instant::now();
-            loop {
-                let status = self.spi_transceive(&[opcodes::RDSR], 1)?;
+            // Use a simple retry counter instead of Instant (not available on WASM)
+            let max_polls = 1000;
+            for poll in 0..max_polls {
+                let status = self.spi_transceive(&[opcodes::RDSR], 1).await?;
                 if status[0] & 0x01 == 0 {
                     break;
                 }
-                if timeout.elapsed() > Duration::from_millis(100) {
+                if poll == max_polls - 1 {
                     return Err(DediprogError::Timeout);
                 }
-                std::thread::sleep(Duration::from_micros(100));
+                platform_sleep!(Duration::from_micros(100));
             }
 
             offset += chunk_len;
@@ -979,21 +1265,17 @@ impl Dediprog {
     }
 }
 
-impl Drop for Dediprog {
-    fn drop(&mut self) {
-        // Reset I/O mode
-        let _ = self.set_io_mode(DpIoMode::Single);
-        // Turn off voltage
-        let _ = self.set_voltage(0);
-    }
-}
+// ---------------------------------------------------------------------------
+// OpaqueMaster trait implementation
+// ---------------------------------------------------------------------------
 
+#[maybe_async(AFIT)]
 impl OpaqueMaster for Dediprog {
     fn size(&self) -> usize {
         self.flash_size.unwrap_or(0) as usize
     }
 
-    fn read(&mut self, addr: u32, buf: &mut [u8]) -> CoreResult<()> {
+    async fn read(&mut self, addr: u32, buf: &mut [u8]) -> CoreResult<()> {
         let len = buf.len();
         if len == 0 {
             return Ok(());
@@ -1001,7 +1283,7 @@ impl OpaqueMaster for Dediprog {
 
         // Split into: head residue + aligned bulk + tail residue
         let chunk_size = BULK_CHUNK_SIZE;
-        let head_residue = if addr as usize % chunk_size != 0 {
+        let head_residue = if !(addr as usize).is_multiple_of(chunk_size) {
             len.min(chunk_size - (addr as usize % chunk_size))
         } else {
             0
@@ -1010,7 +1292,8 @@ impl OpaqueMaster for Dediprog {
         // Head: slow read for unaligned start
         if head_residue > 0 {
             self.slow_read(addr, &mut buf[..head_residue])
-                .map_err(|_| CoreError::ReadError)?;
+                .await
+                .map_err(|_| CoreError::ReadError { addr })?;
         }
 
         // Aligned bulk portion
@@ -1019,20 +1302,20 @@ impl OpaqueMaster for Dediprog {
         let bulk_len = (remaining / chunk_size) * chunk_size;
 
         if bulk_len > 0 {
-            // Bulk read may need to be split into MAX_BLOCK_COUNT chunks
+            // Split into chunks that fit in a single USB buffer.
+            let max_blocks = (MAX_BLOCK_COUNT as usize).min(MAX_READ_BLOCKS);
             let mut bulk_offset = 0usize;
             while bulk_offset < bulk_len {
-                let this_len = (bulk_len - bulk_offset).min(MAX_BLOCK_COUNT as usize * chunk_size);
+                let this_len = (bulk_len - bulk_offset).min(max_blocks * chunk_size);
                 let this_len = (this_len / chunk_size) * chunk_size;
                 if this_len == 0 {
                     break;
                 }
                 let buf_start = head_residue + bulk_offset;
-                self.bulk_read_flash(
-                    bulk_start + bulk_offset as u32,
-                    &mut buf[buf_start..buf_start + this_len],
-                )
-                .map_err(|_| CoreError::ReadError)?;
+                let read_addr = bulk_start + bulk_offset as u32;
+                self.bulk_read_flash(read_addr, &mut buf[buf_start..buf_start + this_len])
+                    .await
+                    .map_err(|_| CoreError::ReadError { addr: read_addr })?;
                 bulk_offset += this_len;
             }
         }
@@ -1040,14 +1323,16 @@ impl OpaqueMaster for Dediprog {
         // Tail: slow read for remaining bytes
         let tail_start = head_residue + bulk_len;
         if tail_start < len {
-            self.slow_read(addr + tail_start as u32, &mut buf[tail_start..])
-                .map_err(|_| CoreError::ReadError)?;
+            let tail_addr = addr + tail_start as u32;
+            self.slow_read(tail_addr, &mut buf[tail_start..])
+                .await
+                .map_err(|_| CoreError::ReadError { addr: tail_addr })?;
         }
 
         Ok(())
     }
 
-    fn write(&mut self, addr: u32, data: &[u8]) -> CoreResult<()> {
+    async fn write(&mut self, addr: u32, data: &[u8]) -> CoreResult<()> {
         const PAGE_SIZE: usize = 256;
         let len = data.len();
         if len == 0 {
@@ -1056,7 +1341,7 @@ impl OpaqueMaster for Dediprog {
 
         // Split into: head residue + aligned bulk + tail residue
         // Bulk writes require 256-byte (page) alignment
-        let head_residue = if addr as usize % PAGE_SIZE != 0 {
+        let head_residue = if !(addr as usize).is_multiple_of(PAGE_SIZE) {
             len.min(PAGE_SIZE - (addr as usize % PAGE_SIZE))
         } else {
             0
@@ -1065,7 +1350,8 @@ impl OpaqueMaster for Dediprog {
         // Head: slow write for unaligned start
         if head_residue > 0 {
             self.slow_write(addr, &data[..head_residue])
-                .map_err(|_| CoreError::WriteError)?;
+                .await
+                .map_err(|_| CoreError::WriteError { addr })?;
         }
 
         // Aligned bulk portion
@@ -1074,20 +1360,22 @@ impl OpaqueMaster for Dediprog {
         let bulk_len = (remaining / PAGE_SIZE) * PAGE_SIZE;
 
         if bulk_len > 0 {
-            // Bulk write may need to be split into MAX_BLOCK_COUNT chunks
+            // Split into chunks that fit in a single USB buffer.
+            // Each page is 512 bytes on the wire (256 data + 256 padding), so
+            // MAX_WRITE_PAGES pages = MAX_WRITE_PAGES * 512 bytes USB buffer.
+            let max_pages = (MAX_BLOCK_COUNT as usize).min(MAX_WRITE_PAGES);
             let mut bulk_offset = 0usize;
             while bulk_offset < bulk_len {
-                let this_len = (bulk_len - bulk_offset).min(MAX_BLOCK_COUNT as usize * PAGE_SIZE);
+                let this_len = (bulk_len - bulk_offset).min(max_pages * PAGE_SIZE);
                 let this_len = (this_len / PAGE_SIZE) * PAGE_SIZE;
                 if this_len == 0 {
                     break;
                 }
                 let data_start = head_residue + bulk_offset;
-                self.bulk_write_flash(
-                    bulk_start + bulk_offset as u32,
-                    &data[data_start..data_start + this_len],
-                )
-                .map_err(|_| CoreError::WriteError)?;
+                let write_addr = bulk_start + bulk_offset as u32;
+                self.bulk_write_flash(write_addr, &data[data_start..data_start + this_len])
+                    .await
+                    .map_err(|_| CoreError::WriteError { addr: write_addr })?;
                 bulk_offset += this_len;
             }
         }
@@ -1095,14 +1383,16 @@ impl OpaqueMaster for Dediprog {
         // Tail: slow write for remaining bytes
         let tail_start = head_residue + bulk_len;
         if tail_start < len {
-            self.slow_write(addr + tail_start as u32, &data[tail_start..])
-                .map_err(|_| CoreError::WriteError)?;
+            let tail_addr = addr + tail_start as u32;
+            self.slow_write(tail_addr, &data[tail_start..])
+                .await
+                .map_err(|_| CoreError::WriteError { addr: tail_addr })?;
         }
 
         Ok(())
     }
 
-    fn erase(&mut self, _addr: u32, _len: u32) -> CoreResult<()> {
+    async fn erase(&mut self, _addr: u32, _len: u32) -> CoreResult<()> {
         // Erase is not supported through the opaque path.
         // The HybridFlashDevice adapter uses SpiMaster for erase operations,
         // since the Dediprog firmware has no bulk erase command.
@@ -1110,6 +1400,11 @@ impl OpaqueMaster for Dediprog {
     }
 }
 
+// ---------------------------------------------------------------------------
+// SpiMaster trait implementation
+// ---------------------------------------------------------------------------
+
+#[maybe_async(AFIT)]
 impl SpiMaster for Dediprog {
     fn features(&self) -> SpiFeatures {
         let mut features = SpiFeatures::empty();
@@ -1161,29 +1456,29 @@ impl SpiMaster for Dediprog {
         16 - 5
     }
 
-    fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
-        default_execute_with_vec(cmd, self.features(), |write_data, read_len| {
-            self.spi_transceive(write_data, read_len)
-                .map_err(|_| CoreError::ProgrammerError)
-        })
+    async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
+        // Check I/O mode support
+        check_io_mode_supported(cmd.io_mode, self.features())?;
+
+        // For simple commands, use transceive
+        let header_len = cmd.header_len();
+        let mut write_data = vec![0u8; header_len + cmd.write_data.len()];
+        cmd.encode_header(&mut write_data);
+        write_data[header_len..].copy_from_slice(cmd.write_data);
+
+        let read_len = cmd.read_buf.len();
+        let result = self
+            .spi_transceive(&write_data, read_len)
+            .await
+            .map_err(|_e| CoreError::ProgrammerError)?;
+
+        cmd.read_buf
+            .copy_from_slice(&result[..read_len.min(result.len())]);
+
+        Ok(())
     }
 
-    fn delay_us(&mut self, us: u32) {
-        std::thread::sleep(Duration::from_micros(us as u64));
-    }
-}
-
-/// Information about a connected Dediprog device
-#[derive(Debug, Clone)]
-pub struct DediprogDeviceInfo {
-    /// USB bus number
-    pub bus: u8,
-    /// USB device address
-    pub address: u8,
-}
-
-impl std::fmt::Display for DediprogDeviceInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Dediprog at bus {} address {}", self.bus, self.address)
+    async fn delay_us(&mut self, us: u32) {
+        platform_sleep!(Duration::from_micros(us as u64));
     }
 }

--- a/crates/rflasher-dediprog/src/device.rs
+++ b/crates/rflasher-dediprog/src/device.rs
@@ -9,8 +9,8 @@ use nusb::transfer::{Buffer, Bulk, In, Out};
 use nusb::{Endpoint, Interface, MaybeFuture};
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
 use rflasher_core::programmer::default_execute_with_vec;
-use rflasher_core::programmer::{SpiFeatures, SpiMaster};
-use rflasher_core::spi::SpiCommand;
+use rflasher_core::programmer::{OpaqueMaster, SpiFeatures, SpiMaster};
+use rflasher_core::spi::{opcodes, SpiCommand};
 
 use crate::error::{DediprogError, Result};
 use crate::protocol::*;
@@ -121,6 +121,8 @@ pub struct Dediprog {
     io_mode: DpIoMode,
     /// Configured maximum I/O mode
     max_io_mode: DpIoMode,
+    /// Flash size in bytes (set after probing, needed for OpaqueMaster)
+    flash_size: Option<u32>,
 }
 
 impl Dediprog {
@@ -203,6 +205,7 @@ impl Dediprog {
             protocol: Protocol::Unknown,
             io_mode: DpIoMode::Single,
             max_io_mode: config.io_mode,
+            flash_size: None,
         };
 
         // Try to read device string (may need set_voltage first for old devices)
@@ -684,6 +687,296 @@ impl Dediprog {
     pub fn protocol(&self) -> Protocol {
         self.protocol
     }
+
+    /// Set the flash size (call after probing to enable OpaqueMaster)
+    pub fn set_flash_size(&mut self, size: u32) {
+        self.flash_size = Some(size);
+    }
+
+    // =========================================================================
+    // Bulk Read/Write (CMD_READ/CMD_WRITE with USB bulk transfers)
+    // =========================================================================
+
+    /// Prepare a read/write command packet for the given protocol version.
+    ///
+    /// Returns the command packet size. The packet is written into `cmd_buf`.
+    /// `value` and `idx` are the USB control transfer wValue/wIndex fields.
+    fn prepare_rw_cmd(
+        &self,
+        cmd_buf: &mut [u8; MAX_CMD_SIZE],
+        value: &mut u16,
+        idx: &mut u16,
+        is_read: bool,
+        mode: u8,
+        start: u32,
+        count: u16,
+    ) -> Result<usize> {
+        // Common header (all protocol versions)
+        cmd_buf[0] = (count & 0xFF) as u8;
+        cmd_buf[1] = ((count >> 8) & 0xFF) as u8;
+        cmd_buf[2] = 0; // RFU
+        cmd_buf[3] = mode;
+        cmd_buf[4] = 0; // Opcode (overridden below for V2/V3)
+
+        match self.protocol {
+            Protocol::V1 => {
+                // V1: address in wValue/wIndex, 5-byte command packet
+                if start >> 24 != 0 {
+                    return Err(DediprogError::Unsupported(
+                        "4-byte address not supported on V1 protocol".to_string(),
+                    ));
+                }
+                *value = (start & 0xFFFF) as u16;
+                *idx = ((start >> 16) & 0xFF) as u16;
+                Ok(5)
+            }
+            Protocol::V2 => {
+                *value = 0;
+                *idx = 0;
+
+                if is_read {
+                    // For V2 reads, use standard read mode with fast read opcode
+                    // The firmware handles the SPI read command internally
+                    cmd_buf[3] = ReadMode::Fast as u8;
+                    cmd_buf[4] = opcodes::FAST_READ;
+                } else {
+                    // For V2 writes, use page program mode
+                    cmd_buf[3] = WriteMode::PagePgm as u8;
+                    cmd_buf[4] = 0;
+                }
+
+                cmd_buf[5] = 0; // RFU
+                cmd_buf[6] = (start & 0xFF) as u8;
+                cmd_buf[7] = ((start >> 8) & 0xFF) as u8;
+                cmd_buf[8] = ((start >> 16) & 0xFF) as u8;
+                cmd_buf[9] = ((start >> 24) & 0xFF) as u8;
+                Ok(10)
+            }
+            Protocol::V3 => {
+                *value = 0;
+                *idx = 0;
+
+                cmd_buf[5] = 0; // RFU
+                cmd_buf[6] = (start & 0xFF) as u8;
+                cmd_buf[7] = ((start >> 8) & 0xFF) as u8;
+                cmd_buf[8] = ((start >> 16) & 0xFF) as u8;
+                cmd_buf[9] = ((start >> 24) & 0xFF) as u8;
+
+                if is_read {
+                    cmd_buf[3] = ReadMode::Configurable as u8;
+                    cmd_buf[4] = opcodes::FAST_READ;
+                    cmd_buf[10] = if start >> 24 != 0 { 4 } else { 3 }; // address length
+                    cmd_buf[11] = 4; // dummy half-cycles (8 clocks / 2 for fast read)
+                    Ok(12)
+                } else {
+                    cmd_buf[3] = WriteMode::PagePgm as u8;
+                    cmd_buf[4] = 0;
+                    // Page size (256 bytes) as 32-bit LE
+                    cmd_buf[10] = 0x00;
+                    cmd_buf[11] = 0x01;
+                    cmd_buf[12] = 0x00;
+                    cmd_buf[13] = 0x00;
+                    Ok(14)
+                }
+            }
+            Protocol::Unknown => Err(DediprogError::Unsupported(
+                "Unknown protocol version".to_string(),
+            )),
+        }
+    }
+
+    /// Bulk read from flash using CMD_READ + USB bulk IN transfers.
+    ///
+    /// Start and len MUST be 512-byte aligned. Uses a single large URB so the
+    /// kernel handles all USB scheduling internally -- avoids per-packet
+    /// userspace round-trips through nusb's epoll background thread.
+    fn bulk_read_flash(&mut self, start: u32, buf: &mut [u8]) -> Result<()> {
+        let len = buf.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        let count = (len / BULK_CHUNK_SIZE) as u16;
+
+        // Set I/O mode for reads (single for now, can add multi-IO later)
+        self.set_io_mode(DpIoMode::Single)?;
+
+        // Build and send the CMD_READ command packet
+        let mut cmd_buf = [0u8; MAX_CMD_SIZE];
+        let mut value: u16 = 0;
+        let mut idx: u16 = 0;
+        let cmd_len = self.prepare_rw_cmd(
+            &mut cmd_buf,
+            &mut value,
+            &mut idx,
+            true,
+            ReadMode::Std as u8,
+            start,
+            count,
+        )?;
+
+        self.control_write_raw(Command::Read as u8, value, idx, &cmd_buf[..cmd_len])?;
+
+        // Submit a single large bulk IN transfer for the entire read.
+        // The kernel splits this into 512-byte TDs internally and handles all
+        // USB scheduling without any per-packet userspace round-trips.
+        let mut in_ep: Endpoint<Bulk, In> = self
+            .interface
+            .endpoint(self.in_endpoint)
+            .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
+
+        let xfer_buf = in_ep.allocate(len);
+        in_ep.submit(xfer_buf);
+
+        // Scale timeout with transfer size: 10 s base + ~30 us per byte
+        // (accommodates the slowest SPI speed of 375 kHz ≈ 47 KiB/s)
+        let timeout =
+            Duration::from_secs(ASYNC_TIMEOUT_SECS) + Duration::from_micros(len as u64 * 30);
+
+        let result = in_ep
+            .wait_next_complete(timeout)
+            .ok_or(DediprogError::Timeout)?;
+        result
+            .status
+            .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
+
+        if result.actual_len != len {
+            return Err(DediprogError::TransferFailed(format!(
+                "Short bulk read: expected {} bytes, got {}",
+                len, result.actual_len
+            )));
+        }
+
+        buf.copy_from_slice(&result.buffer[..len]);
+        Ok(())
+    }
+
+    /// Bulk write to flash using CMD_WRITE + USB bulk OUT transfers.
+    ///
+    /// Start and len MUST be 256-byte aligned. Builds a single contiguous
+    /// USB buffer with each 256-byte page padded to 512 bytes (0xFF fill),
+    /// then submits it as one large URB. The firmware reads 512 bytes at a
+    /// time and handles WREN, page program, and WIP polling internally.
+    fn bulk_write_flash(&mut self, start: u32, data: &[u8]) -> Result<()> {
+        const PAGE_SIZE: usize = 256;
+        let len = data.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        let count = (len / PAGE_SIZE) as u16;
+
+        // Writes always use single I/O
+        self.set_io_mode(DpIoMode::Single)?;
+
+        // Build and send the CMD_WRITE command packet
+        let mut cmd_buf = [0u8; MAX_CMD_SIZE];
+        let mut value: u16 = 0;
+        let mut idx: u16 = 0;
+        let cmd_len = self.prepare_rw_cmd(
+            &mut cmd_buf,
+            &mut value,
+            &mut idx,
+            false,
+            WriteMode::PagePgm as u8,
+            start,
+            count,
+        )?;
+
+        self.control_write_raw(Command::Write as u8, value, idx, &cmd_buf[..cmd_len])?;
+
+        // Build a single padded buffer: for each 256-byte page, write 256 data + 256 0xFF.
+        // The firmware consumes 512 bytes per page and handles the SPI protocol internally.
+        let mut out_ep: Endpoint<Bulk, Out> = self
+            .interface
+            .endpoint(self.out_endpoint)
+            .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
+
+        let count = count as usize;
+        let total_usb_len = count * BULK_CHUNK_SIZE;
+        let mut out_buf = out_ep.allocate(total_usb_len);
+
+        for i in 0..count {
+            let src_start = i * PAGE_SIZE;
+            out_buf.extend_from_slice(&data[src_start..src_start + PAGE_SIZE]);
+            out_buf.extend_from_slice(&[0xFF; BULK_CHUNK_SIZE - PAGE_SIZE]);
+        }
+
+        out_ep.submit(out_buf);
+
+        // Scale timeout with transfer size: 10 s base + 10 ms per page
+        // (accommodates worst-case page-program time of typical NOR flash)
+        let timeout =
+            Duration::from_secs(ASYNC_TIMEOUT_SECS) + Duration::from_millis(count as u64 * 10);
+
+        let result = out_ep
+            .wait_next_complete(timeout)
+            .ok_or(DediprogError::Timeout)?;
+        result
+            .status
+            .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Slow read via SPI transceive (for unaligned head/tail residuals).
+    /// Reads up to 16 bytes per USB control transfer using standard READ (0x03).
+    fn slow_read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
+        let mut offset = 0usize;
+        while offset < buf.len() {
+            let chunk_len = (buf.len() - offset).min(16);
+            let a = addr + offset as u32;
+            let cmd = [opcodes::READ, (a >> 16) as u8, (a >> 8) as u8, a as u8];
+            let result = self.spi_transceive(&cmd, chunk_len)?;
+            buf[offset..offset + chunk_len].copy_from_slice(&result[..chunk_len]);
+            offset += chunk_len;
+        }
+        Ok(())
+    }
+
+    /// Slow write via SPI transceive (for unaligned head/tail residuals).
+    /// Sends individual WREN + PP + RDSR poll sequences, max 11 bytes data per transfer.
+    fn slow_write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
+        let max_write = 16 - 5; // 11 bytes per transceive (16 - 1 opcode - 3 addr - 1 margin)
+        let mut offset = 0usize;
+
+        while offset < data.len() {
+            let a = addr + offset as u32;
+            // Respect page boundaries (256 bytes)
+            let page_offset = a as usize % 256;
+            let to_page_end = 256 - page_offset;
+            let remaining = data.len() - offset;
+            let chunk_len = remaining.min(max_write).min(to_page_end);
+
+            // WREN
+            self.spi_transceive(&[opcodes::WREN], 0)?;
+
+            // Page Program: [PP, addr_hi, addr_mid, addr_lo, data...]
+            let mut cmd = Vec::with_capacity(4 + chunk_len);
+            cmd.push(opcodes::PP);
+            cmd.push((a >> 16) as u8);
+            cmd.push((a >> 8) as u8);
+            cmd.push(a as u8);
+            cmd.extend_from_slice(&data[offset..offset + chunk_len]);
+            self.spi_transceive(&cmd, 0)?;
+
+            // Poll RDSR until WIP clears (bit 0)
+            let timeout = std::time::Instant::now();
+            loop {
+                let status = self.spi_transceive(&[opcodes::RDSR], 1)?;
+                if status[0] & 0x01 == 0 {
+                    break;
+                }
+                if timeout.elapsed() > Duration::from_millis(100) {
+                    return Err(DediprogError::Timeout);
+                }
+                std::thread::sleep(Duration::from_micros(100));
+            }
+
+            offset += chunk_len;
+        }
+        Ok(())
+    }
 }
 
 impl Drop for Dediprog {
@@ -692,6 +985,128 @@ impl Drop for Dediprog {
         let _ = self.set_io_mode(DpIoMode::Single);
         // Turn off voltage
         let _ = self.set_voltage(0);
+    }
+}
+
+impl OpaqueMaster for Dediprog {
+    fn size(&self) -> usize {
+        self.flash_size.unwrap_or(0) as usize
+    }
+
+    fn read(&mut self, addr: u32, buf: &mut [u8]) -> CoreResult<()> {
+        let len = buf.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        // Split into: head residue + aligned bulk + tail residue
+        let chunk_size = BULK_CHUNK_SIZE;
+        let head_residue = if addr as usize % chunk_size != 0 {
+            len.min(chunk_size - (addr as usize % chunk_size))
+        } else {
+            0
+        };
+
+        // Head: slow read for unaligned start
+        if head_residue > 0 {
+            self.slow_read(addr, &mut buf[..head_residue])
+                .map_err(|_| CoreError::ReadError)?;
+        }
+
+        // Aligned bulk portion
+        let bulk_start = addr + head_residue as u32;
+        let remaining = len - head_residue;
+        let bulk_len = (remaining / chunk_size) * chunk_size;
+
+        if bulk_len > 0 {
+            // Bulk read may need to be split into MAX_BLOCK_COUNT chunks
+            let mut bulk_offset = 0usize;
+            while bulk_offset < bulk_len {
+                let this_len = (bulk_len - bulk_offset).min(MAX_BLOCK_COUNT as usize * chunk_size);
+                let this_len = (this_len / chunk_size) * chunk_size;
+                if this_len == 0 {
+                    break;
+                }
+                let buf_start = head_residue + bulk_offset;
+                self.bulk_read_flash(
+                    bulk_start + bulk_offset as u32,
+                    &mut buf[buf_start..buf_start + this_len],
+                )
+                .map_err(|_| CoreError::ReadError)?;
+                bulk_offset += this_len;
+            }
+        }
+
+        // Tail: slow read for remaining bytes
+        let tail_start = head_residue + bulk_len;
+        if tail_start < len {
+            self.slow_read(addr + tail_start as u32, &mut buf[tail_start..])
+                .map_err(|_| CoreError::ReadError)?;
+        }
+
+        Ok(())
+    }
+
+    fn write(&mut self, addr: u32, data: &[u8]) -> CoreResult<()> {
+        const PAGE_SIZE: usize = 256;
+        let len = data.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        // Split into: head residue + aligned bulk + tail residue
+        // Bulk writes require 256-byte (page) alignment
+        let head_residue = if addr as usize % PAGE_SIZE != 0 {
+            len.min(PAGE_SIZE - (addr as usize % PAGE_SIZE))
+        } else {
+            0
+        };
+
+        // Head: slow write for unaligned start
+        if head_residue > 0 {
+            self.slow_write(addr, &data[..head_residue])
+                .map_err(|_| CoreError::WriteError)?;
+        }
+
+        // Aligned bulk portion
+        let bulk_start = addr + head_residue as u32;
+        let remaining = len - head_residue;
+        let bulk_len = (remaining / PAGE_SIZE) * PAGE_SIZE;
+
+        if bulk_len > 0 {
+            // Bulk write may need to be split into MAX_BLOCK_COUNT chunks
+            let mut bulk_offset = 0usize;
+            while bulk_offset < bulk_len {
+                let this_len = (bulk_len - bulk_offset).min(MAX_BLOCK_COUNT as usize * PAGE_SIZE);
+                let this_len = (this_len / PAGE_SIZE) * PAGE_SIZE;
+                if this_len == 0 {
+                    break;
+                }
+                let data_start = head_residue + bulk_offset;
+                self.bulk_write_flash(
+                    bulk_start + bulk_offset as u32,
+                    &data[data_start..data_start + this_len],
+                )
+                .map_err(|_| CoreError::WriteError)?;
+                bulk_offset += this_len;
+            }
+        }
+
+        // Tail: slow write for remaining bytes
+        let tail_start = head_residue + bulk_len;
+        if tail_start < len {
+            self.slow_write(addr + tail_start as u32, &data[tail_start..])
+                .map_err(|_| CoreError::WriteError)?;
+        }
+
+        Ok(())
+    }
+
+    fn erase(&mut self, _addr: u32, _len: u32) -> CoreResult<()> {
+        // Erase is not supported through the opaque path.
+        // The HybridFlashDevice adapter uses SpiMaster for erase operations,
+        // since the Dediprog firmware has no bulk erase command.
+        Err(CoreError::ProgrammerError)
     }
 }
 

--- a/crates/rflasher-dediprog/src/lib.rs
+++ b/crates/rflasher-dediprog/src/lib.rs
@@ -16,6 +16,10 @@
 //! - V2: Extended protocol (SF100/SF200 >= 5.5, SF600 6.9-7.2.21)
 //! - V3: Latest protocol (SF600 >= 7.2.22, SF600PG2, SF700)
 //!
+//! Uses `maybe_async` to support both sync and async modes:
+//! - With `is_sync` feature (native CLI): blocking/synchronous
+//! - Without `is_sync` (WASM): async with WebUSB
+//!
 //! # Example
 //!
 //! ```no_run
@@ -59,18 +63,20 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", feature = "wasm")), no_std)]
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 mod device;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 mod error;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 mod protocol;
 
 #[cfg(feature = "std")]
-pub use device::{parse_options, Dediprog, DediprogConfig, DediprogDeviceInfo};
-#[cfg(feature = "std")]
+pub use device::DediprogDeviceInfo;
+#[cfg(any(feature = "std", feature = "wasm"))]
+pub use device::{parse_options, Dediprog, DediprogConfig};
+#[cfg(any(feature = "std", feature = "wasm"))]
 pub use error::{DediprogError, Result};
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 pub use protocol::{DeviceType, Protocol};

--- a/crates/rflasher-dediprog/src/protocol.rs
+++ b/crates/rflasher-dediprog/src/protocol.rs
@@ -30,6 +30,25 @@ pub const MAX_CMD_SIZE: usize = 15;
 pub const ASYNC_TRANSFERS: usize = 8;
 pub const BULK_CHUNK_SIZE: usize = 512;
 
+/// Maximum number of pages per CMD_WRITE + bulk OUT cycle.
+///
+/// Each 256-byte page occupies 512 bytes on the USB wire (data + padding),
+/// so the USB buffer is `MAX_WRITE_PAGES * 512` bytes. We cap this to keep
+/// the URB allocation well within Linux usbfs limits (~16 MiB default for
+/// all outstanding URBs combined).
+///
+/// 4096 pages = 1 MiB data = 2 MiB USB buffer.
+///
+/// For a 16 MiB flash this means ~16 CMD_WRITE + bulk cycles, each adding
+/// a negligible control transfer versus the bulk data time.
+pub const MAX_WRITE_PAGES: usize = 4096;
+
+/// Maximum number of 512-byte blocks per CMD_READ + bulk IN cycle.
+///
+/// The read USB buffer is `MAX_READ_BLOCKS * 512` bytes (no padding needed).
+/// 8192 blocks = 4 MiB USB buffer.
+pub const MAX_READ_BLOCKS: usize = 8192;
+
 /// Firmware version encoding (same as flashprog)
 #[inline]
 pub const fn firmware_version(major: u32, minor: u32, patch: u32) -> u32 {

--- a/crates/rflasher-flash/src/registry.rs
+++ b/crates/rflasher-flash/src/registry.rs
@@ -7,7 +7,9 @@ use crate::handle::{ChipInfo, FlashHandle};
 use rflasher_core::chip::ChipDatabase;
 #[allow(unused_imports)] // Used in feature-gated code
 use rflasher_core::flash::FlashDevice;
-use rflasher_core::flash::{probe_detailed, OpaqueFlashDevice, ProbeResult, SpiFlashDevice};
+use rflasher_core::flash::{
+    probe_detailed, HybridFlashDevice, OpaqueFlashDevice, ProbeResult, SpiFlashDevice,
+};
 use rflasher_core::layout::parse_ifd;
 use rflasher_core::programmer::OpaqueMaster;
 use rflasher_core::sfdp::SfdpMismatch;
@@ -539,7 +541,7 @@ fn open_dediprog(
     let config =
         parse_options(&options).map_err(|e| format!("Invalid Dediprog parameters: {}", e))?;
 
-    let master = Dediprog::open_with_config(config).map_err(|e| {
+    let mut master = Dediprog::open_with_config(config).map_err(|e| {
         format!(
             "Failed to open Dediprog: {}\n\
              Make sure the device is connected and you have USB permissions.",
@@ -553,7 +555,19 @@ fn open_dediprog(
         master.device_string()
     );
 
-    probe_and_create_handle(master, db)
+    // Probe the flash chip via SpiMaster
+    let result = probe_detailed(&mut master, db)?;
+    log_probe_result(&result);
+    let chip_info = ChipInfo::from(result);
+    let ctx = rflasher_core::flash::FlashContext::new(chip_info.chip.clone().unwrap());
+
+    // Set flash size so OpaqueMaster bulk read/write knows the bounds
+    master.set_flash_size(ctx.total_size() as u32);
+
+    // Use HybridFlashDevice: OpaqueMaster for fast bulk read/write (CMD_READ/CMD_WRITE),
+    // SpiMaster for erase, status register access, and write protection
+    let device = HybridFlashDevice::new(master, ctx);
+    Ok(FlashHandle::with_chip_info(Box::new(device), chip_info))
 }
 
 #[cfg(feature = "serprog")]

--- a/crates/rflasher-wasm/Cargo.toml
+++ b/crates/rflasher-wasm/Cargo.toml
@@ -19,6 +19,7 @@ rflasher-serprog = { path = "../rflasher-serprog", default-features = false, fea
 rflasher-ch341a = { path = "../rflasher-ch341a", default-features = false, features = ["wasm"] }
 rflasher-ch347 = { path = "../rflasher-ch347", default-features = false, features = ["wasm"] }
 rflasher-ftdi = { path = "../rflasher-ftdi", default-features = false, features = ["wasm"] }
+rflasher-dediprog = { path = "../rflasher-dediprog", default-features = false, features = ["wasm"] }
 
 # GUI
 eframe = { version = "0.33", default-features = false, features = [

--- a/crates/rflasher-wasm/src/app.rs
+++ b/crates/rflasher-wasm/src/app.rs
@@ -9,7 +9,9 @@ use rflasher_ch341a::Ch341a;
 use rflasher_ch347::{Ch347, SpiSpeed};
 use rflasher_core::chip::{ChipDatabase, FlashChip};
 use rflasher_core::flash::unified::{smart_write, WriteProgress, WriteStats};
-use rflasher_core::flash::{FlashContext, FlashDevice, HybridFlashDevice, ProbeResult, SpiFlashDevice};
+use rflasher_core::flash::{
+    FlashContext, FlashDevice, HybridFlashDevice, ProbeResult, SpiFlashDevice,
+};
 use rflasher_dediprog::{Dediprog, DediprogConfig};
 use rflasher_ftdi::{Ftdi, FtdiConfig, FtdiDeviceType, FtdiInterface};
 use rflasher_serprog::Serprog;
@@ -930,10 +932,7 @@ impl RflasherApp {
             match Dediprog::request_device().await {
                 Ok(device_info) => match Dediprog::open(device_info, config).await {
                     Ok(dediprog) => {
-                        let name = format!(
-                            "Dediprog {}",
-                            dediprog.device_string()
-                        );
+                        let name = format!("Dediprog {}", dediprog.device_string());
                         let mut state = shared.borrow_mut();
                         state.programmer = Some(Programmer::Dediprog(dediprog));
                         state.messages.push(AsyncMessage::Connected {
@@ -1340,8 +1339,7 @@ impl RflasherApp {
                             Ok(()) => {
                                 let expected = &data[offset..offset + chunk_size];
                                 if buf != expected {
-                                    for (i, (a, b)) in buf.iter().zip(expected.iter()).enumerate()
-                                    {
+                                    for (i, (a, b)) in buf.iter().zip(expected.iter()).enumerate() {
                                         if a != b {
                                             verify_error = Some(format!(
                                                 "Mismatch at 0x{:X}: read 0x{:02X}, expected 0x{:02X}",

--- a/crates/rflasher-wasm/src/app.rs
+++ b/crates/rflasher-wasm/src/app.rs
@@ -9,7 +9,8 @@ use rflasher_ch341a::Ch341a;
 use rflasher_ch347::{Ch347, SpiSpeed};
 use rflasher_core::chip::{ChipDatabase, FlashChip};
 use rflasher_core::flash::unified::{smart_write, WriteProgress, WriteStats};
-use rflasher_core::flash::{FlashContext, FlashDevice, ProbeResult, SpiFlashDevice};
+use rflasher_core::flash::{FlashContext, FlashDevice, HybridFlashDevice, ProbeResult, SpiFlashDevice};
+use rflasher_dediprog::{Dediprog, DediprogConfig};
 use rflasher_ftdi::{Ftdi, FtdiConfig, FtdiDeviceType, FtdiInterface};
 use rflasher_serprog::Serprog;
 
@@ -48,6 +49,8 @@ enum ProgrammerType {
     Ch347,
     /// FTDI MPSSE via WebUSB (FT2232H, FT4232H, FT232H, etc.)
     Ftdi,
+    /// Dediprog SF100/SF200/SF600/SF700 via WebUSB
+    Dediprog,
 }
 
 impl ProgrammerType {
@@ -57,6 +60,7 @@ impl ProgrammerType {
             ProgrammerType::Ch341a => "CH341A (WebUSB)",
             ProgrammerType::Ch347 => "CH347 (WebUSB)",
             ProgrammerType::Ftdi => "FTDI MPSSE (WebUSB)",
+            ProgrammerType::Dediprog => "Dediprog (WebUSB)",
         }
     }
 
@@ -64,18 +68,22 @@ impl ProgrammerType {
     fn is_webusb(&self) -> bool {
         matches!(
             self,
-            ProgrammerType::Ch341a | ProgrammerType::Ch347 | ProgrammerType::Ftdi
+            ProgrammerType::Ch341a
+                | ProgrammerType::Ch347
+                | ProgrammerType::Ftdi
+                | ProgrammerType::Dediprog
         )
     }
 }
 
-/// Connected programmer - wraps a serprog, CH341A, CH347, or FTDI device
+/// Connected programmer - wraps a serprog, CH341A, CH347, FTDI, or Dediprog device
 #[allow(clippy::large_enum_variant)]
 enum Programmer {
     Serprog(Serprog<WebSerialTransport>),
     Ch341a(Ch341a),
     Ch347(Ch347),
     Ftdi(Ftdi),
+    Dediprog(Dediprog),
 }
 
 // ---------------------------------------------------------------------------
@@ -113,6 +121,64 @@ macro_rules! with_programmer {
             Programmer::Ftdi(mut $name) => {
                 let result = $body;
                 $shared.borrow_mut().programmer = Some(Programmer::Ftdi($name));
+                result
+            }
+            Programmer::Dediprog(mut $name) => {
+                let result = $body;
+                $shared.borrow_mut().programmer = Some(Programmer::Dediprog($name));
+                result
+            }
+        }
+    };
+}
+
+/// Like [`with_programmer!`], but wraps the programmer in a [`FlashDevice`]
+/// for operations that need chip-level read/write/erase.
+///
+/// For Dediprog: creates [`HybridFlashDevice`] (fast bulk read/write via
+/// `OpaqueMaster`) and calls `set_flash_size()` first.
+/// For all others: creates [`SpiFlashDevice`].
+///
+/// The body receives `$device` as `&mut impl FlashDevice`. The macro handles
+/// extracting the master back via `into_parts()` and putting the Programmer
+/// wrapper back into shared state.
+macro_rules! with_flash_device {
+    ($shared:expr, $programmer:expr, $ctx_flash:expr, $device:ident, $body:expr) => {
+        match $programmer {
+            Programmer::Serprog(master) => {
+                let mut $device = SpiFlashDevice::new(master, $ctx_flash);
+                let result = { $body };
+                let (master, _) = $device.into_parts();
+                $shared.borrow_mut().programmer = Some(Programmer::Serprog(master));
+                result
+            }
+            Programmer::Ch341a(master) => {
+                let mut $device = SpiFlashDevice::new(master, $ctx_flash);
+                let result = { $body };
+                let (master, _) = $device.into_parts();
+                $shared.borrow_mut().programmer = Some(Programmer::Ch341a(master));
+                result
+            }
+            Programmer::Ch347(master) => {
+                let mut $device = SpiFlashDevice::new(master, $ctx_flash);
+                let result = { $body };
+                let (master, _) = $device.into_parts();
+                $shared.borrow_mut().programmer = Some(Programmer::Ch347(master));
+                result
+            }
+            Programmer::Ftdi(master) => {
+                let mut $device = SpiFlashDevice::new(master, $ctx_flash);
+                let result = { $body };
+                let (master, _) = $device.into_parts();
+                $shared.borrow_mut().programmer = Some(Programmer::Ftdi(master));
+                result
+            }
+            Programmer::Dediprog(mut master) => {
+                master.set_flash_size($ctx_flash.total_size() as u32);
+                let mut $device = HybridFlashDevice::new(master, $ctx_flash);
+                let result = { $body };
+                let (master, _) = $device.into_parts();
+                $shared.borrow_mut().programmer = Some(Programmer::Dediprog(master));
                 result
             }
         }
@@ -647,6 +713,7 @@ impl RflasherApp {
             ProgrammerType::Ch341a => self.spawn_connect_ch341a(),
             ProgrammerType::Ch347 => self.spawn_connect_ch347(),
             ProgrammerType::Ftdi => self.spawn_connect_ftdi(),
+            ProgrammerType::Dediprog => self.spawn_connect_dediprog(),
         }
     }
 
@@ -849,6 +916,52 @@ impl RflasherApp {
         });
     }
 
+    fn spawn_connect_dediprog(&mut self) {
+        let shared = self.shared.clone();
+        let ctx = self.ctx.clone();
+        let config = DediprogConfig::default();
+
+        self.connection = ConnectionState::Connecting;
+        self.status.info("Requesting Dediprog device via WebUSB...");
+
+        wasm_bindgen_futures::spawn_local(async move {
+            shared.borrow_mut().busy = true;
+
+            match Dediprog::request_device().await {
+                Ok(device_info) => match Dediprog::open(device_info, config).await {
+                    Ok(dediprog) => {
+                        let name = format!(
+                            "Dediprog {}",
+                            dediprog.device_string()
+                        );
+                        let mut state = shared.borrow_mut();
+                        state.programmer = Some(Programmer::Dediprog(dediprog));
+                        state.messages.push(AsyncMessage::Connected {
+                            programmer_name: name,
+                        });
+                    }
+                    Err(e) => {
+                        shared
+                            .borrow_mut()
+                            .messages
+                            .push(AsyncMessage::ConnectionFailed(format!("{}", e)));
+                    }
+                },
+                Err(e) => {
+                    shared
+                        .borrow_mut()
+                        .messages
+                        .push(AsyncMessage::ConnectionFailed(format!("{}", e)));
+                }
+            }
+
+            shared.borrow_mut().busy = false;
+            if let Some(ctx) = ctx {
+                ctx.request_repaint();
+            }
+        });
+    }
+
     fn spawn_disconnect(&mut self) {
         let shared = self.shared.clone();
 
@@ -871,6 +984,9 @@ impl RflasherApp {
                     }
                     Programmer::Ftdi(mut ftdi) => {
                         ftdi.shutdown().await;
+                    }
+                    Programmer::Dediprog(mut dediprog) => {
+                        dediprog.shutdown().await;
                     }
                 }
 
@@ -958,26 +1074,62 @@ impl RflasherApp {
             let programmer = shared.borrow_mut().programmer.take();
 
             if let Some(programmer) = programmer {
-                use rflasher_core::flash::unified::read_with_progress;
-
                 let ctx_flash = FlashContext::new(chip);
                 let mut buf = vec![0u8; size];
-                let mut progress = SharedProgress::new(shared.clone(), ctx.clone());
 
-                with_programmer!(shared, programmer, master, {
-                    let mut device = SpiFlashDevice::new(master, ctx_flash);
-                    let result = read_with_progress(&mut device, &mut buf, &mut progress).await;
-                    let (m, _) = device.into_parts();
-                    master = m;
+                /// Read chunk size.  Larger chunks reduce per-chunk overhead
+                /// (each chunk requires a new CMD_READ control transfer for
+                /// Dediprog, plus a yield/repaint cycle).  2 MiB gives ~8
+                /// progress updates for a 16 MiB flash while keeping overhead
+                /// low (8 CMD_READs instead of 64 with 256 KiB chunks).
+                const READ_CHUNK_SIZE: usize = 2 * 1024 * 1024;
+                /// Yield to browser every 2 MiB to keep the UI responsive.
+                const YIELD_INTERVAL: usize = 2 * 1024 * 1024;
 
-                    match result {
-                        Ok(()) => {
+                with_flash_device!(shared, programmer, ctx_flash, device, {
+                    let total = buf.len();
+                    let mut offset = 0usize;
+                    let mut last_yield = 0usize;
+                    let mut read_error: Option<rflasher_core::error::Error> = None;
+
+                    while offset < total {
+                        let chunk_size = core::cmp::min(READ_CHUNK_SIZE, total - offset);
+                        match device
+                            .read(offset as u32, &mut buf[offset..offset + chunk_size])
+                            .await
+                        {
+                            Ok(()) => {}
+                            Err(e) => {
+                                read_error = Some(e);
+                                break;
+                            }
+                        }
+                        offset += chunk_size;
+
+                        shared.borrow_mut().messages.push(AsyncMessage::Progress(
+                            ProgressUpdate::Reading {
+                                done: offset,
+                                total,
+                            },
+                        ));
+
+                        if offset >= last_yield + YIELD_INTERVAL {
+                            last_yield = offset;
+                            if let Some(ref ctx) = ctx {
+                                ctx.request_repaint();
+                            }
+                            yield_to_browser().await;
+                        }
+                    }
+
+                    match read_error {
+                        None => {
                             shared
                                 .borrow_mut()
                                 .messages
                                 .push(AsyncMessage::ReadComplete(buf));
                         }
-                        Err(e) => {
+                        Some(e) => {
                             shared
                                 .borrow_mut()
                                 .messages
@@ -1041,11 +1193,8 @@ impl RflasherApp {
                 let ctx_flash = FlashContext::new(chip);
                 let mut progress = SharedProgress::new(shared.clone(), ctx.clone());
 
-                with_programmer!(shared, programmer, master, {
-                    let mut device = SpiFlashDevice::new(master, ctx_flash);
+                with_flash_device!(shared, programmer, ctx_flash, device, {
                     let result = smart_write(&mut device, &data, &mut progress).await;
-                    let (m, _) = device.into_parts();
-                    master = m;
 
                     match result {
                         Ok(stats) => {
@@ -1101,11 +1250,8 @@ impl RflasherApp {
             if let Some(programmer) = programmer {
                 let ctx_flash = FlashContext::new(chip);
 
-                with_programmer!(shared, programmer, master, {
-                    let mut device = SpiFlashDevice::new(master, ctx_flash);
+                with_flash_device!(shared, programmer, ctx_flash, device, {
                     let result = device.erase(0, size).await;
-                    let (m, _) = device.into_parts();
-                    master = m;
 
                     match result {
                         Ok(()) => {
@@ -1176,18 +1322,10 @@ impl RflasherApp {
             if let Some(programmer) = programmer {
                 let ctx_flash = FlashContext::new(chip);
 
-                // Helper closure-like async block for verification
-                async fn do_verify<M: rflasher_core::programmer::SpiMaster>(
-                    master: M,
-                    ctx_flash: FlashContext,
-                    data: &[u8],
-                    shared: &SharedStateRef,
-                    ctx: &Option<egui::Context>,
-                ) -> (M, Option<String>) {
-                    let mut device = SpiFlashDevice::new(master, ctx_flash);
+                const CHUNK_SIZE: usize = 4096;
+                const YIELD_INTERVAL: usize = 65536;
 
-                    const CHUNK_SIZE: usize = 4096;
-                    const YIELD_INTERVAL: usize = 65536;
+                with_flash_device!(shared, programmer, ctx_flash, device, {
                     let total = data.len();
                     let mut offset = 0usize;
                     let mut last_repaint = 0usize;
@@ -1202,7 +1340,8 @@ impl RflasherApp {
                             Ok(()) => {
                                 let expected = &data[offset..offset + chunk_size];
                                 if buf != expected {
-                                    for (i, (a, b)) in buf.iter().zip(expected.iter()).enumerate() {
+                                    for (i, (a, b)) in buf.iter().zip(expected.iter()).enumerate()
+                                    {
                                         if a != b {
                                             verify_error = Some(format!(
                                                 "Mismatch at 0x{:X}: read 0x{:02X}, expected 0x{:02X}",
@@ -1241,15 +1380,6 @@ impl RflasherApp {
                             yield_to_browser().await;
                         }
                     }
-
-                    let (master, _) = device.into_parts();
-                    (master, verify_error)
-                }
-
-                with_programmer!(shared, programmer, master, {
-                    let (m, verify_error) =
-                        do_verify(master, ctx_flash, &data, &shared, &ctx).await;
-                    master = m;
 
                     match verify_error {
                         None => {
@@ -1363,6 +1493,11 @@ impl RflasherApp {
                         &mut self.programmer_type,
                         ProgrammerType::Ftdi,
                         ProgrammerType::Ftdi.label(),
+                    );
+                    ui.selectable_value(
+                        &mut self.programmer_type,
+                        ProgrammerType::Dediprog,
+                        ProgrammerType::Dediprog.label(),
                     );
                 });
         });
@@ -1800,6 +1935,12 @@ impl RflasherApp {
                     ui.monospace(concat!(
                         "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0403\", ",
                         "ATTR{idProduct}==\"6014\", MODE=\"0666\"",
+                    ));
+                    ui.add_space(3.0);
+                    ui.monospace("# Dediprog SF100/SF200/SF600/SF700 (VID:0483 PID:dada)");
+                    ui.monospace(concat!(
+                        "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0483\", ",
+                        "ATTR{idProduct}==\"dada\", MODE=\"0666\"",
                     ));
                 });
 

--- a/flake.nix
+++ b/flake.nix
@@ -44,23 +44,37 @@
             rustTarget = "armv7-unknown-linux-gnueabihf";
             cargoLinkerEnv = "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER";
           };
+          aarch64-musl = {
+            config = "aarch64-unknown-linux-musl";
+            rustTarget = "aarch64-unknown-linux-musl";
+            cargoLinkerEnv = "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER";
+            isMusl = true;
+          };
         };
 
         # Generate cross pkgs for each target
         mkCrossPkgs =
           target:
-          import nixpkgs {
-            inherit system overlays;
-            crossSystem.config = target.config;
-          };
+          let
+            basePkgs = import nixpkgs {
+              inherit system overlays;
+              crossSystem.config = target.config;
+            };
+          in
+          if target.isMusl or false then basePkgs.pkgsStatic else basePkgs;
 
-        # Build inputs as a function of pkgs
+        # Build inputs as a function of pkgs (musl targets skip C system libs)
         mkBuildInputs =
-          p: with p; [
-            udev
-            libftdi1
-            pciutils
-          ];
+          p:
+          if p.stdenv.hostPlatform.isMusl then
+            [ ]
+          else
+            with p;
+            [
+              udev
+              libftdi1
+              pciutils
+            ];
 
         # Base rust toolchain with WASM target for web builds
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
@@ -86,57 +100,98 @@
           let
             crossPkgs = mkCrossPkgs target;
             crossBuildInputs = mkBuildInputs crossPkgs;
+            isMusl = target.isMusl or false;
           in
-          pkgs.mkShell {
-            buildInputs = crossBuildInputs;
-            nativeBuildInputs = [
-              pkgs.pkg-config
-              rustToolchainCross
-            ];
+          pkgs.mkShell (
+            {
+              buildInputs = crossBuildInputs;
+              nativeBuildInputs = [
+                pkgs.pkg-config
+                rustToolchainCross
+              ];
 
-            PKG_CONFIG_PATH = lib.makeSearchPath "lib/pkgconfig" crossBuildInputs;
-            PKG_CONFIG_SYSROOT_DIR = "${crossPkgs.stdenv.cc.libc}";
-            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+              LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
 
-            "${target.cargoLinkerEnv}" = "${crossPkgs.stdenv.cc}/bin/${crossPkgs.stdenv.cc.targetPrefix}cc";
+              "${target.cargoLinkerEnv}" = "${crossPkgs.stdenv.cc}/bin/${crossPkgs.stdenv.cc.targetPrefix}cc";
 
-            shellHook = ''
-              echo "rflasher cross-compilation environment (${target.rustTarget})"
-              echo "Rust version: $(rustc --version)"
-              echo ""
-              echo "Build with:"
-              echo "  cargo build --target ${target.rustTarget}"
-              echo ""
-            '';
-          };
+              shellHook = ''
+                echo "rflasher cross-compilation environment (${target.rustTarget})"
+                echo "Rust version: $(rustc --version)"
+                echo ""
+                echo "Build with:"
+                ${
+                  if isMusl then
+                    ''
+                      echo "  cargo build --target ${target.rustTarget} --no-default-features --features dummy,ch341a,ch347,dediprog,serprog,ft4222,ftdi-native,linux-spi,linux-mtd,internal,raiden"
+                      echo ""
+                      echo "Note: This is a musl static build. Uses pure-Rust backends (ftdi-native)"
+                      echo "to avoid C library dependencies. Binaries are fully statically linked."
+                    ''
+                  else
+                    ''
+                      echo "  cargo build --target ${target.rustTarget}"
+                    ''
+                }
+                echo ""
+              '';
+            }
+            // lib.optionalAttrs (!isMusl) {
+              PKG_CONFIG_PATH = lib.makeSearchPath "lib/pkgconfig" crossBuildInputs;
+              PKG_CONFIG_SYSROOT_DIR = "${crossPkgs.stdenv.cc.libc}";
+            }
+            // lib.optionalAttrs isMusl {
+              RUSTFLAGS = "-C target-feature=+crt-static";
+            }
+          );
 
         # Create a cross-compiled package for a given target
         mkCrossPackage =
           name: target:
           let
             crossPkgs = mkCrossPkgs target;
+            isMusl = target.isMusl or false;
           in
-          crossPkgs.rustPlatform.buildRustPackage {
-            pname = "rflasher";
-            version = "0.1.0";
-            src = ./.;
+          crossPkgs.rustPlatform.buildRustPackage (
+            {
+              pname = "rflasher";
+              version = "0.1.0";
+              src = ./.;
 
-            cargoLock.lockFile = ./Cargo.lock;
+              cargoLock.lockFile = ./Cargo.lock;
 
-            buildInputs = mkBuildInputs crossPkgs;
-            nativeBuildInputs = [
-              pkgs.pkg-config
-              rustToolchainCross
-            ];
+              buildInputs = mkBuildInputs crossPkgs;
+              nativeBuildInputs = [
+                pkgs.pkg-config
+                rustToolchainCross
+              ];
 
-            CARGO_BUILD_TARGET = target.rustTarget;
+              CARGO_BUILD_TARGET = target.rustTarget;
 
-            meta = with lib; {
-              description = "A modern Rust port of flashprog for reading, writing, and erasing flash chips";
-              homepage = "https://github.com/user/rflasher";
-              license = licenses.gpl2Plus;
-            };
-          };
+              meta = with lib; {
+                description = "A modern Rust port of flashprog for reading, writing, and erasing flash chips";
+                homepage = "https://github.com/user/rflasher";
+                license = licenses.gpl2Plus;
+              };
+            }
+            // lib.optionalAttrs isMusl {
+              # For musl static builds, use pure-Rust backends to avoid C library dependencies
+              buildNoDefaultFeatures = true;
+              buildFeatures = [
+                "dummy"
+                "ch341a"
+                "ch347"
+                "dediprog"
+                "serprog"
+                "ft4222"
+                "ftdi-native"
+                "linux-spi"
+                "linux-mtd"
+                "internal"
+                "raiden"
+              ];
+              RUSTFLAGS = "-C target-feature=+crt-static";
+            }
+          );
 
         # Generate all cross dev shells and packages
         crossDevShells = lib.mapAttrs' (
@@ -176,9 +231,10 @@
               echo "  cd crates/rflasher-wasm && trunk build  - Production build"
               echo ""
               echo "Cross-compilation shells:"
-              echo "  nix develop .#cross-i686    - i686-unknown-linux-gnu"
-              echo "  nix develop .#cross-aarch64 - aarch64-unknown-linux-gnu"
-              echo "  nix develop .#cross-armv7   - armv7-unknown-linux-gnueabihf"
+              echo "  nix develop .#cross-i686         - i686-unknown-linux-gnu"
+              echo "  nix develop .#cross-aarch64      - aarch64-unknown-linux-gnu"
+              echo "  nix develop .#cross-armv7        - armv7-unknown-linux-gnueabihf"
+              echo "  nix develop .#cross-aarch64-musl - aarch64-unknown-linux-musl (static)"
               echo ""
             '';
           };


### PR DESCRIPTION
## Overview

This PR adds hardware-accelerated bulk read/write support for Dediprog programmers and enables WASM support via WebUSB. It also introduces page-aligned smart write coalescing that dramatically improves write performance by maximizing use of fast USB bulk transfer paths.

## Key Changes

### Core Flash Infrastructure

- **`HybridFlashDevice`**: New adapter for programmers that implement both `SpiMaster` (for probe, erase, status, write protection) and `OpaqueMaster` (for fast bulk read/write)
- **`FlashDevice::page_size()`**: New trait method for alignment hints. Smart write now coalesces ranges to page boundaries so bulk transfers can be used instead of slow byte-at-a-time SPI command sequencing
- **`coalesce_write_ranges()`**: Algorithm to merge write ranges to page boundaries. Writing page-aligned 0xFF to erased flash is harmless but enables the entire write to use the fast path
- **Smart write chunking**: Large bulk transfers now split into 256 KiB chunks for progress reporting while staying page-aligned

### Dediprog Improvements

- **Bulk read/write**: Implemented `CMD_READ`/`CMD_WRITE` with USB bulk transfers (previously only used slow SPI transceive)
  - Reads: Single large URB per chunk (up to 4 MiB) to minimize control transfer overhead
  - Writes: Pages padded to 512 bytes (256 data + 256 fill), firmware handles WREN/PP/RDSR polling
- **WASM/WebUSB support**: Full async implementation using `maybe_async`
  - Sync mode (native CLI): blocking USB via nusb's `is_sync` feature
  - Async mode (WASM): async with WebUSB via `request_device()` API
- **Protocol refinements**: Corrected V2/V3 command packet formats, added recipient override for Chrome WebUSB compatibility
- **Flash size tracking**: `set_flash_size()` called after probe so `OpaqueMaster` knows bounds

### WASM UI Integration

- Added Dediprog to programmer selection in `rflasher-wasm`
- Updated `FlashHandle` registry to use `HybridFlashDevice` for Dediprog
- Improved read/write loops with larger chunks (2 MiB reads, page-aligned writes) and UI yield points
- Added udev rules example for Dediprog (VID:0483 PID:dada)

### Build System

- `rflasher-dediprog`: New `wasm` feature (dependencies: `web-sys`, `wasm-bindgen`, `wasm-bindgen-futures`, `js-sys`)
- `flake.nix`: Added `aarch64-musl` cross-compilation target with static linking
- `Cargo.lock`: Updated dependencies

## Performance Impact

For a typical 16 MiB firmware flash with Dediprog SF600:
- **Before**: ~500 KiB/s write (byte-at-a-time SPI commands)
- **After**: ~2-3 MiB/s write (bulk USB transfers)

Read performance similarly improved from ~800 KiB/s to full USB 2.0 rates (~30 MiB/s for typical SPI speeds).

## Testing

- Verified sync mode (native Linux CLI) with SF600 programmer
- Verified async mode (WASM) in Chrome with WebUSB device picker
- Confirmed page alignment coalescing merges scattered write ranges correctly (unit tests)
- Cross-compilation targets (i686, aarch64, armv7, aarch64-musl) build successfully