### PR TITLE
feat(wasm): add Raiden Debug SPI support for Cr50

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,9 +3092,14 @@ name = "rflasher-raiden"
 version = "0.1.0"
 dependencies = [
  "futures-lite",
+ "js-sys",
  "log",
+ "maybe-async",
  "nusb",
  "rflasher-core",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3158,6 +3163,7 @@ dependencies = [
  "rflasher-dediprog",
  "rflasher-ft4222",
  "rflasher-ftdi",
+ "rflasher-raiden",
  "rflasher-serprog",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ You can also specify a custom path with `--chip-db <path>`.
 
 ### USB Device Permissions
 
-For CH341A and FTDI programmers, you may need to set up udev rules:
+For WebUSB programmers, you may need to set up udev rules. This includes
+CH341A, CH347, FTDI, Dediprog, and Raiden Debug SPI / Cr50 devices.
 
 ```bash
 # Copy udev rules (create this file based on your needs)
@@ -121,10 +122,13 @@ sudo udevadm control --reload-rules
 sudo udevadm trigger
 ```
 
-Example udev rule for CH341A:
+Example udev rules:
 ```
 # CH341A USB programmer
 SUBSYSTEM=="usb", ATTR{idVendor}=="1a86", ATTR{idProduct}=="5512", MODE="0666"
+
+# Raiden Debug SPI / Cr50 (Google debug hardware, VID:18d1; product ID varies)
+SUBSYSTEM=="usb", ATTR{idVendor}=="18d1", MODE="0666"
 ```
 
 ### Man Page

--- a/crates/rflasher-raiden/Cargo.toml
+++ b/crates/rflasher-raiden/Cargo.toml
@@ -7,10 +7,26 @@ description = "Raiden Debug SPI (Chrome OS EC USB) programmer support for rflash
 
 [features]
 default = ["std"]
-std = ["rflasher-core/std", "nusb", "futures-lite"]
+std = ["rflasher-core/std", "is_sync", "nusb", "futures-lite"]
+is_sync = ["rflasher-core/is_sync", "maybe-async/is_sync"]
+wasm = ["rflasher-core/std", "nusb", "web-sys", "wasm-bindgen", "wasm-bindgen-futures", "js-sys"]
 
 [dependencies]
 rflasher-core.workspace = true
 nusb = { workspace = true, optional = true }
 futures-lite = { version = "2", optional = true }
+maybe-async.workspace = true
 log.workspace = true
+
+web-sys = { version = "0.3", optional = true, features = [
+    "Navigator",
+    "Window",
+    "console",
+    "Usb",
+    "UsbDevice",
+    "UsbDeviceFilter",
+    "UsbDeviceRequestOptions",
+] }
+wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+js-sys = { version = "0.3", optional = true }

--- a/crates/rflasher-raiden/src/device.rs
+++ b/crates/rflasher-raiden/src/device.rs
@@ -7,9 +7,9 @@ use std::time::Duration;
 
 use maybe_async::maybe_async;
 use nusb::transfer::{Buffer, Bulk, In, Out};
-use nusb::{Endpoint, Interface};
 #[cfg(feature = "is_sync")]
 use nusb::MaybeFuture;
+use nusb::{Endpoint, Interface};
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
 use rflasher_core::programmer::{SpiFeatures, SpiMaster};
 use rflasher_core::spi::{check_io_mode_supported, SpiCommand};

--- a/crates/rflasher-raiden/src/device.rs
+++ b/crates/rflasher-raiden/src/device.rs
@@ -5,15 +5,63 @@
 
 use std::time::Duration;
 
-use nusb::transfer::{Bulk, In, Out};
-use nusb::{Interface, MaybeFuture};
+use maybe_async::maybe_async;
+use nusb::transfer::{Buffer, Bulk, In, Out};
+use nusb::{Endpoint, Interface};
+#[cfg(feature = "is_sync")]
+use nusb::MaybeFuture;
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
-use rflasher_core::programmer::default_execute_with_vec;
 use rflasher_core::programmer::{SpiFeatures, SpiMaster};
-use rflasher_core::spi::SpiCommand;
+use rflasher_core::spi::{check_io_mode_supported, SpiCommand};
 
 use crate::error::{RaidenError, Result};
 use crate::protocol::*;
+
+macro_rules! ep_wait {
+    ($ep:expr, $timeout:expr) => {{
+        #[cfg(feature = "is_sync")]
+        {
+            $ep.wait_next_complete($timeout)
+        }
+        #[cfg(not(feature = "is_sync"))]
+        {
+            Some($ep.next_complete().await)
+        }
+    }};
+}
+
+macro_rules! nusb_await {
+    ($expr:expr) => {{
+        #[cfg(feature = "is_sync")]
+        {
+            $expr.wait()
+        }
+        #[cfg(not(feature = "is_sync"))]
+        {
+            $expr.await
+        }
+    }};
+}
+
+macro_rules! platform_sleep {
+    ($dur:expr) => {{
+        #[cfg(feature = "is_sync")]
+        {
+            std::thread::sleep($dur);
+        }
+        #[cfg(all(feature = "wasm", not(feature = "is_sync")))]
+        {
+            let ms = $dur.as_millis() as i32;
+            let promise = js_sys::Promise::new(&mut |resolve, _| {
+                let window = web_sys::window().unwrap();
+                window
+                    .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms)
+                    .unwrap();
+            });
+            let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+        }
+    }};
+}
 
 /// Configuration options for opening a Raiden device
 #[derive(Debug, Clone, Default)]
@@ -55,17 +103,15 @@ pub struct RaidenDebugSpi {
     supports_full_duplex: bool,
 }
 
+#[cfg(feature = "std")]
 impl RaidenDebugSpi {
-    /// Open a Raiden Debug SPI device with default configuration
-    ///
-    /// Uses the first device found with the default target (AP).
+    /// Open a Raiden Debug SPI device with default configuration.
     pub fn open() -> Result<Self> {
         Self::open_with_config(&RaidenConfig::default())
     }
 
-    /// Open a Raiden Debug SPI device with specific configuration
+    /// Open a Raiden Debug SPI device with specific configuration.
     pub fn open_with_config(config: &RaidenConfig) -> Result<Self> {
-        // Find matching devices
         let devices = Self::find_devices(config.serial.as_deref())?;
 
         if devices.is_empty() {
@@ -91,7 +137,6 @@ impl RaidenDebugSpi {
             .wait()
             .map_err(|e| RaidenError::OpenFailed(e.to_string()))?;
 
-        // Claim the interface
         let interface = device
             .claim_interface(device_info.interface_num)
             .wait()
@@ -108,10 +153,8 @@ impl RaidenDebugSpi {
             supports_full_duplex: false,
         };
 
-        // Enable the SPI bridge for the selected target
         raiden.enable_target(config.target)?;
 
-        // For V2, query device configuration
         if raiden.protocol_version >= PROTOCOL_V2 {
             raiden.configure_v2()?;
         }
@@ -119,17 +162,15 @@ impl RaidenDebugSpi {
         Ok(raiden)
     }
 
-    /// Find all Raiden Debug SPI devices
+    /// Find all Raiden Debug SPI devices.
     fn find_devices(serial_filter: Option<&str>) -> Result<Vec<RaidenDeviceInfo>> {
         let mut devices = Vec::new();
 
         for dev_info in nusb::list_devices().wait()? {
-            // Check vendor ID
             if dev_info.vendor_id() != GOOGLE_VID {
                 continue;
             }
 
-            // Check serial number filter
             if let Some(filter) = serial_filter {
                 if let Some(serial) = dev_info.serial_number() {
                     if !serial.contains(filter) {
@@ -140,77 +181,196 @@ impl RaidenDebugSpi {
                 }
             }
 
-            // Check interfaces for Raiden SPI subclass using DeviceInfo
             for iface_info in dev_info.interfaces() {
-                if iface_info.class() == 0xFF
-                    && iface_info.subclass() == RAIDEN_SPI_SUBCLASS
-                    && (iface_info.protocol() == PROTOCOL_V1
-                        || iface_info.protocol() == PROTOCOL_V2)
+                if iface_info.class() != 0xFF
+                    || iface_info.subclass() != RAIDEN_SPI_SUBCLASS
+                    || (iface_info.protocol() != PROTOCOL_V1
+                        && iface_info.protocol() != PROTOCOL_V2)
                 {
-                    // Need to open device to get endpoint addresses
-                    let device = match dev_info.open().wait() {
-                        Ok(d) => d,
-                        Err(e) => {
-                            log::debug!("Failed to open device for endpoint discovery: {}", e);
+                    continue;
+                }
+
+                let device = match dev_info.open().wait() {
+                    Ok(device) => device,
+                    Err(e) => {
+                        log::debug!("Failed to open device for endpoint discovery: {}", e);
+                        continue;
+                    }
+                };
+
+                let mut in_ep = None;
+                let mut out_ep = None;
+
+                if let Ok(config) = device.active_configuration() {
+                    for iface in config.interface_alt_settings() {
+                        if iface.interface_number() != iface_info.interface_number() {
                             continue;
                         }
-                    };
-
-                    // Get endpoint addresses from the active configuration
-                    let mut in_ep = None;
-                    let mut out_ep = None;
-
-                    if let Ok(config) = device.active_configuration() {
-                        for iface in config.interface_alt_settings() {
-                            if iface.interface_number() == iface_info.interface_number() {
-                                for ep in iface.endpoints() {
-                                    match ep.direction() {
-                                        nusb::transfer::Direction::In => {
-                                            if in_ep.is_none() {
-                                                in_ep = Some(ep.address());
-                                            }
-                                        }
-                                        nusb::transfer::Direction::Out => {
-                                            if out_ep.is_none() {
-                                                out_ep = Some(ep.address());
-                                            }
-                                        }
-                                    }
+                        for ep in iface.endpoints() {
+                            match ep.direction() {
+                                nusb::transfer::Direction::In if in_ep.is_none() => {
+                                    in_ep = Some(ep.address())
                                 }
-                                break;
+                                nusb::transfer::Direction::Out if out_ep.is_none() => {
+                                    out_ep = Some(ep.address())
+                                }
+                                _ => {}
                             }
                         }
+                        break;
                     }
-
-                    if let (Some(in_ep), Some(out_ep)) = (in_ep, out_ep) {
-                        devices.push(RaidenDeviceInfo {
-                            info: dev_info.clone(),
-                            bus: dev_info.busnum(),
-                            address: dev_info.device_address(),
-                            serial: dev_info.serial_number().map(|s| s.to_string()),
-                            interface_num: iface_info.interface_number(),
-                            in_ep,
-                            out_ep,
-                            protocol_version: iface_info.protocol(),
-                        });
-                    }
-
-                    // Only use first matching interface per device
-                    break;
                 }
+
+                if let (Some(in_ep), Some(out_ep)) = (in_ep, out_ep) {
+                    devices.push(RaidenDeviceInfo {
+                        info: dev_info.clone(),
+                        bus: dev_info.busnum(),
+                        address: dev_info.device_address(),
+                        serial: dev_info.serial_number().map(|s| s.to_string()),
+                        interface_num: iface_info.interface_number(),
+                        in_ep,
+                        out_ep,
+                        protocol_version: iface_info.protocol(),
+                    });
+                }
+
+                break;
             }
         }
 
         Ok(devices)
     }
 
-    /// List all connected Raiden Debug SPI devices
+    /// List all connected Raiden Debug SPI devices.
     pub fn list_devices() -> Result<Vec<RaidenDeviceInfo>> {
         Self::find_devices(None)
     }
+}
 
-    /// Enable the SPI bridge for a specific target
-    fn enable_target(&mut self, target: Target) -> Result<()> {
+#[cfg(all(feature = "wasm", not(feature = "is_sync"), target_arch = "wasm32"))]
+impl RaidenDebugSpi {
+    /// Request a Raiden device via the WebUSB permission prompt.
+    pub async fn request_device() -> Result<nusb::DeviceInfo> {
+        use wasm_bindgen::JsCast;
+        use wasm_bindgen_futures::JsFuture;
+        use web_sys::{UsbDevice, UsbDeviceFilter, UsbDeviceRequestOptions};
+
+        let usb = web_sys::window()
+            .ok_or(RaidenError::DeviceNotFound)?
+            .navigator()
+            .usb();
+
+        let filter = UsbDeviceFilter::new();
+        filter.set_vendor_id(GOOGLE_VID);
+
+        let filters = js_sys::Array::new();
+        filters.push(&filter);
+
+        let options = UsbDeviceRequestOptions::new(&filters);
+
+        log::info!("Requesting Raiden Debug SPI device via WebUSB picker...");
+
+        let device_js = JsFuture::from(usb.request_device(&options))
+            .await
+            .map_err(|e| RaidenError::OpenFailed(format!("WebUSB request failed: {:?}", e)))?;
+
+        let device: UsbDevice = device_js
+            .dyn_into()
+            .map_err(|_| RaidenError::OpenFailed("Failed to get USB device".to_string()))?;
+
+        nusb::device_info_from_webusb(device)
+            .await
+            .map_err(|e| RaidenError::OpenFailed(format!("Failed to get device info: {}", e)))
+    }
+
+    /// Open a previously granted Raiden WebUSB device.
+    pub async fn open(device_info: nusb::DeviceInfo, config: &RaidenConfig) -> Result<Self> {
+        let iface_info = device_info
+            .interfaces()
+            .find(|iface| {
+                iface.class() == 0xFF
+                    && iface.subclass() == RAIDEN_SPI_SUBCLASS
+                    && (iface.protocol() == PROTOCOL_V1 || iface.protocol() == PROTOCOL_V2)
+            })
+            .ok_or(RaidenError::DeviceNotFound)?;
+
+        let interface_num = iface_info.interface_number();
+        let protocol_version = iface_info.protocol();
+
+        let device = device_info
+            .open()
+            .await
+            .map_err(|e| RaidenError::OpenFailed(e.to_string()))?;
+
+        let config_desc = device
+            .active_configuration()
+            .map_err(|e| RaidenError::OpenFailed(format!("Failed to get config: {}", e)))?;
+
+        let mut in_ep = None;
+        let mut out_ep = None;
+        for iface in config_desc.interface_alt_settings() {
+            if iface.interface_number() != interface_num {
+                continue;
+            }
+            for ep in iface.endpoints() {
+                match ep.direction() {
+                    nusb::transfer::Direction::In if in_ep.is_none() => in_ep = Some(ep.address()),
+                    nusb::transfer::Direction::Out if out_ep.is_none() => {
+                        out_ep = Some(ep.address())
+                    }
+                    _ => {}
+                }
+            }
+            break;
+        }
+
+        let (in_ep, out_ep) = match (in_ep, out_ep) {
+            (Some(in_ep), Some(out_ep)) => (in_ep, out_ep),
+            _ => {
+                return Err(RaidenError::OpenFailed(
+                    "Failed to discover Raiden bulk endpoints".to_string(),
+                ))
+            }
+        };
+
+        let interface = device
+            .claim_interface(interface_num)
+            .await
+            .map_err(|e| RaidenError::ClaimFailed(e.to_string()))?;
+
+        let mut raiden = Self {
+            interface,
+            interface_num,
+            in_ep,
+            out_ep,
+            protocol_version,
+            max_spi_write: V1_MAX_PAYLOAD as u16,
+            max_spi_read: V1_MAX_PAYLOAD as u16,
+            supports_full_duplex: false,
+        };
+
+        raiden.enable_target(config.target).await?;
+
+        if raiden.protocol_version >= PROTOCOL_V2 {
+            raiden.configure_v2().await?;
+        }
+
+        Ok(raiden)
+    }
+
+    /// Shut down the bridge explicitly in WASM mode.
+    pub async fn shutdown(&mut self) {
+        if let Err(e) = self.disable().await {
+            log::warn!("Failed to disable SPI bridge on shutdown: {}", e);
+        }
+    }
+}
+
+#[cfg_attr(all(feature = "wasm", feature = "is_sync"), allow(dead_code))]
+impl RaidenDebugSpi {
+    /// Enable the SPI bridge for a specific target.
+    #[maybe_async]
+    async fn enable_target(&mut self, target: Target) -> Result<()> {
         let request = target.enable_request();
 
         log::debug!(
@@ -219,69 +379,58 @@ impl RaidenDebugSpi {
             self.interface_num
         );
 
-        // Send USB control transfer to enable the target
-        // bmRequestType: 0x41 = Host-to-device, Vendor, Interface
-        // bRequest: the request type (enable AP/EC/H1)
-        // wValue: 0
-        // wIndex: interface number
-        self.interface
-            .control_out(
-                nusb::transfer::ControlOut {
-                    control_type: nusb::transfer::ControlType::Vendor,
-                    recipient: nusb::transfer::Recipient::Interface,
-                    request: request as u8,
-                    value: 0,
-                    index: self.interface_num as u16,
-                    data: &[],
-                },
-                Duration::from_secs(5),
-            )
-            .wait()
-            .map_err(|e| RaidenError::EnableFailed(e.to_string()))?;
+        nusb_await!(self.interface.control_out(
+            nusb::transfer::ControlOut {
+                control_type: nusb::transfer::ControlType::Vendor,
+                recipient: nusb::transfer::Recipient::Interface,
+                request: request as u8,
+                value: 0,
+                index: self.interface_num as u16,
+                data: &[],
+            },
+            Duration::from_secs(5),
+        ))
+        .map_err(|e| RaidenError::EnableFailed(e.to_string()))?;
 
-        // Wait for target to stabilize
-        std::thread::sleep(Duration::from_millis(ENABLE_DELAY_MS));
+        platform_sleep!(Duration::from_millis(ENABLE_DELAY_MS));
 
         log::info!("SPI bridge enabled for target: {}", target);
         Ok(())
     }
 
-    /// Disable the SPI bridge
-    fn disable(&mut self) -> Result<()> {
+    /// Disable the SPI bridge.
+    #[maybe_async]
+    async fn disable(&mut self) -> Result<()> {
         log::debug!("Disabling SPI bridge (interface {})", self.interface_num);
 
-        self.interface
-            .control_out(
-                nusb::transfer::ControlOut {
-                    control_type: nusb::transfer::ControlType::Vendor,
-                    recipient: nusb::transfer::Recipient::Interface,
-                    request: ControlRequest::Disable as u8,
-                    value: 0,
-                    index: self.interface_num as u16,
-                    data: &[],
-                },
-                Duration::from_secs(5),
-            )
-            .wait()
-            .map_err(|e| RaidenError::EnableFailed(e.to_string()))?;
+        nusb_await!(self.interface.control_out(
+            nusb::transfer::ControlOut {
+                control_type: nusb::transfer::ControlType::Vendor,
+                recipient: nusb::transfer::Recipient::Interface,
+                request: ControlRequest::Disable as u8,
+                value: 0,
+                index: self.interface_num as u16,
+                data: &[],
+            },
+            Duration::from_secs(5),
+        ))
+        .map_err(|e| RaidenError::EnableFailed(e.to_string()))?;
 
         Ok(())
     }
 
-    /// Configure V2 protocol parameters
-    fn configure_v2(&mut self) -> Result<()> {
+    /// Configure V2 protocol parameters.
+    #[maybe_async]
+    async fn configure_v2(&mut self) -> Result<()> {
         log::debug!("Querying V2 device configuration");
 
         for retry in 0..WRITE_RETRIES {
-            // Send get config command
             let cmd = CommandV2GetConfig::default();
-            self.write_packet(&cmd.to_bytes())?;
+            self.write_packet(&cmd.to_bytes()).await?;
 
-            // Read response
-            let rsp_buf = self.read_packet()?;
+            let rsp_buf = self.read_packet().await?;
             let rsp = ResponseV2Config::from_bytes(&rsp_buf);
 
-            // Validate response
             if rsp.packet_id == PacketId::RspUsbSpiConfig as u16 {
                 self.max_spi_write = rsp.max_write_count;
                 self.max_spi_read = rsp.max_read_count;
@@ -301,7 +450,7 @@ impl RaidenDebugSpi {
                 "Invalid config response (attempt {}), retrying...",
                 retry + 1
             );
-            std::thread::sleep(Duration::from_millis(RETRY_DELAY_MS));
+            platform_sleep!(Duration::from_millis(RETRY_DELAY_MS));
         }
 
         Err(RaidenError::InvalidResponse(
@@ -309,43 +458,48 @@ impl RaidenDebugSpi {
         ))
     }
 
-    /// Send a packet to the device
-    fn write_packet(&mut self, data: &[u8]) -> Result<()> {
-        let mut out_ep = self
+    /// Send a packet to the device.
+    #[maybe_async]
+    async fn write_packet(&mut self, data: &[u8]) -> Result<()> {
+        let mut out_ep: Endpoint<Bulk, Out> = self
             .interface
-            .endpoint::<Bulk, Out>(self.out_ep)
+            .endpoint(self.out_ep)
             .map_err(|e| RaidenError::TransferFailed(e.to_string()))?;
 
-        let buf = nusb::transfer::Buffer::from(data.to_vec());
-        let completion = out_ep.transfer_blocking(buf, Duration::from_secs(5));
+        out_ep.submit(Buffer::from(data.to_vec()));
+        let completion = ep_wait!(out_ep, Duration::from_secs(5)).ok_or(RaidenError::Timeout)?;
         completion
-            .into_result()
+            .status
             .map_err(|e| RaidenError::TransferFailed(e.to_string()))?;
 
         log::trace!("USB write {} bytes", data.len());
         Ok(())
     }
 
-    /// Read a packet from the device
-    fn read_packet(&mut self) -> Result<Vec<u8>> {
-        let mut in_ep = self
+    /// Read a packet from the device.
+    #[maybe_async]
+    async fn read_packet(&mut self) -> Result<Vec<u8>> {
+        let mut in_ep: Endpoint<Bulk, In> = self
             .interface
-            .endpoint::<Bulk, In>(self.in_ep)
+            .endpoint(self.in_ep)
             .map_err(|e| RaidenError::TransferFailed(e.to_string()))?;
 
-        let mut buf = nusb::transfer::Buffer::new(USB_PACKET_SIZE);
+        let mut buf = Buffer::new(USB_PACKET_SIZE);
         buf.set_requested_len(USB_PACKET_SIZE);
-        let completion = in_ep.transfer_blocking(buf, Duration::from_secs(5));
-        let data = completion
-            .into_result()
+        in_ep.submit(buf);
+        let completion = ep_wait!(in_ep, Duration::from_secs(5)).ok_or(RaidenError::Timeout)?;
+        completion
+            .status
             .map_err(|e| RaidenError::TransferFailed(e.to_string()))?;
 
+        let data = completion.buffer[..].to_vec();
         log::trace!("USB read {} bytes", data.len());
-        Ok(data.to_vec())
+        Ok(data)
     }
 
-    /// Execute an SPI transaction using V1 protocol
-    fn spi_transfer_v1(&mut self, write_data: &[u8], read_len: usize) -> Result<Vec<u8>> {
+    /// Execute an SPI transaction using V1 protocol.
+    #[maybe_async]
+    async fn spi_transfer_v1(&mut self, write_data: &[u8], read_len: usize) -> Result<Vec<u8>> {
         if write_data.len() > V1_MAX_PAYLOAD {
             return Err(RaidenError::InvalidParameter(format!(
                 "Write length {} exceeds V1 max {}",
@@ -360,7 +514,6 @@ impl RaidenDebugSpi {
             )));
         }
 
-        // Build and send command
         let cmd = CommandV1::new(write_data, read_len as u8);
         let packet = cmd.to_bytes();
         log::debug!(
@@ -370,13 +523,11 @@ impl RaidenDebugSpi {
             packet.len(),
             &packet[..]
         );
-        self.write_packet(&packet)?;
+        self.write_packet(&packet).await?;
 
-        // Read response
-        let rsp_buf = self.read_packet()?;
+        let rsp_buf = self.read_packet().await?;
         let rsp = ResponseV1::from_bytes(&rsp_buf);
 
-        // Check status
         let status = rsp.status();
         log::debug!(
             "V1 response: status_code=0x{:04X} ({:?})",
@@ -387,12 +538,12 @@ impl RaidenDebugSpi {
             return Err(RaidenError::ProtocolError(rsp.status_code));
         }
 
-        // Extract read data
         Ok(rsp.data[..read_len].to_vec())
     }
 
-    /// Execute an SPI transaction using V2 protocol
-    fn spi_transfer_v2(&mut self, write_data: &[u8], read_len: usize) -> Result<Vec<u8>> {
+    /// Execute an SPI transaction using V2 protocol.
+    #[maybe_async]
+    async fn spi_transfer_v2(&mut self, write_data: &[u8], read_len: usize) -> Result<Vec<u8>> {
         let write_len = write_data.len();
 
         if write_len > self.max_spi_write as usize {
@@ -408,16 +559,14 @@ impl RaidenDebugSpi {
             )));
         }
 
-        // Send start command with first chunk of data
         let first_chunk_len = std::cmp::min(write_len, V2_START_PAYLOAD);
         let cmd = CommandV2Start::new(
             write_len as u16,
             read_len as u16,
             &write_data[..first_chunk_len],
         );
-        self.write_packet(&cmd.to_bytes())?;
+        self.write_packet(&cmd.to_bytes()).await?;
 
-        // Send continue packets for remaining write data
         let mut write_offset = first_chunk_len;
         while write_offset < write_len {
             let chunk_len = std::cmp::min(write_len - write_offset, V2_CONTINUE_PAYLOAD);
@@ -425,15 +574,13 @@ impl RaidenDebugSpi {
                 write_offset as u16,
                 &write_data[write_offset..write_offset + chunk_len],
             );
-            self.write_packet(&cmd.to_bytes())?;
+            self.write_packet(&cmd.to_bytes()).await?;
             write_offset += chunk_len;
         }
 
-        // Read start response
-        let rsp_buf = self.read_packet()?;
+        let rsp_buf = self.read_packet().await?;
         let rsp = ResponseV2Start::from_bytes(&rsp_buf);
 
-        // Check packet ID
         if rsp.packet_id != PacketId::RspTransferStart as u16 {
             return Err(RaidenError::InvalidResponse(format!(
                 "Expected RspTransferStart, got {}",
@@ -441,23 +588,19 @@ impl RaidenDebugSpi {
             )));
         }
 
-        // Check status
         let status = rsp.status();
         if !status.is_success() {
             return Err(RaidenError::ProtocolError(rsp.status_code));
         }
 
-        // Collect read data
         let mut result = Vec::with_capacity(read_len);
         let first_read_len = std::cmp::min(read_len, V2_CONTINUE_PAYLOAD);
         result.extend_from_slice(&rsp.data[..first_read_len]);
 
-        // Read continue packets for remaining data
         while result.len() < read_len {
-            let rsp_buf = self.read_packet()?;
+            let rsp_buf = self.read_packet().await?;
             let rsp = ResponseV2Continue::from_bytes(&rsp_buf);
 
-            // Validate packet
             if rsp.packet_id != PacketId::RspTransferContinue as u16 {
                 return Err(RaidenError::InvalidResponse(format!(
                     "Expected RspTransferContinue, got {}",
@@ -465,7 +608,6 @@ impl RaidenDebugSpi {
                 )));
             }
 
-            // Validate data index
             if rsp.data_index != result.len() as u16 {
                 return Err(RaidenError::InvalidResponse(format!(
                     "Data index mismatch: expected {}, got {}",
@@ -481,20 +623,21 @@ impl RaidenDebugSpi {
         Ok(result)
     }
 
-    /// Execute an SPI transaction
-    fn spi_transfer(&mut self, write_data: &[u8], read_len: usize) -> Result<Vec<u8>> {
+    /// Execute an SPI transaction.
+    #[maybe_async]
+    async fn spi_transfer(&mut self, write_data: &[u8], read_len: usize) -> Result<Vec<u8>> {
         for retry in 0..WRITE_RETRIES {
             let result = if self.protocol_version >= PROTOCOL_V2 {
-                self.spi_transfer_v2(write_data, read_len)
+                self.spi_transfer_v2(write_data, read_len).await
             } else {
-                self.spi_transfer_v1(write_data, read_len)
+                self.spi_transfer_v1(write_data, read_len).await
             };
 
             match result {
                 Ok(data) => return Ok(data),
                 Err(RaidenError::ProtocolError(code)) if code == StatusCode::Busy as u16 => {
                     log::warn!("SPI busy (attempt {}), retrying...", retry + 1);
-                    std::thread::sleep(Duration::from_millis(RETRY_DELAY_MS));
+                    platform_sleep!(Duration::from_millis(RETRY_DELAY_MS));
                 }
                 Err(e) => return Err(e),
             }
@@ -504,6 +647,7 @@ impl RaidenDebugSpi {
     }
 }
 
+#[cfg(feature = "is_sync")]
 impl Drop for RaidenDebugSpi {
     fn drop(&mut self) {
         if let Err(e) = self.disable() {
@@ -512,9 +656,9 @@ impl Drop for RaidenDebugSpi {
     }
 }
 
+#[maybe_async(AFIT)]
 impl SpiMaster for RaidenDebugSpi {
     fn features(&self) -> SpiFeatures {
-        // Raiden supports 4-byte addressing
         SpiFeatures::FOUR_BYTE_ADDR
     }
 
@@ -526,28 +670,41 @@ impl SpiMaster for RaidenDebugSpi {
         self.max_spi_write as usize
     }
 
-    fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
+    async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
         log::debug!(
             "SPI execute: opcode=0x{:02X}, read_len={}",
             cmd.opcode,
             cmd.read_buf.len()
         );
-        default_execute_with_vec(cmd, self.features(), |write_data, read_len| {
-            self.spi_transfer(write_data, read_len).map_err(|e| {
+
+        check_io_mode_supported(cmd.io_mode, self.features())?;
+
+        let header_len = cmd.header_len();
+        let mut write_data = vec![0u8; header_len + cmd.write_data.len()];
+        cmd.encode_header(&mut write_data);
+        write_data[header_len..].copy_from_slice(cmd.write_data);
+
+        let result = self
+            .spi_transfer(&write_data, cmd.read_buf.len())
+            .await
+            .map_err(|e| {
                 log::error!("SPI transfer failed: {}", e);
                 CoreError::ProgrammerError
-            })
-        })
+            })?;
+
+        cmd.read_buf.copy_from_slice(&result[..cmd.read_buf.len()]);
+        Ok(())
     }
 
-    fn delay_us(&mut self, us: u32) {
+    async fn delay_us(&mut self, us: u32) {
         if us > 0 {
-            std::thread::sleep(Duration::from_micros(us as u64));
+            platform_sleep!(Duration::from_micros(us as u64));
         }
     }
 }
 
 /// Information about a connected Raiden Debug SPI device
+#[cfg_attr(all(feature = "wasm", not(feature = "is_sync")), allow(dead_code))]
 #[derive(Debug, Clone)]
 pub struct RaidenDeviceInfo {
     /// nusb device info

--- a/crates/rflasher-raiden/src/lib.rs
+++ b/crates/rflasher-raiden/src/lib.rs
@@ -55,18 +55,18 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", feature = "wasm")), no_std)]
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 mod device;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 mod error;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 mod protocol;
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 pub use device::{parse_options, RaidenConfig, RaidenDebugSpi, RaidenDeviceInfo};
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 pub use error::{RaidenError, Result};
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 pub use protocol::Target;

--- a/crates/rflasher-wasm/Cargo.toml
+++ b/crates/rflasher-wasm/Cargo.toml
@@ -21,6 +21,7 @@ rflasher-ch347 = { path = "../rflasher-ch347", default-features = false, feature
 rflasher-ftdi = { path = "../rflasher-ftdi", default-features = false, features = ["wasm"] }
 rflasher-ft4222 = { path = "../rflasher-ft4222", default-features = false, features = ["wasm"] }
 rflasher-dediprog = { path = "../rflasher-dediprog", default-features = false, features = ["wasm"] }
+rflasher-raiden = { path = "../rflasher-raiden", default-features = false, features = ["wasm"] }
 
 # GUI
 eframe = { version = "0.33", default-features = false, features = [

--- a/crates/rflasher-wasm/src/app.rs
+++ b/crates/rflasher-wasm/src/app.rs
@@ -1224,14 +1224,13 @@ impl RflasherApp {
                 let ctx_flash = FlashContext::new(chip);
                 let mut buf = vec![0u8; size];
 
-                /// Read chunk size.  Larger chunks reduce per-chunk overhead
-                /// (each chunk requires a new CMD_READ control transfer for
-                /// Dediprog, plus a yield/repaint cycle).  2 MiB gives ~8
-                /// progress updates for a 16 MiB flash while keeping overhead
-                /// low (8 CMD_READs instead of 64 with 256 KiB chunks).
-                const READ_CHUNK_SIZE: usize = 2 * 1024 * 1024;
-                /// Yield to browser every 2 MiB to keep the UI responsive.
-                const YIELD_INTERVAL: usize = 2 * 1024 * 1024;
+                /// Read chunk size. Larger chunks reduce per-chunk overhead,
+                /// but 2 MiB only gives ~8 updates for a 16 MiB flash. Use
+                /// 1 MiB as a compromise so the UI refreshes roughly every 6%.
+                const READ_CHUNK_SIZE: usize = 1024 * 1024;
+                /// Yield to the browser after each read chunk so progress is
+                /// visible promptly during long WebUSB reads.
+                const YIELD_INTERVAL: usize = READ_CHUNK_SIZE;
 
                 with_flash_device!(shared, programmer, ctx_flash, device, {
                     let total = buf.len();
@@ -1260,11 +1259,12 @@ impl RflasherApp {
                             },
                         ));
 
+                        if let Some(ref ctx) = ctx {
+                            ctx.request_repaint();
+                        }
+
                         if offset >= last_yield + YIELD_INTERVAL {
                             last_yield = offset;
-                            if let Some(ref ctx) = ctx {
-                                ctx.request_repaint();
-                            }
                             yield_to_browser().await;
                         }
                     }

--- a/crates/rflasher-wasm/src/app.rs
+++ b/crates/rflasher-wasm/src/app.rs
@@ -15,6 +15,7 @@ use rflasher_core::flash::{
 use rflasher_dediprog::{Dediprog, DediprogConfig};
 use rflasher_ft4222::{Ft4222, SpiConfig as Ft4222SpiConfig};
 use rflasher_ftdi::{Ftdi, FtdiConfig, FtdiDeviceType, FtdiInterface};
+use rflasher_raiden::{RaidenConfig, RaidenDebugSpi, Target as RaidenTarget};
 use rflasher_serprog::Serprog;
 
 use crate::transport::WebSerialTransport;
@@ -56,6 +57,8 @@ enum ProgrammerType {
     Ft4222,
     /// Dediprog SF100/SF200/SF600/SF700 via WebUSB
     Dediprog,
+    /// Raiden Debug SPI via WebUSB
+    Raiden,
 }
 
 impl ProgrammerType {
@@ -67,6 +70,7 @@ impl ProgrammerType {
             ProgrammerType::Ftdi => "FTDI MPSSE (WebUSB)",
             ProgrammerType::Ft4222 => "FT4222H (WebUSB)",
             ProgrammerType::Dediprog => "Dediprog (WebUSB)",
+            ProgrammerType::Raiden => "Raiden Debug SPI (WebUSB)",
         }
     }
 
@@ -79,11 +83,22 @@ impl ProgrammerType {
                 | ProgrammerType::Ftdi
                 | ProgrammerType::Ft4222
                 | ProgrammerType::Dediprog
+                | ProgrammerType::Raiden
         )
     }
 }
 
-/// Connected programmer - wraps a serprog, CH341A, CH347, FTDI, FT4222H, or Dediprog device
+fn raiden_target_label(target: RaidenTarget) -> &'static str {
+    match target {
+        RaidenTarget::Ap => "AP",
+        RaidenTarget::Ec => "EC",
+        RaidenTarget::H1 => "H1 / Cr50",
+        RaidenTarget::ApCustom => "AP custom",
+    }
+}
+
+/// Connected programmer - wraps a serprog, CH341A, CH347, FTDI, FT4222H,
+/// Dediprog, or Raiden device
 #[allow(clippy::large_enum_variant)]
 enum Programmer {
     Serprog(Serprog<WebSerialTransport>),
@@ -92,6 +107,7 @@ enum Programmer {
     Ftdi(Ftdi),
     Ft4222(Ft4222),
     Dediprog(Dediprog),
+    Raiden(RaidenDebugSpi),
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +155,11 @@ macro_rules! with_programmer {
             Programmer::Dediprog(mut $name) => {
                 let result = $body;
                 $shared.borrow_mut().programmer = Some(Programmer::Dediprog($name));
+                result
+            }
+            Programmer::Raiden(mut $name) => {
+                let result = $body;
+                $shared.borrow_mut().programmer = Some(Programmer::Raiden($name));
                 result
             }
         }
@@ -199,6 +220,13 @@ macro_rules! with_flash_device {
                 let result = { $body };
                 let (master, _) = $device.into_parts();
                 $shared.borrow_mut().programmer = Some(Programmer::Dediprog(master));
+                result
+            }
+            Programmer::Raiden(master) => {
+                let mut $device = SpiFlashDevice::new(master, $ctx_flash);
+                let result = { $body };
+                let (master, _) = $device.into_parts();
+                $shared.borrow_mut().programmer = Some(Programmer::Raiden(master));
                 result
             }
         }
@@ -421,6 +449,8 @@ pub struct RflasherApp {
     ftdi_interface: FtdiInterface,
     /// Selected FTDI clock divisor
     ftdi_divisor: u16,
+    /// Selected Raiden target
+    raiden_target: RaidenTarget,
     /// Chip database
     chip_db: ChipDatabase,
     /// Detected chip info
@@ -546,6 +576,7 @@ impl Default for RflasherApp {
             ftdi_device_type: FtdiDeviceType::default(),
             ftdi_interface: FtdiInterface::default(),
             ftdi_divisor: 2,
+            raiden_target: RaidenTarget::H1,
             chip_db: ChipDatabase::new(),
             chip_info: None,
             ctx: None,
@@ -735,6 +766,7 @@ impl RflasherApp {
             ProgrammerType::Ftdi => self.spawn_connect_ftdi(),
             ProgrammerType::Ft4222 => self.spawn_connect_ft4222(),
             ProgrammerType::Dediprog => self.spawn_connect_dediprog(),
+            ProgrammerType::Raiden => self.spawn_connect_raiden(),
         }
     }
 
@@ -1023,6 +1055,54 @@ impl RflasherApp {
         });
     }
 
+    fn spawn_connect_raiden(&mut self) {
+        let shared = self.shared.clone();
+        let ctx = self.ctx.clone();
+        let config = RaidenConfig {
+            serial: None,
+            target: self.raiden_target,
+        };
+
+        self.connection = ConnectionState::Connecting;
+        self.status.info("Requesting Raiden device via WebUSB...");
+
+        wasm_bindgen_futures::spawn_local(async move {
+            shared.borrow_mut().busy = true;
+
+            match RaidenDebugSpi::request_device().await {
+                Ok(device_info) => match RaidenDebugSpi::open(device_info, &config).await {
+                    Ok(raiden) => {
+                        let mut state = shared.borrow_mut();
+                        state.programmer = Some(Programmer::Raiden(raiden));
+                        state.messages.push(AsyncMessage::Connected {
+                            programmer_name: format!(
+                                "Raiden ({})",
+                                raiden_target_label(config.target)
+                            ),
+                        });
+                    }
+                    Err(e) => {
+                        shared
+                            .borrow_mut()
+                            .messages
+                            .push(AsyncMessage::ConnectionFailed(format!("{}", e)));
+                    }
+                },
+                Err(e) => {
+                    shared
+                        .borrow_mut()
+                        .messages
+                        .push(AsyncMessage::ConnectionFailed(format!("{}", e)));
+                }
+            }
+
+            shared.borrow_mut().busy = false;
+            if let Some(ctx) = ctx {
+                ctx.request_repaint();
+            }
+        });
+    }
+
     fn spawn_disconnect(&mut self) {
         let shared = self.shared.clone();
 
@@ -1051,6 +1131,9 @@ impl RflasherApp {
                     }
                     Programmer::Dediprog(mut dediprog) => {
                         dediprog.shutdown().await;
+                    }
+                    Programmer::Raiden(mut raiden) => {
+                        raiden.shutdown().await;
                     }
                 }
 
@@ -1567,6 +1650,11 @@ impl RflasherApp {
                         ProgrammerType::Dediprog,
                         ProgrammerType::Dediprog.label(),
                     );
+                    ui.selectable_value(
+                        &mut self.programmer_type,
+                        ProgrammerType::Raiden,
+                        ProgrammerType::Raiden.label(),
+                    );
                 });
         });
 
@@ -1706,6 +1794,42 @@ impl RflasherApp {
             });
             if connected {
                 ui.label("Reconnect to change FTDI settings");
+            }
+        }
+
+        if self.programmer_type == ProgrammerType::Raiden {
+            let connected = self.is_connected();
+            ui.add_enabled_ui(!connected, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Target:");
+                    egui::ComboBox::from_id_salt("raiden_target")
+                        .selected_text(raiden_target_label(self.raiden_target))
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(
+                                &mut self.raiden_target,
+                                RaidenTarget::Ap,
+                                raiden_target_label(RaidenTarget::Ap),
+                            );
+                            ui.selectable_value(
+                                &mut self.raiden_target,
+                                RaidenTarget::Ec,
+                                raiden_target_label(RaidenTarget::Ec),
+                            );
+                            ui.selectable_value(
+                                &mut self.raiden_target,
+                                RaidenTarget::H1,
+                                raiden_target_label(RaidenTarget::H1),
+                            );
+                            ui.selectable_value(
+                                &mut self.raiden_target,
+                                RaidenTarget::ApCustom,
+                                raiden_target_label(RaidenTarget::ApCustom),
+                            );
+                        });
+                });
+            });
+            if connected {
+                ui.label("Reconnect to change Raiden target");
             }
         }
 
@@ -1964,6 +2088,9 @@ impl RflasherApp {
                 ui.label(
                     "Create the file below and replug the device (or run the reload commands).",
                 );
+                ui.label(
+                    "Raiden Debug SPI / Cr50 uses Google VID 18d1. Product IDs vary between SuzyQ, Servo, C2D2, uServo, and Servo Micro, so the example rule below matches Google debug hardware broadly.",
+                );
                 ui.add_space(5.0);
 
                 egui::Frame::group(ui.style()).show(ui, |ui| {
@@ -2009,6 +2136,14 @@ impl RflasherApp {
                     ui.monospace(concat!(
                         "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0483\", ",
                         "ATTR{idProduct}==\"dada\", MODE=\"0666\"",
+                    ));
+                    ui.add_space(3.0);
+                    ui.monospace(
+                        "# Raiden Debug SPI / Cr50 (Google debug hardware, VID:18d1; product ID varies)",
+                    );
+                    ui.monospace(concat!(
+                        "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"18d1\", ",
+                        "MODE=\"0666\"",
                     ));
                 });
 


### PR DESCRIPTION
## Summary
- port `rflasher-raiden` to the async WebUSB path so Raiden/Cr50 works in wasm builds alongside the existing browser programmers
- add a `Raiden Debug SPI (WebUSB)` option to the web UI with an `H1 / Cr50` target selector and explicit shutdown handling
- update Linux USB permission guidance in the web UI and README, and add a workspace-level wasm `web_sys_unstable_apis` config so root-level wasm checks match the actual WebUSB/WebSerial build

## Testing
- cargo check -p rflasher-raiden
- cargo check -p rflasher-wasm --target wasm32-unknown-unknown