### PR TITLE
feat(ft4222): WASM/WebUSB support for FT4222H programmer

### DIFF
--- a/crates/rflasher-wasm/src/app.rs
+++ b/crates/rflasher-wasm/src/app.rs
@@ -2005,6 +2005,12 @@ impl RflasherApp {
                         "ATTR{idProduct}==\"6014\", MODE=\"0666\"",
                     ));
                     ui.add_space(3.0);
+                    ui.monospace("# FTDI FT4222H (VID:0403 PID:601c)");
+                    ui.monospace(concat!(
+                        "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0403\", ",
+                        "ATTR{idProduct}==\"601c\", MODE=\"0666\"",
+                    ));
+                    ui.add_space(3.0);
                     ui.monospace("# Dediprog SF100/SF200/SF600/SF700 (VID:0483 PID:dada)");
                     ui.monospace(concat!(
                         "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0483\", ",


### PR DESCRIPTION
## Summary

- Ports the FT4222H programmer to the browser/WASM path using the same `maybe_async` + WebUSB pattern as CH341A, CH347, FTDI, and Dediprog
- Adds FT4222H to the rflasher web UI programmer picker with a WebUSB device request flow
- Fixes CI: replaces the broken `dtolnay/rust-toolchain` action (tarball no longer resolvable) with direct `rustup` calls across all jobs
- Adds the FT4222H udev rule (`VID:0403 PID:601c`) to the USB permissions help window

## Changes

### `crates/rflasher-ft4222`
- New `wasm` feature flag; `std` feature now implies `is_sync` so existing native CLI behaviour is unchanged
- Rewrote `device.rs` to use `maybe_async` + `ep_wait!`/`nusb_await!` macros — single source tree compiles to both sync (native) and async (WASM)
- Added `request_device()` (WebUSB picker), `open()`, and `shutdown()` WASM-only helpers
- Cached bulk IN/OUT endpoints on open to avoid repeated endpoint lookups per transfer

### `crates/rflasher-wasm`
- Added `rflasher-ft4222` as a wasm dependency
- Added `ProgrammerType::Ft4222`, `Programmer::Ft4222`, and `spawn_connect_ft4222()` following the same pattern as FTDI/CH347
- Added FT4222H entry to the USB permissions udev rules help window

### `.github/workflows/ci.yml`
- Replaced all `dtolnay/rust-toolchain@stable` steps with inline `rustup toolchain install` commands — removes the third-party action that was causing `Set up job` failures