### PR TITLE
feat: add operation-scoped dual and quad SPI I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -78,9 +78,9 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -306,13 +306,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3015,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3032,7 +3032,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rflasher"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "rflasher-chip-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.13.1",
  "heapless",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "rflasher-chips"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "once_cell",
  "rflasher-chip-types",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "rflasher-chips-codegen"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "rflasher-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.13.1",
  "embedded-io",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rflasher-internal"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libc",
  "log",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "rflasher-pci"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libc",
  "pci_types",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "rflasher-programmers"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "embedded-io",
  "embedded-io-async",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "rflasher-repl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "colored",
  "crossbeam-utils",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "rflasher-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -4105,9 +4105,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
  "jni",
  "log",
@@ -4496,9 +4496,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "yoke"
@@ -4525,18 +4525,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,18 +24,18 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "GPL-2.0-or-later"
 repository = "https://github.com/ArthurHeymans/rflasher"
 
 [workspace.dependencies]
 # Internal crates
-rflasher-chip-types = { version = "0.1.0", path = "crates/rflasher-chip-types", default-features = false }
-rflasher-core = { version = "0.1.0", path = "crates/rflasher-core", default-features = false }
-rflasher-chips = { version = "0.1.0", path = "crates/rflasher-chips" }
-rflasher-programmers = { version = "0.1.0", path = "crates/rflasher-programmers", default-features = false }
-rflasher-pci = { version = "0.1.0", path = "crates/rflasher-pci", default-features = false }
+rflasher-chip-types = { version = "0.2.0", path = "crates/rflasher-chip-types", default-features = false }
+rflasher-core = { version = "0.2.0", path = "crates/rflasher-core", default-features = false }
+rflasher-chips = { version = "0.2.0", path = "crates/rflasher-chips" }
+rflasher-programmers = { version = "0.2.0", path = "crates/rflasher-programmers", default-features = false }
+rflasher-pci = { version = "0.2.0", path = "crates/rflasher-pci", default-features = false }
 
 # Core
 bitflags = "2"
@@ -119,7 +119,7 @@ static-linux-programmers = ["portable-programmers", "linux-spi", "linux-mtd", "i
 rflasher-core = { workspace = true, features = ["std"] }
 rflasher-chips.workspace = true
 rflasher-programmers = { workspace = true, features = ["std"] }
-rflasher-repl = { version = "0.1.0", path = "crates/rflasher-repl", optional = true }
+rflasher-repl = { version = "0.2.0", path = "crates/rflasher-repl", optional = true }
 futures-lite.workspace = true
 clap.workspace = true
 clap_mangen = "0.2"

--- a/crates/rflasher-chip-types/src/features.rs
+++ b/crates/rflasher-chip-types/src/features.rs
@@ -6,6 +6,9 @@ bitflags! {
     /// Feature flags for flash chips
     ///
     /// These flags describe what capabilities and behaviors a flash chip has.
+    ///
+    /// Multi-IO read flags are split by JEDEC bus mode so programmers can
+    /// select the fastest operation supported by both the chip and controller.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(transparent))]
@@ -13,7 +16,7 @@ bitflags! {
         // Write enable behavior
         /// Use WREN (0x06) before WRSR
         const WRSR_WREN       = 1 << 0;
-        /// Use EWSR (0x50) before WRSR (legacy SST)
+        /// EWSR (0x50): required on legacy SST; optional volatile writes with WREN.
         const WRSR_EWSR       = 1 << 1;
         /// WRSR writes both SR1 and SR2 with one command
         const WRSR_EXT        = 1 << 2;
@@ -21,9 +24,15 @@ bitflags! {
         // Read capabilities
         /// Supports Fast Read (0x0B)
         const FAST_READ       = 1 << 3;
-        /// Supports Dual I/O read commands
+        /// Legacy coarse dual-IO flag (vestige: selection uses FAST_READ_DOUT/DIO now).
+        ///
+        /// Retained as an API bit; no longer parsed from the database or used
+        /// by read selection.
         const DUAL_IO         = 1 << 4;
-        /// Supports Quad I/O read commands
+        /// Legacy coarse quad-IO flag (vestige: selection uses FAST_READ_QOUT/QIO now).
+        ///
+        /// Retained as an API bit; no longer parsed from the database or used
+        /// by read selection.
         const QUAD_IO         = 1 << 5;
 
         // 4-byte addressing
@@ -39,7 +48,10 @@ bitflags! {
         // Special features
         /// Has OTP (One-Time Programmable) area
         const OTP             = 1 << 10;
-        /// Supports QPI mode (4-4-4)
+        /// Legacy coarse QPI flag (vestige: selection uses QPI_35_F5/QPI_38_FF now).
+        ///
+        /// Retained as an API bit and set by SFDP for 4-4-4-capable chips;
+        /// no longer parsed from the database or used by read selection.
         const QPI             = 1 << 11;
         /// Has security registers
         const SECURITY_REG    = 1 << 12;
@@ -63,7 +75,10 @@ bitflags! {
         const STATUS_REG_2    = 1 << 19;
         /// Has status register 3
         const STATUS_REG_3    = 1 << 20;
-        /// Quad Enable bit is in SR2
+        /// Legacy coarse QE-location flag (vestige: QE handling uses `QeMethod` now).
+        ///
+        /// Retained as an API bit; no longer parsed from the database or used
+        /// by QE preparation.
         const QE_SR2          = 1 << 21;
 
         // Power management
@@ -109,6 +124,42 @@ bitflags! {
         const FOUR_BYTE_QUAD_OUT_READ = 1 << 39;
         /// Native 4BA quad-I/O read instruction 0xEC
         const FOUR_BYTE_QUAD_IO_READ  = 1 << 40;
+
+        // Fine-grained multi-IO read support
+        /// Supports Dual Output Fast Read (1-1-2, opcode 0x3B / 0x3C)
+        const FAST_READ_DOUT  = 1 << 41;
+        /// Supports Dual I/O Fast Read (1-2-2, opcode 0xBB / 0xBC)
+        const FAST_READ_DIO   = 1 << 42;
+        /// Supports Quad Output Fast Read (1-1-4, opcode 0x6B / 0x6C)
+        const FAST_READ_QOUT  = 1 << 43;
+        /// Supports Quad I/O Fast Read (1-4-4, opcode 0xEB / 0xEC)
+        const FAST_READ_QIO   = 1 << 44;
+        /// Supports 4-byte QPI Fast Read (4-4-4, opcode 0xEC)
+        const FAST_READ_QPI4B = 1 << 45;
+        /// QPI entry/exit via 0x35/0xF5
+        const QPI_35_F5       = 1 << 46;
+        /// QPI entry/exit via 0x38/0xFF
+        const QPI_38_FF       = 1 << 47;
+        /// Supports Set Read Parameters (0xC0)
+        const SET_READ_PARAMS = 1 << 48;
+
+        /// Fast-read and dual-read capabilities.
+        const DIO_BUNDLE = Self::FAST_READ.bits()
+                         | Self::FAST_READ_DOUT.bits()
+                         | Self::FAST_READ_DIO.bits();
+        /// Fast-read, dual-read, and quad-read capabilities.
+        const QIO_BUNDLE = Self::DIO_BUNDLE.bits()
+                         | Self::FAST_READ_QOUT.bits()
+                         | Self::FAST_READ_QIO.bits();
+        /// All capabilities that require quad data lines.
+        const ANY_QUAD = Self::FAST_READ_QOUT.bits()
+                       | Self::FAST_READ_QIO.bits()
+                       | Self::FAST_READ_QPI4B.bits()
+                       | Self::QPI_35_F5.bits()
+                       | Self::QPI_38_FF.bits()
+                       | Self::SET_READ_PARAMS.bits();
+        /// All QPI entry/exit mechanisms.
+        const ANY_QPI = Self::QPI_35_F5.bits() | Self::QPI_38_FF.bits();
     }
 }
 
@@ -168,4 +219,21 @@ impl Default for Features {
     fn default() -> Self {
         Features::empty()
     }
+}
+
+/// Method used to enable quad I/O on a flash chip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum QeMethod {
+    /// The chip has no QE bit.
+    #[default]
+    None,
+    /// QE is SR2 bit 1, written with command 0x01 and two status bytes.
+    Sr2Bit1WriteSr,
+    /// QE is SR2 bit 1, written with the dedicated 0x31 command.
+    Sr2Bit1WriteSr2,
+    /// QE is SR1 bit 6, written with command 0x01.
+    Sr1Bit6,
+    /// QE is SR2 bit 7 and requires the chip-specific unlocked sequence.
+    Sr2Bit7,
 }

--- a/crates/rflasher-chip-types/src/lib.rs
+++ b/crates/rflasher-chip-types/src/lib.rs
@@ -14,6 +14,6 @@ mod features;
 mod provider;
 mod types;
 
-pub use features::Features;
+pub use features::{Features, QeMethod};
 pub use provider::ChipProvider;
 pub use types::*;

--- a/crates/rflasher-chip-types/src/types.rs
+++ b/crates/rflasher-chip-types/src/types.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
-use super::features::Features;
+use super::features::{Features, QeMethod};
 
 /// Maximum number of erase regions per erase block (for no_std)
 pub const MAX_ERASE_REGIONS: usize = 8;
@@ -249,6 +249,15 @@ pub struct ChipTestStatus {
 /// This structure contains all the information needed to identify and
 /// interact with a specific flash chip model. Uses owned types (String, Vec)
 /// for runtime flexibility.
+///
+/// # Migrating from 0.1
+///
+/// `qe_method` and the per-mode `dummy_cycles_*` fields were added in 0.2.0.
+/// They are required in struct literals: external constructors must
+/// initialize them (use `QeMethod::None` and `0` for "unknown" — zero
+/// selects the JEDEC-default dummy cycles). The `serde(default)` attributes
+/// only affect deserialization of older chip databases; they do not provide
+/// defaults for struct literals.
 #[derive(Debug, Clone)]
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -282,6 +291,24 @@ pub struct FlashChip {
     /// Test status
     #[cfg_attr(feature = "serde", serde(default))]
     pub tested: ChipTestStatus,
+    /// Quad-enable method for this chip.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub qe_method: QeMethod,
+    /// Dummy cycles for 1-1-2 reads; `None` selects the JEDEC default; `Some(0)` means zero clocks.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub dummy_cycles_112: Option<u8>,
+    /// Dummy cycles for 1-2-2 reads; `None` selects the JEDEC default; `Some(0)` means zero clocks.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub dummy_cycles_122: Option<u8>,
+    /// Dummy cycles for 1-1-4 reads; `None` selects the JEDEC default; `Some(0)` means zero clocks.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub dummy_cycles_114: Option<u8>,
+    /// Dummy cycles for 1-4-4 reads; `None` selects the JEDEC default; `Some(0)` means zero clocks.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub dummy_cycles_144: Option<u8>,
+    /// Dummy cycles for QPI reads; `None` selects the JEDEC default; `Some(0)` means zero clocks.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub dummy_cycles_qpi: Option<u8>,
 }
 
 #[cfg(feature = "serde")]
@@ -297,6 +324,13 @@ fn default_voltage_max() -> u16 {
 /// Flash chip definition (static/const version for no_std)
 ///
 /// This structure uses static references for zero-cost embedded use.
+///
+/// # Migrating from 0.1
+///
+/// `qe_method` and the per-mode `dummy_cycles_*` fields were added in 0.2.0
+/// and are required in struct literals. Use `None` for JEDEC-default timing;
+/// `Some(0)` specifies exactly zero clocks. `QeMethod::None` means no QE register,
+/// not an unknown requirement: unknown QE requirements must exclude quad modes.
 #[derive(Debug, Clone, Copy)]
 #[cfg(not(feature = "alloc"))]
 pub struct FlashChip {
@@ -324,6 +358,18 @@ pub struct FlashChip {
     pub erase_blocks: &'static [EraseBlock],
     /// Test status
     pub tested: ChipTestStatus,
+    /// Quad-enable method for this chip.
+    pub qe_method: QeMethod,
+    /// Dummy cycles for 1-1-2 reads; `None` selects the JEDEC default; `Some(0)` means zero clocks.
+    pub dummy_cycles_112: Option<u8>,
+    /// Dummy cycles for 1-2-2 reads; `None` selects the JEDEC default; `Some(0)` means zero clocks.
+    pub dummy_cycles_122: Option<u8>,
+    /// Dummy cycles for 1-1-4 reads; `None` selects the JEDEC default; `Some(0)` means zero clocks.
+    pub dummy_cycles_114: Option<u8>,
+    /// Dummy cycles for 1-4-4 reads; `None` selects the JEDEC default; `Some(0)` means zero clocks.
+    pub dummy_cycles_144: Option<u8>,
+    /// Dummy cycles for QPI reads; `None` selects the JEDEC default; `Some(0)` means zero clocks.
+    pub dummy_cycles_qpi: Option<u8>,
 }
 
 impl FlashChip {
@@ -472,6 +518,12 @@ mod tests {
             write_granularity: WriteGranularity::Page,
             erase_blocks: alloc::vec![EraseBlock::with_count(0x20, 4096, 4096)],
             tested: ChipTestStatus::default(),
+            qe_method: QeMethod::default(),
+            dummy_cycles_112: None,
+            dummy_cycles_122: None,
+            dummy_cycles_114: None,
+            dummy_cycles_144: None,
+            dummy_cycles_qpi: None,
         };
 
         let encoded = ron::to_string(&chip).unwrap();

--- a/crates/rflasher-chips-codegen/src/lib.rs
+++ b/crates/rflasher-chips-codegen/src/lib.rs
@@ -89,10 +89,14 @@ pub struct FeaturesDef {
     // Read capabilities
     /// Supports Fast Read (0x0B)
     pub fast_read: bool,
-    /// Supports Dual I/O read commands
-    pub dual_io: bool,
-    /// Supports Quad I/O read commands
-    pub quad_io: bool,
+    pub fast_read_dout: bool,
+    pub fast_read_dio: bool,
+    pub fast_read_qout: bool,
+    pub fast_read_qio: bool,
+    pub fast_read_qpi4b: bool,
+    pub qpi_35_f5: bool,
+    pub qpi_38_ff: bool,
+    pub set_read_params: bool,
 
     // 4-byte addressing
     /// Supports 4-byte address mode
@@ -129,8 +133,7 @@ pub struct FeaturesDef {
     // Special features
     /// Has OTP (One-Time Programmable) area
     pub otp: bool,
-    /// Supports QPI mode (4-4-4)
-    pub qpi: bool,
+
     /// Has security registers
     pub security_reg: bool,
     /// Supports SFDP (Serial Flash Discoverable Parameters)
@@ -149,8 +152,6 @@ pub struct FeaturesDef {
     pub status_reg_2: bool,
     /// Has status register 3
     pub status_reg_3: bool,
-    /// Quad Enable bit is in SR2
-    pub qe_sr2: bool,
 
     // Power management
     /// Supports deep power down
@@ -182,11 +183,29 @@ impl FeaturesDef {
         if self.fast_read {
             flags.push(quote!(Features::FAST_READ));
         }
-        if self.dual_io {
-            flags.push(quote!(Features::DUAL_IO));
+        if self.fast_read_dout {
+            flags.push(quote!(Features::FAST_READ_DOUT));
         }
-        if self.quad_io {
-            flags.push(quote!(Features::QUAD_IO));
+        if self.fast_read_dio {
+            flags.push(quote!(Features::FAST_READ_DIO));
+        }
+        if self.fast_read_qout {
+            flags.push(quote!(Features::FAST_READ_QOUT));
+        }
+        if self.fast_read_qio {
+            flags.push(quote!(Features::FAST_READ_QIO));
+        }
+        if self.fast_read_qpi4b {
+            flags.push(quote!(Features::FAST_READ_QPI4B));
+        }
+        if self.qpi_35_f5 {
+            flags.push(quote!(Features::QPI_35_F5));
+        }
+        if self.qpi_38_ff {
+            flags.push(quote!(Features::QPI_38_FF));
+        }
+        if self.set_read_params {
+            flags.push(quote!(Features::SET_READ_PARAMS));
         }
         if self.four_byte_addr {
             flags.push(quote!(Features::FOUR_BYTE_ADDR));
@@ -236,9 +255,7 @@ impl FeaturesDef {
         if self.otp {
             flags.push(quote!(Features::OTP));
         }
-        if self.qpi {
-            flags.push(quote!(Features::QPI));
-        }
+
         if self.security_reg {
             flags.push(quote!(Features::SECURITY_REG));
         }
@@ -260,9 +277,7 @@ impl FeaturesDef {
         if self.status_reg_3 {
             flags.push(quote!(Features::STATUS_REG_3));
         }
-        if self.qe_sr2 {
-            flags.push(quote!(Features::QE_SR2));
-        }
+
         if self.deep_power_down {
             flags.push(quote!(Features::DEEP_POWER_DOWN));
         }
@@ -282,6 +297,28 @@ impl FeaturesDef {
             let first = &flags[0];
             let rest = &flags[1..];
             quote!(#first #(.union(#rest))*)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+pub enum QeMethodDef {
+    #[default]
+    None,
+    Sr2Bit1WriteSr,
+    Sr2Bit1WriteSr2,
+    Sr1Bit6,
+    Sr2Bit7,
+}
+
+impl QeMethodDef {
+    fn to_tokens(self) -> TokenStream {
+        match self {
+            Self::None => quote!(QeMethod::None),
+            Self::Sr2Bit1WriteSr => quote!(QeMethod::Sr2Bit1WriteSr),
+            Self::Sr2Bit1WriteSr2 => quote!(QeMethod::Sr2Bit1WriteSr2),
+            Self::Sr1Bit6 => quote!(QeMethod::Sr1Bit6),
+            Self::Sr2Bit7 => quote!(QeMethod::Sr2Bit7),
         }
     }
 }
@@ -429,6 +466,18 @@ pub struct ChipDef {
     /// Test status
     #[serde(default)]
     pub tested: TestStatusDef,
+    #[serde(default)]
+    pub qe_method: QeMethodDef,
+    #[serde(default)]
+    pub dummy_cycles_112: Option<u8>,
+    #[serde(default)]
+    pub dummy_cycles_122: Option<u8>,
+    #[serde(default)]
+    pub dummy_cycles_114: Option<u8>,
+    #[serde(default)]
+    pub dummy_cycles_144: Option<u8>,
+    #[serde(default)]
+    pub dummy_cycles_qpi: Option<u8>,
 }
 
 fn default_page_size() -> u16 {
@@ -582,6 +631,22 @@ impl ChipDatabase {
                 let voltage_max = Literal::u16_unsuffixed(chip.voltage.max);
                 let write_gran = chip.write_granularity.to_tokens();
                 let tested = chip.tested.to_tokens();
+                let qe_method = chip.qe_method.to_tokens();
+                let dummy_cycles_112 = chip
+                    .dummy_cycles_112
+                    .map_or_else(|| quote!(None), |n| quote!(Some(#n)));
+                let dummy_cycles_122 = chip
+                    .dummy_cycles_122
+                    .map_or_else(|| quote!(None), |n| quote!(Some(#n)));
+                let dummy_cycles_114 = chip
+                    .dummy_cycles_114
+                    .map_or_else(|| quote!(None), |n| quote!(Some(#n)));
+                let dummy_cycles_144 = chip
+                    .dummy_cycles_144
+                    .map_or_else(|| quote!(None), |n| quote!(Some(#n)));
+                let dummy_cycles_qpi = chip
+                    .dummy_cycles_qpi
+                    .map_or_else(|| quote!(None), |n| quote!(Some(#n)));
 
                 chip_defs.push(quote! {
                     FlashChip {
@@ -597,6 +662,12 @@ impl ChipDatabase {
                         write_granularity: #write_gran,
                         erase_blocks: vec![#(#erase_blocks),*],
                         tested: #tested,
+                        qe_method: #qe_method,
+                        dummy_cycles_112: #dummy_cycles_112,
+                        dummy_cycles_122: #dummy_cycles_122,
+                        dummy_cycles_114: #dummy_cycles_114,
+                        dummy_cycles_144: #dummy_cycles_144,
+                        dummy_cycles_qpi: #dummy_cycles_qpi,
                     }
                 });
             }
@@ -655,11 +726,15 @@ mod tests {
                     device_id: 0x4018,
                     total_size: MiB(16),
                     page_size: 256,
+                    dummy_cycles_122: Some(0),
+                    dummy_cycles_144: Some(6),
                     features: (
                         wrsr_wren: true,
                         fast_read: true,
-                        dual_io: true,
-                        quad_io: true,
+                        fast_read_dout: true,
+                        fast_read_dio: true,
+                        fast_read_qout: true,
+                        fast_read_qio: true,
                     ),
                     voltage: (min: 2700, max: 3600),
                     erase_blocks: [
@@ -685,6 +760,17 @@ mod tests {
         assert_eq!(chip.total_size.to_bytes(), 16 * 1024 * 1024);
         assert!(chip.features.wrsr_wren);
         assert!(chip.features.fast_read);
+        assert_eq!(chip.dummy_cycles_112, None);
+        assert_eq!(chip.dummy_cycles_122, Some(0));
+        assert_eq!(chip.dummy_cycles_144, Some(6));
+        let generated = ChipDatabase {
+            vendors: vec![vendor],
+        }
+        .generate_code();
+        let compact: String = generated.split_whitespace().collect();
+        assert!(compact.contains("dummy_cycles_112:None"));
+        assert!(compact.contains("dummy_cycles_122:Some(0u8)"));
+        assert!(compact.contains("dummy_cycles_144:Some(6u8)"));
     }
 
     #[test]

--- a/crates/rflasher-chips/Cargo.toml
+++ b/crates/rflasher-chips/Cargo.toml
@@ -21,4 +21,4 @@ ron.workspace = true
 once_cell = { workspace = true, features = ["std"] }
 
 [build-dependencies]
-rflasher-chips-codegen = { version = "0.1.0", path = "../rflasher-chips-codegen", optional = true }
+rflasher-chips-codegen = { version = "0.2.0", path = "../rflasher-chips-codegen", optional = true }

--- a/crates/rflasher-chips/data/vendors/amic.ron
+++ b/crates/rflasher-chips/data/vendors/amic.ron
@@ -220,7 +220,7 @@
             name: "A25LQ032/A25LQ32A",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -235,7 +235,7 @@
             name: "A25LQ16",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -250,7 +250,7 @@
             name: "A25LQ64",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true, qpi_35_f5: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_dio: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),

--- a/crates/rflasher-chips/data/vendors/atmel.ron
+++ b/crates/rflasher-chips/data/vendors/atmel.ron
@@ -297,7 +297,8 @@
             name: "AT25SF128A",
             device_id: 0x8901,
             total_size: MiB(16),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2500, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -325,7 +326,7 @@
             name: "AT25SF321",
             device_id: 0x8701,
             total_size: MiB(4),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2500, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -340,7 +341,8 @@
             name: "AT25SL128A",
             device_id: 0x4218,
             total_size: MiB(16),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),

--- a/crates/rflasher-chips/data/vendors/boya.ron
+++ b/crates/rflasher-chips/data/vendors/boya.ron
@@ -9,7 +9,8 @@
             name: "BY25Q128FS",
             device_id: 0x4118,
             total_size: MiB(16),
-            features: (otp: true),
+            features: (otp: true, fast_read: true, fast_read_dio: true, fast_read_dout: true, fast_read_qio: true, fast_read_qout: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -23,7 +24,7 @@
             name: "B.25D05AS",
             device_id: 0x4010,
             total_size: KiB(64),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -37,7 +38,7 @@
             name: "B.25D10AS",
             device_id: 0x4011,
             total_size: KiB(128),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -51,7 +52,7 @@
             name: "B.25D20AS",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -65,7 +66,7 @@
             name: "B.25D40AS/BY25D40ES",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -79,7 +80,7 @@
             name: "B.25D80AS/BY25Q80BS/BY25Q80ES",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -93,7 +94,7 @@
             name: "B.25D16AS/BY25Q16BS/BY25Q16ES",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -107,7 +108,8 @@
             name: "B.25Q32BS/BY25Q32CS/BY25Q32ES",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -121,7 +123,8 @@
             name: "B.25Q64AS/BY25Q64ES",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -135,7 +138,8 @@
             name: "B.25Q128AS/BY25Q128ES",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),

--- a/crates/rflasher-chips/data/vendors/eon.ron
+++ b/crates/rflasher-chips/data/vendors/eon.ron
@@ -82,7 +82,7 @@
             name: "EN25QH16",
             device_id: 0x7015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, qpi_38_ff: true, fast_read_qio: true, fast_read_dio: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -97,7 +97,7 @@
             name: "EN25QH128",
             device_id: 0x7018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, qpi_38_ff: true, fast_read_qio: true, fast_read_dio: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -622,7 +622,7 @@
             name: "EN25QH32B",
             device_id: 0x7016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -637,7 +637,7 @@
             name: "EN25QH64A",
             device_id: 0x7017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -652,7 +652,7 @@
             name: "EN25QH32",
             device_id: 0x7016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, qpi: true),
+            features: (wrsr_wren: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, qpi_38_ff: true, fast_read_dio: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -665,7 +665,7 @@
             name: "EN25QH64",
             device_id: 0x7017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, qpi: true),
+            features: (wrsr_wren: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, qpi_38_ff: true, fast_read_dio: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -691,7 +691,7 @@
             name: "EN25S16",
             device_id: 0x3815,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, qpi_38_ff: true, fast_read_dio: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -718,7 +718,7 @@
             name: "EN25S32",
             device_id: 0x3816,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, qpi_38_ff: true, fast_read_dio: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -746,7 +746,7 @@
             name: "EN25S64",
             device_id: 0x3817,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, qpi_38_ff: true, fast_read_dio: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),

--- a/crates/rflasher-chips/data/vendors/esmt.ron
+++ b/crates/rflasher-chips/data/vendors/esmt.ron
@@ -64,7 +64,7 @@
             name: "F25D08QA",
             device_id: 0x3214,
             total_size: MiB(1),
-            features: (wrsr_wren: true, dual_io: true),
+            features: (wrsr_wren: true, fast_read_dio: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -74,11 +74,14 @@
             ],
         ),
         // F49 series - Quad SPI
+        // NOTE: the SST49LF004 family is a parallel Firmware-Hub (BUS_FWH)
+        // part in flashprog, not SPI: SPI multi-IO flags and qe_method are
+        // not applicable and are left unset deliberately.
         (
             name: "F49L004UA",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),

--- a/crates/rflasher-chips/data/vendors/fudan.ron
+++ b/crates/rflasher-chips/data/vendors/fudan.ron
@@ -65,7 +65,8 @@
             name: "FM25Q02",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -79,7 +80,8 @@
             name: "FM25Q04",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -93,7 +95,8 @@
             name: "FM25Q08",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -107,7 +110,8 @@
             name: "FM25Q08A",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -121,7 +125,8 @@
             name: "FM25Q16",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -135,7 +140,8 @@
             name: "FM25Q32",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -149,7 +155,8 @@
             name: "FM25Q64",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -163,7 +170,8 @@
             name: "FM25Q128",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read: true, fast_read_qout: true, fast_read_dout: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -177,7 +185,8 @@
             name: "FM25W128",
             device_id: 0x2818,
             total_size: MiB(16),
-            features: (wrsr_wren: true, wrsr_ext: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, wrsr_ext: true, otp: true, status_reg_2: true, fast_read: true, fast_read_dio: true, fast_read_dout: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, set_read_params: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),

--- a/crates/rflasher-chips/data/vendors/gigadevice.ron
+++ b/crates/rflasher-chips/data/vendors/gigadevice.ron
@@ -26,7 +26,8 @@
             name: "GD25Q512",
             device_id: 0x4010,
             total_size: KiB(64),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -40,7 +41,8 @@
             name: "GD25Q10",
             device_id: 0x4011,
             total_size: KiB(128),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -55,7 +57,8 @@
             name: "GD25Q20",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -70,7 +73,8 @@
             name: "GD25Q40",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -85,7 +89,8 @@
             name: "GD25Q80",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -100,7 +105,8 @@
             name: "GD25Q16",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -115,7 +121,8 @@
             name: "GD25Q32",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -130,7 +137,8 @@
             name: "GD25Q64",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -142,10 +150,16 @@
             tested: (probe: Ok, read: Ok, erase: Ok, write: Ok),
         ),
         (
+            // Family entry: 0x4018 is shared with the B/C/E/H revisions
+            // below, which flashprog documents separately (notably
+            // GD25Q128B uses combined-WRSR QE while the rest use 0x31).
+            // Probing cannot distinguish the revisions; both write methods
+            // work on GigaDevice parts, so this keeps the dedicated one.
             name: "GD25Q128",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -160,7 +174,8 @@
             name: "GD25Q256D",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, qe_sr2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, status_reg_3: true, wrsr_ext: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, status_reg_3: true, wrsr_ext: true, fast_read_dout: true, fast_read_dio: true, fast_read_qout: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -176,7 +191,8 @@
             name: "GD25VQ21B",
             device_id: 0x4212,
             total_size: KiB(256),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -190,7 +206,8 @@
             name: "GD25VQ40C",
             device_id: 0x4213,
             total_size: KiB(512),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -204,7 +221,8 @@
             name: "GD25VQ41B",
             device_id: 0x4213,
             total_size: KiB(512),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -219,7 +237,8 @@
             name: "GD25VQ80C",
             device_id: 0x4214,
             total_size: MiB(1),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -233,7 +252,8 @@
             name: "GD25VQ16C",
             device_id: 0x4215,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -249,7 +269,8 @@
             name: "GD25LQ20",
             device_id: 0x6012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, otp: true, status_reg_2: true, wp_tb: true, wp_sec: true, wp_cmp: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -263,7 +284,8 @@
             name: "GD25LQ40",
             device_id: 0x6013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, otp: true, status_reg_2: true, wp_tb: true, wp_sec: true, wp_cmp: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -277,7 +299,8 @@
             name: "GD25LQ80",
             device_id: 0x6014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, otp: true, status_reg_2: true, wp_tb: true, wp_sec: true, wp_cmp: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -291,7 +314,8 @@
             name: "GD25LQ16",
             device_id: 0x6015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -305,7 +329,8 @@
             name: "GD25LQ32",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dout: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -319,7 +344,8 @@
             name: "GD25LQ64",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true, qpi_38_ff: true, set_read_params: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -333,7 +359,8 @@
             name: "GD25LQ128",
             device_id: 0x6018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -347,7 +374,8 @@
             name: "GD25LQ256D",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, qe_sr2: true, wrsr_ext: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, wrsr_ext: true, fast_read_dout: true, fast_read_dio: true, fast_read_qout: true, fast_read_qio: true, qpi_38_ff: true, set_read_params: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -363,7 +391,8 @@
             name: "GD25LF80E",
             device_id: 0x6314,
             total_size: MiB(1),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, otp: true, status_reg_2: true, wp_tb: true, wp_sec: true, wp_cmp: true, fast_read_dout: true, set_read_params: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -377,7 +406,8 @@
             name: "GD25LF16E",
             device_id: 0x6315,
             total_size: MiB(2),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, otp: true, status_reg_2: true, wp_tb: true, wp_sec: true, wp_cmp: true, fast_read_dout: true, set_read_params: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -391,7 +421,8 @@
             name: "GD25LF32E",
             device_id: 0x6316,
             total_size: MiB(4),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, otp: true, status_reg_2: true, wp_tb: true, wp_sec: true, wp_cmp: true, fast_read_dout: true, set_read_params: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -405,7 +436,8 @@
             name: "GD25LF64E",
             device_id: 0x6317,
             total_size: MiB(8),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, otp: true, status_reg_2: true, wp_tb: true, wp_sec: true, wp_cmp: true, fast_read_dout: true, set_read_params: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -419,7 +451,8 @@
             name: "GD25LF128E",
             device_id: 0x6318,
             total_size: MiB(16),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, otp: true, status_reg_2: true, wp_tb: true, wp_sec: true, wp_cmp: true, fast_read_dout: true, set_read_params: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -435,7 +468,8 @@
             name: "GD25WQ80E",
             device_id: 0x6514,
             total_size: MiB(1),
-            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, fast_read: true, otp: true, status_reg_2: true, wp_tb: true, wp_sec: true, wp_cmp: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -449,7 +483,8 @@
             name: "GD25LQ128C/GD25LQ128D/GD25LQ128E",
             device_id: 0x6018,
             total_size: MiB(16),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -462,7 +497,8 @@
             name: "GD25LQ256D/GD25LE256D/GD25LB256D/GD25LQ255E",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, wrsr_ext: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, wrsr_ext: true, fast_read_dout: true, set_read_params: true, qpi_38_ff: true, fast_read: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -474,7 +510,8 @@
             name: "GD25LQ256H/GD25LE256H/GD25LB256F",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -486,7 +523,8 @@
             name: "GD25LE255E",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_program: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_program: true, wrsr_ext: true, status_reg_3: true, fast_read_qpi4b: true, qpi_38_ff: true, set_read_params: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -498,7 +536,7 @@
             name: "GD25LB256E/GD25LR256E",
             device_id: 0x6719,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, wrsr_ewsr: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -510,7 +548,8 @@
             name: "GD25LQ64(B)",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -523,7 +562,7 @@
             name: "GD25LB512ME/GD25LR512ME",
             device_id: 0x671A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, wrsr_ewsr: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -538,7 +577,8 @@
             name: "GD25LB512MF/GD25LR512MF",
             device_id: 0x601A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -552,7 +592,7 @@
             name: "GD55LB01GE",
             device_id: 0x671B,
             total_size: MiB(128),
-            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, wrsr_ewsr: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 32768)]),
@@ -566,7 +606,8 @@
             name: "GD55LB01GF",
             device_id: 0x601B,
             total_size: MiB(128),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 32768)]),
@@ -580,7 +621,7 @@
             name: "GD55LB02GE",
             device_id: 0x671C,
             total_size: MiB(256),
-            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, wrsr_ewsr: true),
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 65536)]),
@@ -594,7 +635,8 @@
             name: "GD55LB02GF",
             device_id: 0x601C,
             total_size: MiB(256),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 65536)]),
@@ -608,7 +650,8 @@
             name: "GD25Q127C/GD25B127D",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (otp: true),
+            features: (otp: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -621,7 +664,8 @@
             name: "GD25Q128B/GD25B128B",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -634,7 +678,8 @@
             name: "GD25Q128C",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (otp: true, qpi: true),
+            features: (otp: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -647,7 +692,8 @@
             name: "GD25Q128E/GD25B128E/GD25R128E/GD25Q128H/GD25B128H",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (otp: true),
+            features: (otp: true, fast_read: true, fast_read_qout: true, fast_read_dout: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -659,7 +705,8 @@
             name: "GD25Q16(B)",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -672,7 +719,8 @@
             name: "GD25Q20(B)",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, status_reg_2: true),
+            features: (wrsr_wren: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -687,7 +735,8 @@
             name: "GD25Q256D/GD25B256D/GD25R256D",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, status_reg_3: true, dual_io: true, quad_io: true, wrsr_ext: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, status_reg_3: true, wrsr_ext: true, fast_read_dout: true, fast_read: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -700,7 +749,8 @@
             name: "GD25Q257D/GD25B257D",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true, fast_read_qout: true, fast_read_dout: true, fast_read_dio: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -712,7 +762,8 @@
             name: "GD25Q256E/GD25B256E/GD25R256E",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, status_reg_2: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, status_reg_2: true, status_reg_3: true, fast_read_qout: true, fast_read_dout: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -724,7 +775,8 @@
             name: "GD25Q32(B)",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -737,7 +789,8 @@
             name: "GD25Q40(B)",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, status_reg_2: true),
+            features: (wrsr_wren: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -752,7 +805,8 @@
             name: "GD25Q64(B)",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -765,7 +819,8 @@
             name: "GD25Q80(B)",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -780,7 +835,7 @@
             name: "GD25B512ME/GD25R512ME",
             device_id: 0x471A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read_qout: true, fast_read_qpi4b: true, wrsr_ewsr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -794,7 +849,8 @@
             name: "GD25B512MF/GD25R512MF",
             device_id: 0x401A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -808,7 +864,7 @@
             name: "GD55B01GE",
             device_id: 0x471B,
             total_size: MiB(128),
-            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, quad_io: true, four_byte_quad_out_read: true, status_reg_2: true),
+            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_quad_out_read: true, status_reg_2: true, fast_read_qout: true, fast_read_qpi4b: true, wrsr_ewsr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 32768)]),
@@ -822,7 +878,8 @@
             name: "GD55B01GF",
             device_id: 0x401B,
             total_size: MiB(128),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 32768)]),
@@ -836,7 +893,7 @@
             name: "GD55B02GE",
             device_id: 0x471C,
             total_size: MiB(256),
-            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, quad_io: true, four_byte_quad_out_read: true, status_reg_2: true),
+            features: (otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_quad_out_read: true, status_reg_2: true, fast_read_qout: true, fast_read_qpi4b: true, wrsr_ewsr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 65536)]),
@@ -850,7 +907,8 @@
             name: "GD55B02GF",
             device_id: 0x401C,
             total_size: MiB(256),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_quad_out_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 65536)]),

--- a/crates/rflasher-chips/data/vendors/issi.ron
+++ b/crates/rflasher-chips/data/vendors/issi.ron
@@ -78,11 +78,15 @@
             ],
         ),
         // IS25WP series - Wide voltage range
+        // NOTE: flashprog encodes no multi-IO modes and no QE register for
+        // the IS25WP family (IS25WP032/064 are WRSR_WREN|OTP only); the quad
+        // flags formerly claimed here are removed for family parity. Kept
+        // minimal deliberately: no reference entry exists for IS25WP016D.
         (
             name: "IS25WP016D",
             device_id: 0x7015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -95,7 +99,7 @@
             name: "IS25WP032",
             device_id: 0x7016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -110,7 +114,7 @@
             name: "IS25WP064",
             device_id: 0x7017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -125,7 +129,7 @@
             name: "IS25WP128",
             device_id: 0x7018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -140,7 +144,7 @@
             name: "IS25WP256",
             device_id: 0x7019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, ext_addr_reg_c5c8: true, four_byte_enter_ear7: true, ext_addr_reg_1716: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (wrsr_wren: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, ext_addr_reg_c5c8: true, four_byte_enter_ear7: true, ext_addr_reg_1716: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),

--- a/crates/rflasher-chips/data/vendors/macronix.ron
+++ b/crates/rflasher-chips/data/vendors/macronix.ron
@@ -114,7 +114,7 @@
             name: "MX25L1605D",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true),
+            features: (wrsr_wren: true, fast_read: true, fast_read_dio: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -128,7 +128,8 @@
             name: "MX25L1635D",
             device_id: 0x2415,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_qio: true, fast_read_dio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -142,7 +143,8 @@
             name: "MX25L1635E",
             device_id: 0x2515,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_qio: true, fast_read_dio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -184,7 +186,7 @@
             name: "MX25L3205D",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, otp: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, fast_read_dio: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -198,7 +200,7 @@
             name: "MX25L3206E",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, otp: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -213,7 +215,8 @@
             name: "MX25L3233F",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -228,7 +231,8 @@
             name: "MX25L3235D",
             device_id: 0x5E16,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_qio: true, fast_read_dio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -242,7 +246,7 @@
             name: "MX25L6405",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),
@@ -255,7 +259,7 @@
             name: "MX25L6405D",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true),
+            features: (wrsr_wren: true, fast_read: true, fast_read_dio: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -269,7 +273,7 @@
             name: "MX25L6406E",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, otp: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -283,7 +287,8 @@
             name: "MX25L6436E",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -298,7 +303,7 @@
             name: "MX25L6495F",
             device_id: 0x9517,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -327,7 +332,8 @@
             name: "MX25L12833F",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -342,7 +348,8 @@
             name: "MX25L25635F",
             device_id: 0x2019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true, fast_read_dout: true, fast_read_dio: true, fast_read_qout: true, fast_read_qio: true, fast_read_qpi4b: true, qpi_35_f5: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -357,7 +364,7 @@
             name: "MX66L51235F",
             device_id: 0x201A,
             total_size: MiB(64),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, ext_addr_reg_c5c8: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, ext_addr_reg_c5c8: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -372,7 +379,7 @@
             name: "MX66L1G45G",
             device_id: 0x201B,
             total_size: MiB(128),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, ext_addr_reg_c5c8: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, ext_addr_reg_c5c8: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 32768)]),
@@ -388,7 +395,8 @@
             name: "MX25U8032E",
             device_id: 0x2534,
             total_size: MiB(1),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_qio: true, fast_read_dio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -403,7 +411,8 @@
             name: "MX25U1635E",
             device_id: 0x2535,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_qio: true, qpi_35_f5: true, fast_read_dio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -418,7 +427,8 @@
             name: "MX25U3235E",
             device_id: 0x2536,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, qpi_35_f5: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -433,7 +443,8 @@
             name: "MX25U6435E",
             device_id: 0x2537,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, qpi_35_f5: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -448,7 +459,8 @@
             name: "MX25U12835F",
             device_id: 0x2538,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, qpi_35_f5: true, fast_read_dout: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -463,7 +475,8 @@
             name: "MX25U25635F",
             device_id: 0x2539,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, qe_sr2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true, fast_read_dout: true, fast_read_qpi4b: true, fast_read_qout: true, qpi_35_f5: true, fast_read_dio: true, fast_read_qio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -478,7 +491,8 @@
             name: "MX25U51245G",
             device_id: 0x253A,
             total_size: MiB(64),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, qe_sr2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true, fast_read_dout: true, fast_read_qpi4b: true, fast_read_qout: true, qpi_35_f5: true, fast_read_dio: true, fast_read_qio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -495,7 +509,8 @@
             name: "MX25R3235F",
             device_id: 0x2816,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -510,7 +525,8 @@
             name: "MX25R6435F",
             device_id: 0x2817,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -525,7 +541,7 @@
             name: "MX25L1005(C)/MX25L1006E",
             device_id: 0x2011,
             total_size: KiB(128),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -539,7 +555,8 @@
             name: "MX25L12833F/MX25L12835F/MX25L12845E/MX25L12865E/MX25L12873F",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read: true, fast_read_qio: true, fast_read_dio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -554,7 +571,7 @@
             name: "MX25L1605A/MX25L1606E/MX25L1608E",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true),
+            features: (wrsr_wren: true, otp: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -569,7 +586,7 @@
             name: "MX25L1605D/MX25L1608D/MX25L1673E",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true, fast_read_dio: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -583,7 +600,7 @@
             name: "MX25L2005(C)/MX25L2006E",
             device_id: 0x2012,
             total_size: KiB(256),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -598,7 +615,8 @@
             name: "MX25L25635F/MX25L25645G",
             device_id: 0x2019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, dual_io: true, quad_io: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, fast_read_dout: true, fast_read_qpi4b: true, fast_read: true, fast_read_qout: true, qpi_35_f5: true, fast_read_dio: true, fast_read_qio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -613,7 +631,7 @@
             name: "MX25L3205(A)",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(64), count: 64)]),
@@ -627,7 +645,7 @@
             name: "MX25L3205D/MX25L3208D",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true),
+            features: (wrsr_wren: true, otp: true, fast_read: true, fast_read_dio: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -641,7 +659,7 @@
             name: "MX25L3206E/MX25L3208E",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true),
+            features: (wrsr_wren: true, otp: true, fast_read: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -656,7 +674,8 @@
             name: "MX25L3233F/MX25L3273E",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -671,7 +690,7 @@
             name: "MX25L4005(A/C)/MX25L4006E",
             device_id: 0x2013,
             total_size: KiB(512),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -686,7 +705,7 @@
             name: "MX25L512(E)/MX25V512(C)",
             device_id: 0x2010,
             total_size: KiB(64),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -701,7 +720,7 @@
             name: "MX25L6406E/MX25L6408E",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true),
+            features: (wrsr_wren: true, otp: true, fast_read: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -716,7 +735,8 @@
             name: "MX25L6436E/MX25L6445E/MX25L6465E/MX25L6473E/MX25L6473F",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true),
+            features: (wrsr_wren: true, otp: true, fast_read: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -731,7 +751,7 @@
             name: "MX25L8005/MX25L8006E/MX25L8008E/MX25V8005",
             device_id: 0x2014,
             total_size: MiB(1),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -746,7 +766,8 @@
             name: "MX25U3235E/F",
             device_id: 0x2536,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read: true, fast_read_qio: true, qpi_35_f5: true, fast_read_dio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -761,7 +782,8 @@
             name: "MX25U6435E/F",
             device_id: 0x2537,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read: true, fast_read_qio: true, qpi_35_f5: true, fast_read_dio: true),
+            qe_method: Sr1Bit6,
             voltage: (min: 1650, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),

--- a/crates/rflasher-chips/data/vendors/micron.ron
+++ b/crates/rflasher-chips/data/vendors/micron.ron
@@ -277,7 +277,7 @@
             name: "N25Q016",
             device_id: 0xBB15,
             total_size: MiB(2),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -289,7 +289,7 @@
             name: "N25Q032",
             device_id: 0xBA16,
             total_size: MiB(4),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -302,7 +302,7 @@
             name: "N25Q032..1E",
             device_id: 0xBB16,
             total_size: MiB(4),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -314,7 +314,7 @@
             name: "N25Q064",
             device_id: 0xBA17,
             total_size: MiB(8),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -327,7 +327,7 @@
             name: "N25Q064..1E",
             device_id: 0xBB17,
             total_size: MiB(8),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -339,7 +339,7 @@
             name: "N25Q128",
             device_id: 0xBA18,
             total_size: MiB(16),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -352,7 +352,7 @@
             name: "N25Q128..1E",
             device_id: 0xBB18,
             total_size: MiB(16),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -364,7 +364,7 @@
             name: "N25Q256",
             device_id: 0xBA19,
             total_size: MiB(32),
-            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (wrsr_wren: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -377,7 +377,7 @@
             name: "N25Q256..1E",
             device_id: 0xBB19,
             total_size: MiB(32),
-            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (wrsr_wren: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -389,7 +389,7 @@
             name: "N25Q512",
             device_id: 0xBA20,
             total_size: MiB(64),
-            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (wrsr_wren: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -402,7 +402,7 @@
             name: "N25Q512..1G",
             device_id: 0xBB20,
             total_size: MiB(64),
-            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (wrsr_wren: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -415,7 +415,7 @@
             name: "MT25QL128",
             device_id: 0xBA18,
             total_size: MiB(16),
-            features: (wrsr_wren: true, quad_io: true),
+            features: (wrsr_wren: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -428,7 +428,7 @@
             name: "MT25QL256",
             device_id: 0xBA19,
             total_size: MiB(32),
-            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (wrsr_wren: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -442,7 +442,7 @@
             name: "MT25QL512",
             device_id: 0xBA20,
             total_size: MiB(64),
-            features: (wrsr_wren: true, quad_io: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (wrsr_wren: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -557,7 +557,7 @@
             name: "N25Q00A..1G",
             device_id: 0xBB21,
             total_size: MiB(128),
-            features: (wrsr_wren: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
             voltage: (min: 1700, max: 2000),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 32768)]),
@@ -569,7 +569,7 @@
             name: "N25Q00A..3G",
             device_id: 0xBA21,
             total_size: MiB(128),
-            features: (wrsr_wren: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 32768)]),

--- a/crates/rflasher-chips/data/vendors/puya.ron
+++ b/crates/rflasher-chips/data/vendors/puya.ron
@@ -9,7 +9,8 @@
             name: "P25Q05H",
             device_id: 0x6010,
             total_size: KiB(64),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 256)]),
@@ -24,7 +25,8 @@
             name: "P25Q06H",
             device_id: 0x4010,
             total_size: KiB(64),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 256)]),
@@ -39,7 +41,8 @@
             name: "P25Q10H",
             device_id: 0x6011,
             total_size: KiB(128),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 512)]),
@@ -54,7 +57,8 @@
             name: "P25Q11H",
             device_id: 0x4011,
             total_size: KiB(128),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 512)]),
@@ -69,7 +73,8 @@
             name: "P25Q20H",
             device_id: 0x6012,
             total_size: KiB(256),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 1024)]),
@@ -84,7 +89,8 @@
             name: "P25Q21H",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 1024)]),
@@ -99,7 +105,8 @@
             name: "P25Q40H",
             device_id: 0x6013,
             total_size: KiB(512),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 2048)]),
@@ -114,7 +121,8 @@
             name: "P25Q40SH",
             device_id: 0x6013,
             total_size: KiB(512),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 2048)]),
@@ -129,7 +137,8 @@
             name: "P25Q80H",
             device_id: 0x6014,
             total_size: MiB(1),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 4096)]),
@@ -144,7 +153,8 @@
             name: "P25Q80SH",
             device_id: 0x6014,
             total_size: MiB(1),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 4096)]),
@@ -159,7 +169,8 @@
             name: "P25Q16H",
             device_id: 0x6015,
             total_size: MiB(2),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 8192)]),
@@ -174,7 +185,8 @@
             name: "P25Q16SH",
             device_id: 0x6015,
             total_size: MiB(2),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 8192)]),
@@ -189,7 +201,8 @@
             name: "P25Q32H",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (otp: true, qpi: true),
+            features: (otp: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 16384)]),
@@ -204,7 +217,8 @@
             name: "P25Q32SH",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (otp: true, qpi: true),
+            features: (otp: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 16384)]),
@@ -219,7 +233,8 @@
             name: "P25Q64H",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (otp: true, qpi: true),
+            features: (otp: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 32768)]),
@@ -234,7 +249,8 @@
             name: "P25Q64SH",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (otp: true, qpi: true),
+            features: (otp: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 32768)]),
@@ -249,7 +265,8 @@
             name: "P25Q128H",
             device_id: 0x6018,
             total_size: MiB(16),
-            features: (otp: true, qpi: true),
+            features: (otp: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x81, regions: [(size: B(256), count: 65536)]),
@@ -264,7 +281,8 @@
             name: "PY25Q40HB",
             device_id: 0x2013,
             total_size: KiB(512),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -278,7 +296,8 @@
             name: "PY25Q80HB",
             device_id: 0x2014,
             total_size: MiB(1),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -292,7 +311,8 @@
             name: "PY25Q16HB",
             device_id: 0x2015,
             total_size: MiB(2),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -306,7 +326,8 @@
             name: "PY25Q32HB",
             device_id: 0x2016,
             total_size: MiB(4),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -320,7 +341,8 @@
             name: "PY25Q64HA",
             device_id: 0x2017,
             total_size: MiB(8),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -334,7 +356,8 @@
             name: "PY25F64HA",
             device_id: 0x2317,
             total_size: MiB(8),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -348,7 +371,8 @@
             name: "PY25Q128HA",
             device_id: 0x2018,
             total_size: MiB(16),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -362,7 +386,8 @@
             name: "PY25F128HA/PY25R128HA",
             device_id: 0x2318,
             total_size: MiB(16),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -376,7 +401,8 @@
             name: "PY25Q256HB",
             device_id: 0x2019,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -390,7 +416,8 @@
             name: "PY25F256HB",
             device_id: 0x2319,
             total_size: MiB(32),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -404,7 +431,8 @@
             name: "PY25Q512HB",
             device_id: 0x201A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -418,7 +446,8 @@
             name: "PY25F512HB",
             device_id: 0x231A,
             total_size: MiB(64),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -432,7 +461,8 @@
             name: "PY25Q01GHB",
             device_id: 0x201B,
             total_size: MiB(128),
-            features: (otp: true, four_byte_addr: true, qpi: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, dual_io: true, quad_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true),
+            features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, fast_read: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, wrsr_ext: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qpi4b: true, qpi_38_ff: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 32768)]),

--- a/crates/rflasher-chips/data/vendors/spansion.ron
+++ b/crates/rflasher-chips/data/vendors/spansion.ron
@@ -129,7 +129,7 @@
             name: "S25FL116K",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, otp: true, quad_io: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -143,7 +143,7 @@
             name: "S25FL132K",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, quad_io: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -157,7 +157,7 @@
             name: "S25FL164K",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, quad_io: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),

--- a/crates/rflasher-chips/data/vendors/sst.ron
+++ b/crates/rflasher-chips/data/vendors/sst.ron
@@ -47,7 +47,7 @@
             name: "SST25VF512A",
             device_id: 0x4800,
             total_size: KiB(64),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),
@@ -72,7 +72,7 @@
             name: "SST25VF010A",
             device_id: 0x4900,
             total_size: KiB(128),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -486,7 +486,7 @@
             name: "SST26VF064B",
             device_id: 0x2603,
             total_size: MiB(8),
-            features: (wrsr_wren: true, quad_io: true, otp: true, sst26_bpr: true),
+            features: (wrsr_wren: true, otp: true, sst26_bpr: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),

--- a/crates/rflasher-chips/data/vendors/winbond.ron
+++ b/crates/rflasher-chips/data/vendors/winbond.ron
@@ -10,7 +10,8 @@
             name: "W25Q16.V",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -25,7 +26,8 @@
             name: "W25Q32.V",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -40,7 +42,8 @@
             name: "W25Q64.V",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -55,7 +58,8 @@
             name: "W25Q128.V",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_sec: true, wp_cmp: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, wp_tb: true, wp_sec: true, wp_cmp: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -70,7 +74,8 @@
             name: "W25Q256JV_Q",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_cmp: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, wp_tb: true, wp_cmp: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true, fast_read_qout: true, fast_read_dout: true, fast_read_dio: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -86,14 +91,14 @@
             device_id: 0x4020,
             total_size: MiB(64),
             features: (
-                wrsr_wren: true, wrsr_ext: true, fast_read: true, dual_io: true, quad_io: true, otp: true,
+                wrsr_wren: true, wrsr_ext: true, fast_read: true, otp: true,
                 four_byte_addr: true, four_byte_enter: true, ext_addr_reg_c5c8: true,
                 four_byte_native: true, four_byte_read: true, four_byte_fast_read: true,
                 four_byte_program: true, four_byte_dual_out_read: true,
                 four_byte_dual_io_read: true, four_byte_quad_out_read: true,
-                four_byte_quad_io_read: true, status_reg_2: true, status_reg_3: true,
-                qe_sr2: true,
-            ),
+                four_byte_quad_io_read: true, status_reg_2: true, status_reg_3: true,fast_read_dout: true, fast_read_dio: true, fast_read_qout: true, fast_read_qio: true,
+                ),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -110,7 +115,8 @@
             name: "W25Q16.W",
             device_id: 0x6015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -125,7 +131,8 @@
             name: "W25Q32.W",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -140,7 +147,8 @@
             name: "W25Q64.W",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -155,7 +163,8 @@
             name: "W25Q128.W",
             device_id: 0x6018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dio: true, fast_read_qio: true, fast_read_qout: true, fast_read_dout: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -170,7 +179,8 @@
             name: "W25Q256JW",
             device_id: 0x6019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, status_reg_3: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true, fast_read_qout: true, fast_read_dout: true, fast_read_dio: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -187,7 +197,8 @@
             name: "W25Q32JV_M",
             device_id: 0x7016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true, qpi_38_ff: true, set_read_params: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -202,7 +213,8 @@
             name: "W25Q64JV_M",
             device_id: 0x7017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true, qpi_38_ff: true, set_read_params: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -217,7 +229,8 @@
             name: "W25Q128JV_M",
             device_id: 0x7018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dio: true, fast_read_dout: true, fast_read_qout: true, fast_read_qio: true, qpi_38_ff: true, set_read_params: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -232,7 +245,8 @@
             name: "W25Q256JV_M",
             device_id: 0x7019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, dual_io: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, qe_sr2: true, wp_tb: true, wp_cmp: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, four_byte_native: true, status_reg_2: true, wp_tb: true, wp_cmp: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, ext_addr_reg_c5c8: true, fast_read_dout: true, set_read_params: true, qpi_38_ff: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -249,7 +263,7 @@
             name: "W25X10",
             device_id: 0x3011,
             total_size: KiB(128),
-            features: (wrsr_wren: true, fast_read: true),
+            features: (wrsr_wren: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 32)]),
@@ -262,7 +276,7 @@
             name: "W25X20",
             device_id: 0x3012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, fast_read: true),
+            features: (wrsr_wren: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -275,7 +289,7 @@
             name: "W25X40",
             device_id: 0x3013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, fast_read: true),
+            features: (wrsr_wren: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -288,7 +302,7 @@
             name: "W25X80",
             device_id: 0x3014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, fast_read: true),
+            features: (wrsr_wren: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -301,7 +315,7 @@
             name: "W25X16",
             device_id: 0x3015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, fast_read: true),
+            features: (wrsr_wren: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -314,7 +328,7 @@
             name: "W25X32",
             device_id: 0x3016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true),
+            features: (wrsr_wren: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -327,7 +341,7 @@
             name: "W25X64",
             device_id: 0x3017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true),
+            features: (wrsr_wren: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -373,7 +387,8 @@
             name: "W25Q128.V..M",
             device_id: 0x7018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -388,7 +403,8 @@
             name: "W25Q128.JW.DTR",
             device_id: 0x8018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -403,7 +419,8 @@
             name: "W25Q16JV_M",
             device_id: 0x7015,
             total_size: MiB(2),
-            features: (otp: true, qpi: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -417,7 +434,8 @@
             name: "W25Q20.W",
             device_id: 0x5012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -431,7 +449,8 @@
             name: "W25Q256FV",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_read: true, four_byte_fast_read: true, fast_read_dout: true, set_read_params: true, qpi_38_ff: true, fast_read: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 8192)]),
@@ -446,7 +465,8 @@
             name: "W25Q256JW_DTR",
             device_id: 0x8019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, status_reg_2: true, status_reg_3: true, dual_io: true, quad_io: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, status_reg_2: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, qpi_38_ff: true, fast_read: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -459,7 +479,8 @@
             name: "W25Q32BV/W25Q32CV/W25Q32DV",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -474,7 +495,8 @@
             name: "W25Q32FV",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -489,7 +511,8 @@
             name: "W25Q32JV",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -504,7 +527,8 @@
             name: "W25Q32JV-.M",
             device_id: 0x7016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -519,7 +543,8 @@
             name: "W25Q32BW/W25Q32CW/W25Q32DW",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -534,7 +559,8 @@
             name: "W25Q32FW",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -549,7 +575,8 @@
             name: "W25Q32JW...Q",
             device_id: 0x6016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -564,7 +591,8 @@
             name: "W25Q32JW...M",
             device_id: 0x8016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -579,7 +607,8 @@
             name: "W25Q40.V",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -594,7 +623,8 @@
             name: "W25Q40BW",
             device_id: 0x5013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -609,7 +639,8 @@
             name: "W25Q40EW",
             device_id: 0x6013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -639,7 +670,8 @@
             name: "W25Q512NW-IM",
             device_id: 0x8020,
             total_size: MiB(64),
-            features: (wrsr_wren: true, otp: true, four_byte_addr: true, qpi: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, status_reg_2: true, status_reg_3: true, dual_io: true, quad_io: true),
+            features: (wrsr_wren: true, otp: true, four_byte_addr: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, status_reg_2: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, qpi_38_ff: true, fast_read: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -652,7 +684,8 @@
             name: "W25Q64BV/W25Q64CV/W25Q64FV",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -667,7 +700,8 @@
             name: "W25Q64JV-.Q",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -682,7 +716,8 @@
             name: "W25Q64JV-.M",
             device_id: 0x7017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -697,7 +732,8 @@
             name: "W25Q64DW",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -712,7 +748,8 @@
             name: "W25Q64FW/W25Q64JW...Q",
             device_id: 0x6017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -727,7 +764,8 @@
             name: "W25Q64JW...M",
             device_id: 0x8017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true),
+            features: (wrsr_wren: true, otp: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -742,7 +780,8 @@
             name: "W25Q80.V",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -757,7 +796,8 @@
             name: "W25Q80BW",
             device_id: 0x5014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 1700, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -772,7 +812,8 @@
             name: "W25Q80EW",
             device_id: 0x6014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -787,7 +828,7 @@
             name: "W25X05",
             device_id: 0x3010,
             total_size: KiB(64),
-            features: (wrsr_wren: true),
+            features: (wrsr_wren: true, fast_read_dout: true),
             voltage: (min: 2300, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 16)]),

--- a/crates/rflasher-chips/data/vendors/xmc.ron
+++ b/crates/rflasher-chips/data/vendors/xmc.ron
@@ -10,7 +10,8 @@
             name: "XM25QH64C",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -24,7 +25,8 @@
             name: "XM25QH128C",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, wp_tb: true, fast_read_dout: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -38,7 +40,8 @@
             name: "XM25QH256C",
             device_id: 0x4019,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, dual_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, fast_read_dout: true, set_read_params: true, qpi_38_ff: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -54,7 +57,8 @@
             name: "XM25QU64C",
             device_id: 0x4117,
             total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -68,7 +72,8 @@
             name: "XM25QU128C",
             device_id: 0x4118,
             total_size: MiB(16),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, status_reg_3: true, qe_sr2: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, status_reg_2: true, status_reg_3: true, fast_read_dout: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -82,7 +87,8 @@
             name: "XM25QU256C",
             device_id: 0x4119,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, dual_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, fast_read_dout: true, set_read_params: true, qpi_38_ff: true, fast_read_qout: true, fast_read_dio: true, fast_read_qio: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -98,7 +104,8 @@
             name: "XM25QH512C",
             device_id: 0x4020,
             total_size: MiB(64),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, dual_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, fast_read_dio: true, fast_read_dout: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, set_read_params: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -114,7 +121,8 @@
             name: "XM25RH256C",
             device_id: 0x4319,
             total_size: MiB(32),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, dual_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, fast_read_dio: true, fast_read_dout: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, set_read_params: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
@@ -130,7 +138,8 @@
             name: "XM25RH512C",
             device_id: 0x4320,
             total_size: MiB(64),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, dual_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, fast_read_dio: true, fast_read_dout: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, set_read_params: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
@@ -146,7 +155,8 @@
             name: "XM25QU512C",
             device_id: 0x4120,
             total_size: MiB(64),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, dual_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true),
+            features: (wrsr_wren: true, fast_read: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, fast_read_dio: true, fast_read_dout: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, set_read_params: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),

--- a/crates/rflasher-chips/data/vendors/xtx.ron
+++ b/crates/rflasher-chips/data/vendors/xtx.ron
@@ -10,7 +10,7 @@
             name: "XT25F02E",
             device_id: 0x4012,
             total_size: KiB(256),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, status_reg_2: true, fast_read: true, fast_read_dio: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 64)]),
@@ -24,7 +24,7 @@
             name: "XT25F04D",
             device_id: 0x4013,
             total_size: KiB(512),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, status_reg_2: true, fast_read: true, fast_read_dio: true, fast_read_dout: true),
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 128)]),
@@ -38,7 +38,8 @@
             name: "XT25F08B",
             device_id: 0x4014,
             total_size: MiB(1),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, status_reg_2: true, qe_sr2: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, status_reg_2: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
@@ -52,7 +53,8 @@
             name: "XT25F16B",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, otp: true, status_reg_2: true, wp_tb: true, fast_read_dout: true, fast_read: true, fast_read_qio: true, fast_read_qout: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -66,7 +68,8 @@
             name: "XT25F32B",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, otp: true, status_reg_2: true, wp_tb: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -80,7 +83,8 @@
             name: "XT25F64B",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, otp: true, status_reg_2: true, wp_tb: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -94,7 +98,8 @@
             name: "XT25F128B",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (wrsr_wren: true, wrsr_ewsr: true, quad_io: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true, wp_tb: true),
+            features: (wrsr_wren: true, wrsr_ewsr: true, otp: true, status_reg_2: true, wp_tb: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
@@ -108,7 +113,8 @@
             name: "XT25F16F",
             device_id: 0x4015,
             total_size: MiB(2),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read: true, fast_read_qout: true, fast_read_dout: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 512)]),
@@ -122,7 +128,8 @@
             name: "XT25F32F",
             device_id: 0x4016,
             total_size: MiB(4),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read: true, fast_read_qout: true, fast_read_dout: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
@@ -136,7 +143,8 @@
             name: "XT25F64F",
             device_id: 0x4017,
             total_size: MiB(8),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read: true, fast_read_qout: true, fast_read_dout: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -150,7 +158,8 @@
             name: "XT25F128F/XT25BF128F",
             device_id: 0x4018,
             total_size: MiB(16),
-            features: (otp: true, status_reg_2: true),
+            features: (otp: true, status_reg_2: true, fast_read: true, fast_read_qout: true, fast_read_dout: true, wrsr_ewsr: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 2700, max: 3600),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),

--- a/crates/rflasher-chips/data/vendors/zetta.ron
+++ b/crates/rflasher-chips/data/vendors/zetta.ron
@@ -37,7 +37,8 @@
             name: "ZD25LQ64",
             device_id: 0x4317,
             total_size: MiB(8),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
@@ -51,7 +52,8 @@
             name: "ZD25LQ128",
             device_id: 0x4218,
             total_size: MiB(16),
-            features: (wrsr_wren: true, otp: true, qpi: true, status_reg_2: true),
+            features: (wrsr_wren: true, otp: true, status_reg_2: true, fast_read_dout: true, fast_read: true, set_read_params: true, fast_read_qio: true, fast_read_qout: true, qpi_38_ff: true, fast_read_dio: true),
+            qe_method: Sr2Bit1WriteSr2,
             voltage: (min: 1650, max: 1950),
             erase_blocks: [
                 (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),

--- a/crates/rflasher-chips/src/lib.rs
+++ b/crates/rflasher-chips/src/lib.rs
@@ -76,8 +76,14 @@ struct FeaturesDef {
     wrsr_ewsr: bool,
     wrsr_ext: bool,
     fast_read: bool,
-    dual_io: bool,
-    quad_io: bool,
+    fast_read_dout: bool,
+    fast_read_dio: bool,
+    fast_read_qout: bool,
+    fast_read_qio: bool,
+    fast_read_qpi4b: bool,
+    qpi_35_f5: bool,
+    qpi_38_ff: bool,
+    set_read_params: bool,
     four_byte_addr: bool,
     four_byte_enter: bool,
     four_byte_native: bool,
@@ -94,7 +100,7 @@ struct FeaturesDef {
     four_byte_quad_out_read: bool,
     four_byte_quad_io_read: bool,
     otp: bool,
-    qpi: bool,
+
     security_reg: bool,
     sfdp: bool,
     write_byte: bool,
@@ -102,7 +108,7 @@ struct FeaturesDef {
     sst26_bpr: bool,
     status_reg_2: bool,
     status_reg_3: bool,
-    qe_sr2: bool,
+
     deep_power_down: bool,
     wp_tb: bool,
     wp_sec: bool,
@@ -116,8 +122,14 @@ impl From<FeaturesDef> for Features {
             (def.wrsr_ewsr, Features::WRSR_EWSR),
             (def.wrsr_ext, Features::WRSR_EXT),
             (def.fast_read, Features::FAST_READ),
-            (def.dual_io, Features::DUAL_IO),
-            (def.quad_io, Features::QUAD_IO),
+            (def.fast_read_dout, Features::FAST_READ_DOUT),
+            (def.fast_read_dio, Features::FAST_READ_DIO),
+            (def.fast_read_qout, Features::FAST_READ_QOUT),
+            (def.fast_read_qio, Features::FAST_READ_QIO),
+            (def.fast_read_qpi4b, Features::FAST_READ_QPI4B),
+            (def.qpi_35_f5, Features::QPI_35_F5),
+            (def.qpi_38_ff, Features::QPI_38_FF),
+            (def.set_read_params, Features::SET_READ_PARAMS),
             (def.four_byte_addr, Features::FOUR_BYTE_ADDR),
             (def.four_byte_enter, Features::FOUR_BYTE_ENTER),
             (def.four_byte_native, Features::FOUR_BYTE_NATIVE),
@@ -143,7 +155,6 @@ impl From<FeaturesDef> for Features {
             ),
             (def.four_byte_quad_io_read, Features::FOUR_BYTE_QUAD_IO_READ),
             (def.otp, Features::OTP),
-            (def.qpi, Features::QPI),
             (def.security_reg, Features::SECURITY_REG),
             (def.sfdp, Features::SFDP),
             (def.write_byte, Features::WRITE_BYTE),
@@ -151,7 +162,6 @@ impl From<FeaturesDef> for Features {
             (def.sst26_bpr, Features::SST26_BPR),
             (def.status_reg_2, Features::STATUS_REG_2),
             (def.status_reg_3, Features::STATUS_REG_3),
-            (def.qe_sr2, Features::QE_SR2),
             (def.deep_power_down, Features::DEEP_POWER_DOWN),
             (def.wp_tb, Features::WP_TB),
             (def.wp_sec, Features::WP_SEC),
@@ -164,6 +174,28 @@ impl From<FeaturesDef> for Features {
                 if enabled { acc | flag } else { acc }
             },
         )
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
+enum QeMethodDef {
+    #[default]
+    None,
+    Sr2Bit1WriteSr,
+    Sr2Bit1WriteSr2,
+    Sr1Bit6,
+    Sr2Bit7,
+}
+
+impl From<QeMethodDef> for QeMethod {
+    fn from(value: QeMethodDef) -> Self {
+        match value {
+            QeMethodDef::None => QeMethod::None,
+            QeMethodDef::Sr2Bit1WriteSr => QeMethod::Sr2Bit1WriteSr,
+            QeMethodDef::Sr2Bit1WriteSr2 => QeMethod::Sr2Bit1WriteSr2,
+            QeMethodDef::Sr1Bit6 => QeMethod::Sr1Bit6,
+            QeMethodDef::Sr2Bit7 => QeMethod::Sr2Bit7,
+        }
     }
 }
 
@@ -278,6 +310,18 @@ struct ChipDef {
     erase_blocks: Vec<EraseBlockDef>,
     #[serde(default)]
     tested: TestStatusesDef,
+    #[serde(default)]
+    qe_method: QeMethodDef,
+    #[serde(default)]
+    dummy_cycles_112: Option<u8>,
+    #[serde(default)]
+    dummy_cycles_122: Option<u8>,
+    #[serde(default)]
+    dummy_cycles_114: Option<u8>,
+    #[serde(default)]
+    dummy_cycles_144: Option<u8>,
+    #[serde(default)]
+    dummy_cycles_qpi: Option<u8>,
 }
 
 fn default_page_size() -> u16 {
@@ -385,6 +429,12 @@ impl ChipDatabase {
                     })
                     .collect(),
                 tested: chip_def.tested.into(),
+                qe_method: chip_def.qe_method.into(),
+                dummy_cycles_112: chip_def.dummy_cycles_112,
+                dummy_cycles_122: chip_def.dummy_cycles_122,
+                dummy_cycles_114: chip_def.dummy_cycles_114,
+                dummy_cycles_144: chip_def.dummy_cycles_144,
+                dummy_cycles_qpi: chip_def.dummy_cycles_qpi,
             };
             self.chips.push(chip);
         }
@@ -474,11 +524,15 @@ mod tests {
                     device_id: 0x4018,
                     total_size: MiB(16),
                     page_size: 256,
+                    dummy_cycles_122: Some(0),
+                    dummy_cycles_144: Some(6),
                     features: (
                         wrsr_wren: true,
                         fast_read: true,
-                        dual_io: true,
-                        quad_io: true,
+                        fast_read_dout: true,
+                        fast_read_dio: true,
+                        fast_read_qout: true,
+                        fast_read_qio: true,
                     ),
                     voltage: (min: 2700, max: 3600),
                     erase_blocks: [
@@ -505,6 +559,9 @@ mod tests {
         assert_eq!(chip.total_size, 16 * 1024 * 1024);
         assert!(chip.features.contains(Features::WRSR_WREN));
         assert!(chip.features.contains(Features::FAST_READ));
+        assert_eq!(chip.dummy_cycles_112, None);
+        assert_eq!(chip.dummy_cycles_122, Some(0));
+        assert_eq!(chip.dummy_cycles_144, Some(6));
     }
 
     #[test]

--- a/crates/rflasher-core/src/error.rs
+++ b/crates/rflasher-core/src/error.rs
@@ -76,6 +76,8 @@ pub enum Error {
     // Programmer errors
     /// Programmer is not ready (not initialized or busy)
     ProgrammerNotReady,
+    /// Uncertain flash state: explicit hardware recovery and reprobe required.
+    RecoveryRequired,
     /// General programmer error
     ProgrammerError,
     /// Requested I/O mode is not supported by the programmer
@@ -135,6 +137,7 @@ impl fmt::Display for Error {
             Self::BufferTooSmall => write!(f, "buffer too small"),
             Self::WriteProtected => write!(f, "flash chip is write protected"),
             Self::RegionProtected => write!(f, "region is protected"),
+            Self::RecoveryRequired => write!(f, "hardware recovery and reprobe required"),
             Self::ProgrammerNotReady => write!(f, "programmer not ready"),
             Self::ProgrammerError => write!(f, "programmer error"),
             Self::IoModeNotSupported => write!(f, "I/O mode not supported by programmer"),

--- a/crates/rflasher-core/src/flash/context.rs
+++ b/crates/rflasher-core/src/flash/context.rs
@@ -2,7 +2,7 @@
 
 use crate::chip::FlashChip;
 
-/// Address mode currently in use
+/// Address capacity required by the chip, not its current hardware mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AddressMode {
     /// 3-byte addressing (up to 16 MiB)
@@ -21,7 +21,7 @@ pub enum AddressMode {
 pub struct FlashContext {
     /// The identified flash chip (owned)
     pub chip: FlashChip,
-    /// Current address mode
+    /// Required address capacity (temporary modes belong to an operation)
     pub address_mode: AddressMode,
 }
 
@@ -31,7 +31,7 @@ pub struct FlashContext {
 pub struct FlashContext {
     /// The identified flash chip (static reference)
     pub chip: &'static FlashChip,
-    /// Current address mode
+    /// Required address capacity (temporary modes belong to an operation)
     pub address_mode: AddressMode,
 }
 

--- a/crates/rflasher-core/src/flash/hybrid_device.rs
+++ b/crates/rflasher-core/src/flash/hybrid_device.rs
@@ -1,302 +1,194 @@
-//! Hybrid flash device adapter
-//!
-//! This module provides `HybridFlashDevice`, an adapter for programmers that
-//! implement both `SpiMaster` (for probe, erase, status, write protection) and
-//! `OpaqueMaster` (for fast bulk read/write via hardware-accelerated paths).
-//!
-//! This is the natural fit for programmers like the Dediprog SF-series, which
-//! support generic SPI command pass-through (`CMD_TRANSCEIVE`) for arbitrary
-//! opcodes, but also have dedicated firmware commands (`CMD_READ`/`CMD_WRITE`)
-//! that handle SPI flash protocols internally with USB bulk transfers for
-//! dramatically higher throughput.
-//!
-//! # Architecture
-//!
-//! ```text
-//!   FlashDevice::read()  ──► OpaqueMaster::read()   (CMD_READ + bulk IN)
-//!   FlashDevice::write() ──► OpaqueMaster::write()   (CMD_WRITE + bulk OUT)
-//!   FlashDevice::erase() ──► SpiMaster (WREN + SE/BE + RDSR polling)
-//!   FlashDevice::wp_*()  ──► SpiMaster (status register access)
-//! ```
-
+//! HybridFlashDevice: operation-scoped SPI flash access.
 use crate::chip::{EraseBlock, WriteGranularity};
 use crate::error::{Error, Result};
-use crate::flash::context::{AddressMode, FlashContext};
-use crate::flash::device::FlashDevice;
-use crate::flash::operations::{
-    addressing_for_4byte_operation, check_erased_range, select_erase_block,
-};
-use crate::programmer::{OpaqueMaster, SpiFeatures, SpiMaster};
-use crate::protocol::{self, CommandAddressing};
-#[cfg(feature = "alloc")]
+use crate::flash::io::{self, IoLifecycle};
+use crate::flash::{FlashContext, FlashDevice};
+use crate::programmer::{OpaqueMaster, SpiMaster};
+use crate::protocol;
 use crate::wp::{
     self, RangeDecoder, WpBits, WpConfig, WpMode, WpRange, WpRegBitMap, WpResult, WriteOptions,
 };
 
-/// Flash device adapter for hybrid programmers (SpiMaster + OpaqueMaster)
-///
-/// Uses `OpaqueMaster` for bulk read/write (fast path) and `SpiMaster` for
-/// everything else (probe, erase, status registers, write protection).
-///
-/// # Example
-///
-/// ```ignore
-/// use rflasher_core::flash::{HybridFlashDevice, probe};
-/// use rflasher_core::chip::ChipProvider;
-/// use rflasher_programmers::dediprog::Dediprog;
-///
-/// let mut master = Dediprog::open().unwrap();
-/// let ctx = probe(&mut master, &db).unwrap();
-/// master.set_flash_size(ctx.total_size() as u32);
-/// let mut device = HybridFlashDevice::new(master, ctx);
-/// ```
+/// Adapter assuming an externally established ordinary-SPI, three-byte baseline.
+/// Probe does not reset the chip. After cancellation/failed cleanup, explicitly
+/// recover the hardware and reprobe; USB disconnect alone is not recovery.
 pub struct HybridFlashDevice<M: SpiMaster + OpaqueMaster> {
-    /// Owned master (implements both SpiMaster and OpaqueMaster)
     master: M,
-    /// Flash chip context (from probing via SpiMaster)
     ctx: FlashContext,
+    lifecycle: IoLifecycle,
 }
-
 impl<M: SpiMaster + OpaqueMaster> HybridFlashDevice<M> {
-    /// Create a new hybrid flash device adapter
-    ///
-    /// # Arguments
-    /// * `master` - The programmer (must implement both SpiMaster and OpaqueMaster)
-    /// * `ctx` - Flash context with chip metadata (from probing via SpiMaster)
+    /// Construct on a known idle ordinary-SPI, three-byte baseline.
     pub fn new(master: M, ctx: FlashContext) -> Self {
-        HybridFlashDevice { master, ctx }
+        Self {
+            master,
+            ctx,
+            lifecycle: IoLifecycle::default(),
+        }
     }
-
-    /// Get a mutable reference to the underlying master
+    /// Low-level escape: caller owns hardware recovery if the adapter is latched.
     pub fn master(&mut self) -> &mut M {
         &mut self.master
     }
-
-    /// Get a reference to the flash context
+    /// Chip metadata; this does not describe temporary hardware state.
     pub fn context(&self) -> &FlashContext {
         &self.ctx
     }
-
-    /// Get a mutable reference to the flash context
+    /// Mutable chip metadata, not a hardware recovery mechanism.
     pub fn context_mut(&mut self) -> &mut FlashContext {
         &mut self.ctx
     }
-
-    /// Consume the adapter and return the flash context
+    /// Whether explicit hardware recovery and reprobe are required.
+    pub fn recovery_required(&self) -> bool {
+        self.lifecycle.recovery_required()
+    }
+    /// Consume the adapter, discarding its master.
     pub fn into_context(self) -> FlashContext {
         self.ctx
     }
-
-    /// Consume the adapter and return both the master and flash context
+    /// Low-level escape, not recovery. Do not reconstruct an adapter on uncertain hardware.
     pub fn into_parts(self) -> (M, FlashContext) {
         (self.master, self.ctx)
     }
 }
-
 impl<M: SpiMaster + OpaqueMaster> FlashDevice for HybridFlashDevice<M> {
     fn size(&self) -> u32 {
         self.ctx.total_size() as u32
     }
-
     fn erase_granularity(&self) -> u32 {
         self.ctx.chip.min_erase_size().unwrap_or(4096)
     }
-
     fn write_granularity(&self) -> WriteGranularity {
         self.ctx.chip.write_granularity
     }
-
     fn erase_blocks(&self) -> &[EraseBlock] {
         self.ctx.chip.erase_blocks()
     }
-
     fn page_size(&self) -> u32 {
         self.ctx.page_size() as u32
     }
-
-    // Write protection support (delegates to SpiMaster, same as SpiFlashDevice)
     #[cfg(feature = "alloc")]
     fn wp_supported(&self) -> bool {
         true
     }
-
     #[cfg(feature = "alloc")]
     async fn read_wp_config(&mut self) -> WpResult<WpConfig> {
         HybridFlashDevice::read_wp_config(self).await
     }
-
     #[cfg(feature = "alloc")]
     async fn write_wp_config(&mut self, config: &WpConfig, options: WriteOptions) -> WpResult<()> {
         HybridFlashDevice::write_wp_config(self, config, options).await
     }
-
     #[cfg(feature = "alloc")]
     async fn set_wp_mode(&mut self, mode: WpMode, options: WriteOptions) -> WpResult<()> {
         HybridFlashDevice::set_wp_mode(self, mode, options).await
     }
-
     #[cfg(feature = "alloc")]
     async fn set_wp_range(&mut self, range: &WpRange, options: WriteOptions) -> WpResult<()> {
         HybridFlashDevice::set_wp_range(self, range, options).await
     }
-
     #[cfg(feature = "alloc")]
     async fn disable_wp(&mut self, options: WriteOptions) -> WpResult<()> {
         HybridFlashDevice::disable_wp(self, options).await
     }
-
     #[cfg(feature = "alloc")]
     fn get_available_wp_ranges(&self) -> alloc::vec::Vec<WpRange> {
         HybridFlashDevice::get_available_wp_ranges(self)
     }
 
-    // =========================================================================
-    // Read/Write: use OpaqueMaster (fast bulk path)
-    // =========================================================================
-
     async fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
-        let ctx = self.context();
-        if !ctx.is_valid_range(addr, buf.len()) {
+        self.lifecycle.check()?;
+        if !self.ctx.is_valid_range(addr, buf.len()) {
             return Err(Error::AddressOutOfBounds);
         }
-
-        // OpaqueMaster::read handles alignment splitting internally
-        OpaqueMaster::read(&mut self.master, addr, buf).await
-    }
-
-    async fn write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
-        let ctx = self.context();
-        if !ctx.is_valid_range(addr, data.len()) {
-            return Err(Error::AddressOutOfBounds);
-        }
-
-        // OpaqueMaster::write handles alignment splitting internally
-        OpaqueMaster::write(&mut self.master, addr, data).await
-    }
-
-    // =========================================================================
-    // Erase: try OpaqueMaster first, fall back to SpiMaster
-    //
-    // Following flashprog's architecture: erase is a first-class operation
-    // on the opaque interface. Programmers with firmware-accelerated erase
-    // (e.g., SPI_CMD_SPINOR_WAIT) implement OpaqueMaster::erase(). Those
-    // without (e.g., Dediprog) return Err, triggering the SPI fallback.
-    // =========================================================================
-
-    async fn erase(&mut self, addr: u32, len: u32) -> Result<()> {
-        // Bounds check (borrow ctx briefly, then drop before mutable borrow)
-        if !self.context().is_valid_range(addr, len as usize) {
-            return Err(Error::AddressOutOfBounds);
-        }
-
-        // Try opaque erase first — the programmer handles everything internally
-        // (block selection, busy-wait, etc.). If it returns Ok, we're done.
-        // Programmers without firmware erase (e.g., Dediprog) return Err,
-        // triggering the SPI fallback below.
-        if OpaqueMaster::erase(&mut self.master, addr, len)
+        let (plan, accelerated) = match io::select_read_plan(&self.master, &self.ctx, false, |p| {
+            self.master.supports_read_plan(p)
+        }) {
+            Ok(plan) => (plan, true),
+            Err(Error::ChipNotSupported) => {
+                log::debug!(
+                    "No representable bulk read plan; selecting single-I/O SPI before setup"
+                );
+                (
+                    io::select_read_plan(&self.master, &self.ctx, true, |_| true)?,
+                    false,
+                )
+            }
+            Err(error) => return Err(error),
+        };
+        self.lifecycle
+            .run(&mut self.master, plan.address, plan.qe, async |master| {
+                if !accelerated {
+                    return io::read_spi(master, &plan, addr, buf).await;
+                }
+                master
+                    .read_planned(&plan, addr, buf)
+                    .await
+                    .map_err(|error| {
+                        log::error!(
+                            "firmware transfer failed: {error:?}; hardware recovery required"
+                        );
+                        Error::RecoveryRequired
+                    })
+            })
             .await
-            .is_ok()
-        {
-            return Ok(());
+    }
+    async fn write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
+        self.lifecycle.check()?;
+        if !self.ctx.is_valid_range(addr, data.len()) {
+            return Err(Error::AddressOutOfBounds);
         }
-
-        // Opaque erase not supported — fall back to SPI-based erase.
-        // NOTE: OpaqueMaster::erase cannot distinguish "unsupported" from a
-        // genuine mid-erase failure; the SPI fallback retries the whole range
-        // either way, which is safe for flash (erase is idempotent) but means
-        // opaque hardware errors are not surfaced here.
-        // SST26 chips use a per-block protection register (not SR BP bits).
-        // A global unlock (WREN + ULBPR 0x98) is required before any erase
-        // succeeds — same as SpiFlashDevice::erase.
-        let needs_sst26_unprotect = self
-            .context()
+        let plan = io::select_write_plan(&self.master, &self.ctx, |p| {
+            self.master.supports_write_plan(p)
+        })?;
+        self.lifecycle
+            .run(
+                &mut self.master,
+                plan.address,
+                protocol::QuadEnableMethod::None,
+                async |master| {
+                    master
+                        .write_planned(&plan, addr, data)
+                        .await
+                        .map_err(|error| {
+                            log::error!(
+                                "firmware transfer failed: {error:?}; hardware recovery required"
+                            );
+                            Error::RecoveryRequired
+                        })
+                },
+            )
+            .await
+    }
+    async fn erase(&mut self, addr: u32, len: u32) -> Result<()> {
+        self.lifecycle.check()?;
+        if !self.ctx.is_valid_range(addr, len as usize) {
+            return Err(Error::AddressOutOfBounds);
+        }
+        let plan = io::select_erase_plan(&self.master, &self.ctx, addr, len)?;
+        let verify_plan = io::select_read_plan(&self.master, &self.ctx, true, |_| true)?;
+        let unprotect = self
+            .ctx
             .chip
             .features
             .contains(crate::chip::Features::SST26_BPR);
-        if needs_sst26_unprotect {
-            protocol::sst26_global_unprotect(&mut self.master).await?;
-        }
-
-        let ctx = self.context();
-        let erase_block = select_erase_block(ctx.chip.erase_blocks(), addr, len)
-            .ok_or(Error::InvalidAlignment)?;
-
-        let chip_features = ctx.chip.features;
-        let use_4byte = ctx.address_mode == AddressMode::FourByte;
-        let master_features = self.master.features();
-        let use_native = use_4byte
-            && erase_block.opcode_4b.is_some_and(|opcode| {
-                master_features.contains(SpiFeatures::FOUR_BYTE_ADDR)
-                    && self.master.probe_opcode(opcode)
-            });
-        let opcode = erase_block.opcode_for_address_width(use_native);
-        let (addressing, enter_exit_4byte) = if use_4byte {
-            addressing_for_4byte_operation(use_native, chip_features, master_features)?
-        } else {
-            (CommandAddressing::ThreeByte, false)
-        };
-
-        if enter_exit_4byte {
-            protocol::enter_4byte_mode_with_features(self.master(), chip_features).await?;
-        }
-
-        let mut current_addr = addr;
-        let end_addr = addr + len;
-        let max_block_size = erase_block.max_block_size();
-
-        let (poll_delay_us, timeout_us) = match max_block_size {
-            s if s <= 4096 => (10_000, 1_000_000),
-            s if s <= 32768 => (100_000, 4_000_000),
-            s if s <= 65536 => (100_000, 4_000_000),
-            _ => (500_000, 60_000_000),
-        };
-
-        while current_addr < end_addr {
-            let offset_in_layout = current_addr - addr;
-            let block_size = erase_block
-                .block_size_at_offset(offset_in_layout)
-                .unwrap_or(max_block_size);
-
-            let result = protocol::erase_block(
-                self.master(),
-                opcode,
-                current_addr,
-                addressing,
-                poll_delay_us,
-                timeout_us,
-            )
-            .await;
-
-            if result.is_err() {
-                if enter_exit_4byte
-                    && let Err(e) =
-                        protocol::exit_4byte_mode_with_features(self.master(), chip_features).await
-                {
-                    log::warn!("Failed to exit 4-byte address mode: {}", e);
-                }
-                return result;
-            }
-
-            current_addr += block_size;
-        }
-
-        if enter_exit_4byte {
-            protocol::exit_4byte_mode_with_features(self.master(), chip_features).await?;
-        }
-
-        // Verify only after the erase loop has left its persistent 4-byte
-        // mode. The read helper manages 4-byte mode itself; calling it inside
-        // the loop would exit that mode and make the next legacy erase opcode
-        // target the wrong address.
-        check_erased_range(&mut self.master, &self.ctx, addr, len).await
+        let accelerated = self.master.supports_erase_plan(&plan);
+        self.lifecycle.run(&mut self.master, plan.address, protocol::QuadEnableMethod::None, async |master| {
+            if unprotect { protocol::sst26_global_unprotect(master).await?; }
+            if accelerated { master.erase_planned(&plan, addr, len).await.map_err(|error| { log::error!("firmware transfer failed: {error:?}; hardware recovery required"); Error::RecoveryRequired }) } else { io::erase_spi(master, &plan, addr, len).await }
+        }).await?;
+        // Verification owns a fresh, single-I/O scope after erase addressing is restored.
+        io::verify_erased(
+            &mut self.lifecycle,
+            &mut self.master,
+            &verify_plan,
+            addr,
+            len,
+        )
+        .await
     }
 }
 
-// =============================================================================
-// Write Protection Support (delegates to SpiMaster, identical to SpiFlashDevice)
-// =============================================================================
-
-#[cfg(feature = "alloc")]
 impl<M: SpiMaster + OpaqueMaster> HybridFlashDevice<M> {
     fn wp_bit_map(&self) -> WpRegBitMap {
         let features = self.ctx.chip.features;
@@ -313,22 +205,47 @@ impl<M: SpiMaster + OpaqueMaster> HybridFlashDevice<M> {
 
     /// Read current write protection bits
     pub async fn read_wp_bits(&mut self) -> WpResult<WpBits> {
+        self.lifecycle.check()?;
         let bit_map = self.wp_bit_map();
-        wp::read_wp_bits(&mut self.master, &bit_map).await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| wp::read_wp_bits(master, &bit_map).await,
+            )
+            .await
     }
 
     /// Read current write protection configuration
     pub async fn read_wp_config(&mut self) -> WpResult<WpConfig> {
+        self.lifecycle.check()?;
         let bit_map = self.wp_bit_map();
         let decoder = self.wp_decoder();
         let total_size = self.ctx.chip.total_size;
-        wp::read_wp_config(&mut self.master, &bit_map, total_size, decoder).await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| wp::read_wp_config(master, &bit_map, total_size, decoder).await,
+            )
+            .await
     }
 
     /// Write write protection bits
     pub async fn write_wp_bits(&mut self, bits: &WpBits, options: WriteOptions) -> WpResult<()> {
+        self.lifecycle.check()?;
+        let options = wp::chip_write_options(self.ctx.chip.features, options);
         let bit_map = self.wp_bit_map();
-        wp::write_wp_bits(&mut self.master, bits, &bit_map, options).await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| wp::write_wp_bits(master, bits, &bit_map, options).await,
+            )
+            .await
     }
 
     /// Write write protection configuration
@@ -337,46 +254,71 @@ impl<M: SpiMaster + OpaqueMaster> HybridFlashDevice<M> {
         config: &WpConfig,
         options: WriteOptions,
     ) -> WpResult<()> {
+        self.lifecycle.check()?;
+        let options = wp::chip_write_options(self.ctx.chip.features, options);
         let bit_map = self.wp_bit_map();
         let decoder = self.wp_decoder();
         let total_size = self.ctx.chip.total_size;
-        wp::write_wp_config(
-            &mut self.master,
-            config,
-            &bit_map,
-            total_size,
-            decoder,
-            options,
-        )
-        .await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| {
+                    wp::write_wp_config(master, config, &bit_map, total_size, decoder, options)
+                        .await
+                },
+            )
+            .await
     }
 
     /// Set write protection mode
     pub async fn set_wp_mode(&mut self, mode: WpMode, options: WriteOptions) -> WpResult<()> {
+        self.lifecycle.check()?;
+        let options = wp::chip_write_options(self.ctx.chip.features, options);
         let bit_map = self.wp_bit_map();
-        wp::set_wp_mode(&mut self.master, mode, &bit_map, options).await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| wp::set_wp_mode(master, mode, &bit_map, options).await,
+            )
+            .await
     }
 
     /// Set protected range
     pub async fn set_wp_range(&mut self, range: &WpRange, options: WriteOptions) -> WpResult<()> {
+        self.lifecycle.check()?;
+        let options = wp::chip_write_options(self.ctx.chip.features, options);
         let bit_map = self.wp_bit_map();
         let decoder = self.wp_decoder();
         let total_size = self.ctx.chip.total_size;
-        wp::set_wp_range(
-            &mut self.master,
-            range,
-            &bit_map,
-            total_size,
-            decoder,
-            options,
-        )
-        .await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| {
+                    wp::set_wp_range(master, range, &bit_map, total_size, decoder, options).await
+                },
+            )
+            .await
     }
 
     /// Disable all write protection
     pub async fn disable_wp(&mut self, options: WriteOptions) -> WpResult<()> {
+        self.lifecycle.check()?;
+        let options = wp::chip_write_options(self.ctx.chip.features, options);
         let bit_map = self.wp_bit_map();
-        wp::disable_wp(&mut self.master, &bit_map, options).await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| wp::disable_wp(master, &bit_map, options).await,
+            )
+            .await
     }
 
     /// Get all available protection ranges

--- a/crates/rflasher-core/src/flash/io.rs
+++ b/crates/rflasher-core/src/flash/io.rs
@@ -1,0 +1,558 @@
+//! Immutable command plans and the single owner of temporary flash state.
+//!
+//! Construction/probe assumes an externally established ordinary-SPI, three-byte
+//! baseline (and no command in flight). JEDEC probing does not reset a chip.
+//! Cancellation requires hardware recovery and reprobe, not merely reconnecting USB.
+
+use super::context::{AddressMode, FlashContext};
+use crate::chip::{EraseBlock, Features, WriteGranularity};
+use crate::error::{EraseFailure, Error, Result};
+use crate::programmer::{SpiFeatures, SpiMaster};
+use crate::protocol::{self, CommandAddressing, QuadEnableMethod, SpiReadOp};
+use crate::spi::{AddressWidth, IoMode, SpiCommand, opcodes};
+
+/// Command addressing, not a cache of the chip's current mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddressPlan {
+    /// Ordinary three-byte commands.
+    ThreeByte,
+    /// Dedicated four-byte opcodes; no chip mode change.
+    NativeFourByte,
+    /// Bracket compatibility commands with chip-specific mode entry/exit.
+    EnterFourByte(Features),
+    /// Three-byte commands with explicit bank selection and saved EAR restoration.
+    Ear(Features),
+}
+impl AddressPlan {
+    /// Address strategy consumed by raw SPI protocol helpers.
+    pub fn command_addressing(self) -> CommandAddressing {
+        match self {
+            Self::ThreeByte => CommandAddressing::ThreeByte,
+            Self::NativeFourByte | Self::EnterFourByte(_) => CommandAddressing::FourByte,
+            Self::Ear(f) => CommandAddressing::ExtendedAddressRegister(f),
+        }
+    }
+    /// Reject address truncation before submitting a planned transfer.
+    pub fn validate_range(self, addr: u32, len: usize) -> Result<()> {
+        let end = addr as u64 + len as u64;
+        if end > (1u64 << 32) || (self == Self::ThreeByte && end > 0x0100_0000) {
+            Err(Error::AddressOutOfBounds)
+        } else {
+            Ok(())
+        }
+    }
+    /// Number of address bytes on the wire.
+    pub fn width(self) -> AddressWidth {
+        match self {
+            Self::NativeFourByte | Self::EnterFourByte(_) => AddressWidth::FourByte,
+            _ => AddressWidth::ThreeByte,
+        }
+    }
+}
+
+/// One read command and its residual path. Construct with `select_read_plan`.
+#[derive(Debug, Clone, Copy)]
+pub struct ReadPlan {
+    /// Selected command and exact dummy timing.
+    pub op: SpiReadOp,
+    /// Addressing shared by every chunk of this operation.
+    pub address: AddressPlan,
+    /// A valid single-I/O residual command under the same addressing strategy.
+    pub single_read: Option<SpiReadOp>,
+    pub(crate) qe: QuadEnableMethod,
+}
+/// Program command selected independently from reads.
+#[derive(Debug, Clone, Copy)]
+pub struct WritePlan {
+    /// Command opcode sent to the flash.
+    pub opcode: u8,
+    /// Addressing shared by every chunk of this operation.
+    pub address: AddressPlan,
+    /// Chip page boundary in bytes.
+    pub page_size: usize,
+    /// Minimum programming unit.
+    pub granularity: WriteGranularity,
+}
+/// Erase command, layout and polling timing.
+#[derive(Debug, Clone)]
+pub struct ErasePlan {
+    /// Command opcode sent to the flash.
+    pub opcode: u8,
+    /// Addressing shared by every chunk of this operation.
+    pub address: AddressPlan,
+    /// Validated chip erase layout.
+    pub block: EraseBlock,
+    /// Delay between status polls.
+    pub poll_delay_us: u32,
+    /// Erase completion timeout.
+    pub timeout_us: u32,
+}
+
+fn addresses(ctx: &FlashContext, features: SpiFeatures, native: bool) -> [Option<AddressPlan>; 3] {
+    if ctx.address_mode == AddressMode::ThreeByte {
+        return [Some(AddressPlan::ThreeByte), None, None];
+    }
+    let f = ctx.chip.features;
+    [
+        (native && features.contains(SpiFeatures::FOUR_BYTE_ADDR))
+            .then_some(AddressPlan::NativeFourByte),
+        (!features.contains(SpiFeatures::NO_4BA_MODES)
+            && features.contains(SpiFeatures::FOUR_BYTE_ADDR)
+            && f.supports_4ba_mode_switch())
+        .then_some(AddressPlan::EnterFourByte(f)),
+        (!features.contains(SpiFeatures::NO_4BA_MODES) && f.supports_extended_address_register())
+            .then_some(AddressPlan::Ear(f)),
+    ]
+}
+
+fn qe_method(ctx: &FlashContext) -> QuadEnableMethod {
+    use crate::chip::QeMethod;
+    match ctx.chip.qe_method {
+        QeMethod::None => QuadEnableMethod::None,
+        QeMethod::Sr2Bit1WriteSr => QuadEnableMethod::Sr2Bit1WriteSr,
+        QeMethod::Sr2Bit1WriteSr2 => QuadEnableMethod::Sr2Bit1WriteSr2,
+        QeMethod::Sr1Bit6 => QuadEnableMethod::Sr1Bit6,
+        QeMethod::Sr2Bit7 => QuadEnableMethod::Sr2Bit7,
+    }
+}
+
+/// Pure selection, including the backend's complete bulk/residual representability.
+pub fn select_read_plan<M: SpiMaster + ?Sized>(
+    master: &M,
+    ctx: &FlashContext,
+    single: bool,
+    accepts: impl Fn(&ReadPlan) -> bool,
+) -> Result<ReadPlan> {
+    use protocol::{ChipReadCapabilities, DummyCycleOverrides};
+    if master.max_read_len() == 0 {
+        return Err(Error::ChipNotSupported);
+    }
+    let f = ctx.chip.features;
+    let qe = qe_method(ctx);
+    // Unknown SFDP QER removes quad capabilities during conversion. Without
+    // volatile writes, conservatively exclude quad even if QE might be set.
+    let quad = !single
+        && qe != QuadEnableMethod::Sr2Bit7
+        && (qe == QuadEnableMethod::None || f.contains(Features::WRSR_EWSR));
+    let dc = DummyCycleOverrides {
+        dc_112: ctx.chip.dummy_cycles_112,
+        dc_122: ctx.chip.dummy_cycles_122,
+        dc_114: ctx.chip.dummy_cycles_114,
+        dc_144: ctx.chip.dummy_cycles_144,
+        dc_qpi: None,
+    };
+    let exact = |mode, cycles: Option<u8>, default| {
+        master.supports_read_dummy_cycles(mode, cycles.unwrap_or(default))
+    };
+    let caps = ChipReadCapabilities {
+        fast_read: f.contains(Features::FAST_READ) && exact(IoMode::Single, Some(8), 8),
+        dout: !single
+            && f.contains(Features::FAST_READ_DOUT)
+            && exact(IoMode::DualOut, dc.dc_112, 8),
+        dio: !single && f.contains(Features::FAST_READ_DIO) && exact(IoMode::DualIo, dc.dc_122, 4),
+        qout: quad && f.contains(Features::FAST_READ_QOUT) && exact(IoMode::QuadOut, dc.dc_114, 8),
+        qio: quad && f.contains(Features::FAST_READ_QIO) && exact(IoMode::QuadIo, dc.dc_144, 6),
+        native_4ba_read: f.contains(Features::FOUR_BYTE_READ),
+        native_4ba_fast_read: f.contains(Features::FOUR_BYTE_FAST_READ),
+        native_4ba_dout: f.contains(Features::FOUR_BYTE_DUAL_OUT_READ),
+        native_4ba_dio: f.contains(Features::FOUR_BYTE_DUAL_IO_READ),
+        native_4ba_qout: f.contains(Features::FOUR_BYTE_QUAD_OUT_READ),
+        native_4ba_qio: f.contains(Features::FOUR_BYTE_QUAD_IO_READ),
+        qpi_fast_read: false,
+        qpi4b: false,
+        in_qpi_mode: false,
+    };
+    let compatibility = addresses(ctx, master.features(), false);
+    let mut rejected = [false; 256];
+    while let Some(mut op) = protocol::select_read_op(
+        master.features(),
+        caps,
+        dc,
+        ctx.address_mode == AddressMode::FourByte,
+        compatibility.iter().any(Option::is_some),
+        |opcode| !rejected[opcode as usize] && master.probe_opcode(opcode),
+    ) {
+        let strategies = if op.native_4ba {
+            [Some(AddressPlan::NativeFourByte), None, None]
+        } else {
+            compatibility
+        };
+        for address in strategies.into_iter().flatten() {
+            op.address_width = address.width();
+            let single_read = single_read_op(master, f, address);
+            let plan = ReadPlan {
+                op,
+                address,
+                single_read,
+                qe: if op.io_mode.requires_quad() {
+                    qe
+                } else {
+                    QuadEnableMethod::None
+                },
+            };
+            if accepts(&plan) {
+                return Ok(plan);
+            }
+        }
+        rejected[op.opcode as usize] = true;
+    }
+    Err(Error::ChipNotSupported)
+}
+
+fn single_read_op<M: SpiMaster + ?Sized>(
+    master: &M,
+    features: Features,
+    address: AddressPlan,
+) -> Option<SpiReadOp> {
+    if address == AddressPlan::NativeFourByte {
+        if features.contains(Features::FOUR_BYTE_READ) && master.probe_opcode(opcodes::READ_4B) {
+            Some(SpiReadOp::sio_read_4b())
+        } else if features.contains(Features::FOUR_BYTE_FAST_READ | Features::FAST_READ)
+            && master.probe_opcode(opcodes::FAST_READ_4B)
+            && master.supports_read_dummy_cycles(IoMode::Single, 8)
+        {
+            Some(SpiReadOp {
+                opcode: opcodes::FAST_READ_4B,
+                dummy_cycles: 8,
+                ..SpiReadOp::sio_read_4b()
+            })
+        } else {
+            None
+        }
+    } else {
+        master.probe_opcode(opcodes::READ).then_some(SpiReadOp {
+            address_width: address.width(),
+            ..SpiReadOp::sio_read()
+        })
+    }
+}
+
+/// Select program addressing and backend representation without hardware I/O.
+pub fn select_write_plan<M: SpiMaster + ?Sized>(
+    master: &M,
+    ctx: &FlashContext,
+    accepts: impl Fn(&WritePlan) -> bool,
+) -> Result<WritePlan> {
+    if ctx.page_size() == 0 || master.max_write_len() == 0 {
+        return Err(Error::ChipNotSupported);
+    }
+    for address in addresses(
+        ctx,
+        master.features(),
+        ctx.chip.features.supports_4ba_program(),
+    )
+    .into_iter()
+    .flatten()
+    {
+        let opcode =
+            if ctx.chip.features.contains(Features::AAI_WORD) && master.max_write_len() >= 2 {
+                if address != AddressPlan::ThreeByte {
+                    continue;
+                }
+                opcodes::AAI_WP
+            } else if address == AddressPlan::NativeFourByte {
+                opcodes::PP_4B
+            } else {
+                opcodes::PP
+            };
+        let plan = WritePlan {
+            opcode,
+            address,
+            page_size: ctx.page_size(),
+            granularity: ctx.chip.write_granularity,
+        };
+        if master.probe_opcode(opcode) && accepts(&plan) {
+            return Ok(plan);
+        }
+    }
+    Err(Error::ChipNotSupported)
+}
+
+/// Select a range-aligned erase command without hardware I/O.
+pub fn select_erase_plan<M: SpiMaster + ?Sized>(
+    master: &M,
+    ctx: &FlashContext,
+    addr: u32,
+    len: u32,
+) -> Result<ErasePlan> {
+    let block = super::operations::select_erase_block(ctx.chip.erase_blocks(), addr, len)
+        .ok_or(Error::InvalidAlignment)?;
+    for address in addresses(ctx, master.features(), block.opcode_4b.is_some())
+        .into_iter()
+        .flatten()
+    {
+        let opcode = block.opcode_for_address_width(address == AddressPlan::NativeFourByte);
+        if !master.probe_opcode(opcode) {
+            continue;
+        }
+        let (poll_delay_us, timeout_us) = match block.max_block_size() {
+            0..=4096 => (10_000, 1_000_000),
+            4097..=65536 => (100_000, 4_000_000),
+            _ => (500_000, 60_000_000),
+        };
+        return Ok(ErasePlan {
+            opcode,
+            address,
+            block,
+            poll_delay_us,
+            timeout_us,
+        });
+    }
+    Err(Error::ChipNotSupported)
+}
+
+/// The only adapter-retained I/O state. Dropping a future never clears this latch.
+#[derive(Default)]
+pub(crate) struct IoLifecycle {
+    recovery_required: bool,
+}
+impl IoLifecycle {
+    pub fn recovery_required(&self) -> bool {
+        self.recovery_required
+    }
+    pub fn check(&self) -> Result<()> {
+        if self.recovery_required {
+            Err(Error::RecoveryRequired)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// One bracket for a whole transfer. Undo obligations are local to this future;
+    /// each is recorded before submitting the corresponding hardware mutation.
+    pub async fn run<M, T, E, F>(
+        &mut self,
+        master: &mut M,
+        address: AddressPlan,
+        qe: QuadEnableMethod,
+        transfer: F,
+    ) -> core::result::Result<T, E>
+    where
+        M: SpiMaster + ?Sized,
+        E: From<Error> + core::fmt::Debug + PartialEq,
+        F: for<'a> AsyncFnOnce(&'a mut M) -> core::result::Result<T, E>,
+    {
+        self.check().map_err(E::from)?;
+        self.recovery_required = true;
+        let mut restore_qe = false;
+        let mut exit_4b = false;
+        let mut ear = None;
+        let result = async {
+            match address {
+                AddressPlan::Ear(f) => {
+                    ear = Some((f, read_ear(master, f).await.map_err(E::from)?));
+                }
+                AddressPlan::EnterFourByte(f) => {
+                    if f.contains(Features::FOUR_BYTE_ENTER_EAR7)
+                        && !f.intersects(Features::FOUR_BYTE_ENTER | Features::FOUR_BYTE_ENTER_WREN)
+                    {
+                        ear = Some((f, read_ear(master, f).await.map_err(E::from)?));
+                    } else {
+                        exit_4b = true;
+                    }
+                    protocol::enter_4byte_mode_with_features(master, f)
+                        .await
+                        .map_err(E::from)?;
+                }
+                _ => {}
+            }
+            if qe != QuadEnableMethod::None
+                && !protocol::is_quad_enabled(master, qe)
+                    .await
+                    .map_err(E::from)?
+            {
+                restore_qe = true;
+                protocol::enable_quad_mode_volatile(master, qe)
+                    .await
+                    .map_err(E::from)?;
+                if !protocol::is_quad_enabled(master, qe)
+                    .await
+                    .map_err(E::from)?
+                {
+                    return Err(E::from(Error::ProgrammerError));
+                }
+            }
+            transfer(master).await
+        }
+        .await;
+        // An uncertain firmware engine may issue more commands even while the
+        // flash reports idle. Without a quiescence barrier, even RDSR is unsafe.
+        if result.as_ref().err() == Some(&E::from(Error::RecoveryRequired)) {
+            return result;
+        }
+        // A timed-out program/erase must be confirmed idle before register/mode
+        // restoration. If it is still busy, no mutation is safe and recovery is required.
+        let cleanup = async {
+            protocol::wait_ready(master, 1_000, 60_000_000).await?;
+            let mut failure = None;
+            if master.probe_opcode(opcodes::WRDI)
+                && let Err(e) = protocol::write_disable(master).await
+            {
+                failure = Some(e);
+            }
+            if restore_qe {
+                let restored = async {
+                    protocol::disable_quad_mode_volatile(master, qe).await?;
+                    if protocol::is_quad_enabled(master, qe).await? {
+                        return Err(Error::ProgrammerError);
+                    }
+                    Ok(())
+                }
+                .await;
+                if let Err(e) = restored {
+                    failure = Some(e);
+                }
+            }
+            if exit_4b
+                && let AddressPlan::EnterFourByte(f) = address
+                && let Err(e) = protocol::exit_4byte_mode_with_features(master, f).await
+            {
+                failure = Some(e);
+            }
+            if let Some((f, saved)) = ear {
+                let restored = async {
+                    protocol::set_extended_address(master, f, saved).await?;
+                    if read_ear(master, f).await? != saved {
+                        return Err(Error::ProgrammerError);
+                    }
+                    Ok(())
+                }
+                .await;
+                if let Err(e) = restored {
+                    failure = Some(e);
+                }
+            }
+            failure.map_or(Ok(()), Err)
+        }
+        .await;
+        if let Err(error) = cleanup {
+            log::error!(
+                "flash cleanup failed: {error:?}; operation error: {:?}; hardware recovery required",
+                result.as_ref().err()
+            );
+            return Err(E::from(Error::RecoveryRequired));
+        }
+        self.recovery_required = false;
+        result
+    }
+}
+
+async fn read_ear<M: SpiMaster + ?Sized>(master: &mut M, f: Features) -> Result<u8> {
+    let (opcode, _) = protocol::extended_address_opcodes(f)?;
+    let mut value = [0];
+    master
+        .execute(&mut SpiCommand::read_reg(opcode, &mut value))
+        .await?;
+    Ok(value[0])
+}
+
+/// Execute all read chunks under a caller-owned scope. Does not change QE/mode.
+pub async fn read_spi<M: SpiMaster + ?Sized>(
+    master: &mut M,
+    plan: &ReadPlan,
+    addr: u32,
+    buf: &mut [u8],
+) -> Result<()> {
+    protocol::read_io_with_addressing(
+        master,
+        plan.op.opcode,
+        addr,
+        buf,
+        plan.address.command_addressing(),
+        plan.op.io_mode,
+        plan.op.dummy_cycles,
+    )
+    .await
+}
+/// Execute all program chunks under a caller-owned scope.
+pub async fn write_spi<M: SpiMaster + ?Sized>(
+    master: &mut M,
+    plan: &WritePlan,
+    addr: u32,
+    data: &[u8],
+) -> Result<()> {
+    if plan.opcode == opcodes::AAI_WP {
+        return protocol::aai_word_program(master, addr, data).await;
+    }
+    let mut offset = 0;
+    while offset < data.len() {
+        let address = addr + offset as u32;
+        let len = if plan.granularity == WriteGranularity::Byte {
+            1
+        } else {
+            (data.len() - offset)
+                .min(plan.page_size - address as usize % plan.page_size)
+                .min(master.max_write_len())
+                .min(0x0100_0000 - (address as usize & 0xffffff))
+        };
+        if len == 0 {
+            return Err(Error::ProgrammerError);
+        }
+        protocol::program_page_with_addressing(
+            master,
+            plan.opcode,
+            address,
+            &data[offset..offset + len],
+            plan.address.command_addressing(),
+        )
+        .await?;
+        offset += len;
+    }
+    Ok(())
+}
+/// Execute all erase blocks under a caller-owned scope.
+pub async fn erase_spi<M: SpiMaster + ?Sized>(
+    master: &mut M,
+    plan: &ErasePlan,
+    addr: u32,
+    len: u32,
+) -> Result<()> {
+    let mut offset = 0;
+    while offset < len {
+        protocol::erase_block(
+            master,
+            plan.opcode,
+            addr + offset,
+            plan.address.command_addressing(),
+            plan.poll_delay_us,
+            plan.timeout_us,
+        )
+        .await?;
+        offset += plan
+            .block
+            .block_size_at_offset(offset)
+            .unwrap_or(plan.block.max_block_size());
+    }
+    Ok(())
+}
+pub(crate) async fn verify_erased<M: SpiMaster + ?Sized>(
+    lifecycle: &mut IoLifecycle,
+    master: &mut M,
+    plan: &ReadPlan,
+    addr: u32,
+    len: u32,
+) -> Result<()> {
+    lifecycle
+        .run(
+            master,
+            plan.address,
+            QuadEnableMethod::None,
+            async |master| {
+                let mut buf = [0; 4096];
+                let mut offset = 0;
+                while offset < len {
+                    let count = buf.len().min((len - offset) as usize);
+                    read_spi(master, plan, addr + offset, &mut buf[..count]).await?;
+                    if let Some(index) = buf[..count].iter().position(|b| *b != 0xff) {
+                        return Err(Error::EraseError(EraseFailure::VerifyFailed {
+                            addr: addr + offset + index as u32,
+                            found: buf[index],
+                        }));
+                    }
+                    offset += count as u32;
+                }
+                Ok(())
+            },
+        )
+        .await
+}

--- a/crates/rflasher-core/src/flash/io_tests.rs
+++ b/crates/rflasher-core/src/flash/io_tests.rs
@@ -1,0 +1,602 @@
+//! Stateful behavioral coverage of the shared operation owner, through both adapters.
+use super::io::{self, AddressPlan, ErasePlan, ReadPlan, WritePlan};
+use super::*;
+use crate::chip::{EraseBlock, Features, FlashChip, QeMethod, WriteGranularity};
+use crate::error::{Error, Result};
+use crate::programmer::{OpaqueMaster, SpiFeatures, SpiMaster};
+use crate::spi::{AddressWidth, IoMode, SpiCommand, opcodes};
+use crate::wp::{WpBits, WpConfig, WpMode, WpRange, WriteOptions};
+use alloc::{vec, vec::Vec};
+
+#[derive(Clone, Copy)]
+enum Failure {
+    Error,
+    Pending,
+}
+
+#[derive(Default)]
+struct Master {
+    sr: [u8; 3],
+    nv: [u8; 3],
+    volatile: bool,
+    legacy: bool,
+    four: bool,
+    ear: u8,
+    reject_restore: bool,
+    fault: Option<(u8, usize, Failure)>,
+    calls: Vec<u8>,
+    addresses: Vec<(u8, u32)>,
+    bulk_reads: usize,
+    short_read: bool,
+    no_bulk_read: bool,
+    firmware_erase: bool,
+    fail_firmware_erase: bool,
+    firmware_erases: usize,
+    erased: Vec<(u32, u32)>,
+    busy: bool,
+}
+impl Master {
+    async fn event(&mut self, opcode: u8) -> Result<()> {
+        self.calls.push(opcode);
+        if let Some((op, nth, kind)) = self.fault
+            && op == opcode
+            && self.calls.iter().filter(|o| **o == op).count() == nth
+        {
+            self.fault = None;
+            match kind {
+                Failure::Error => return Err(Error::SpiTransferFailed),
+                Failure::Pending => core::future::pending::<()>().await,
+            }
+        }
+        Ok(())
+    }
+    fn address(&mut self, opcode: u8, addr: u32, width: AddressWidth, native: bool) -> u32 {
+        assert_eq!(
+            width == AddressWidth::FourByte,
+            native || self.four,
+            "wrong command address width"
+        );
+        let actual = if width == AddressWidth::ThreeByte {
+            (addr & 0xffffff) | u32::from(self.ear) << 24
+        } else {
+            addr
+        };
+        self.addresses.push((opcode, actual));
+        actual
+    }
+    fn fill(&self, addr: u32, mode: IoMode, buf: &mut [u8]) {
+        assert!(
+            !mode.requires_quad() || self.sr[1] & 2 != 0,
+            "quad before QE"
+        );
+        for (offset, b) in buf.iter_mut().enumerate() {
+            let at = addr + offset as u32;
+            *b = if self.erased.iter().any(|(a, n)| at >= *a && at < a + n) {
+                0xff
+            } else {
+                (at ^ (at >> 8) ^ (at >> 24)) as u8
+            };
+        }
+    }
+}
+impl SpiMaster for Master {
+    fn features(&self) -> SpiFeatures {
+        SpiFeatures::FOUR_BYTE_ADDR | SpiFeatures::QUAD_IO | SpiFeatures::DUAL_IO
+    }
+    fn max_read_len(&self) -> usize {
+        512
+    }
+    fn max_write_len(&self) -> usize {
+        256
+    }
+    async fn delay_us(&mut self, _: u32) {}
+    async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> Result<()> {
+        match cmd.opcode {
+            opcodes::RDSR => cmd.read_buf[0] = self.sr[0] | u8::from(self.busy),
+            opcodes::RDSR2 => cmd.read_buf[0] = self.sr[1],
+            opcodes::RDSR3 => cmd.read_buf[0] = self.sr[2],
+            opcodes::EWSR => self.volatile = !self.legacy,
+            opcodes::WREN => self.volatile = false,
+            opcodes::WRSR | opcodes::WRSR2 => {
+                let first = usize::from(cmd.opcode == opcodes::WRSR2);
+                for (i, &b) in cmd.write_data.iter().enumerate() {
+                    if !(self.reject_restore && first + i == 1 && b & 2 == 0) {
+                        self.sr[first + i] = b;
+                        if !self.volatile {
+                            self.nv[first + i] = b;
+                        }
+                    }
+                }
+            }
+            opcodes::EN4B => self.four = true,
+            opcodes::EX4B => self.four = false,
+            opcodes::RDEAR | opcodes::RDEAR_ALT => cmd.read_buf[0] = self.ear,
+            opcodes::WREAR | opcodes::WREAR_ALT => self.ear = cmd.write_data[0],
+            _ => {
+                if let Some(addr) = cmd.address {
+                    let native = matches!(cmd.opcode, 0x13 | 0x0c | 0xec | 0x12 | 0x21);
+                    let actual = self.address(cmd.opcode, addr, cmd.address_width, native);
+                    if matches!(cmd.opcode, 0x20 | 0x21) {
+                        self.erased.push((actual, 4096));
+                    } else if !cmd.read_buf.is_empty() {
+                        self.fill(actual, cmd.io_mode, cmd.read_buf);
+                    }
+                }
+            }
+        }
+        // Fail after accepting the mutation, as real transports can do.
+        self.event(cmd.opcode).await
+    }
+}
+impl OpaqueMaster for Master {
+    fn size(&self) -> usize {
+        32 << 20
+    }
+    fn supports_read_plan(&self, _: &ReadPlan) -> bool {
+        !self.no_bulk_read
+    }
+    fn supports_write_plan(&self, _: &WritePlan) -> bool {
+        true
+    }
+    fn supports_erase_plan(&self, _: &ErasePlan) -> bool {
+        self.firmware_erase
+    }
+    async fn read(&mut self, _: u32, _: &mut [u8]) -> Result<()> {
+        panic!("raw opaque read discarded plan")
+    }
+    async fn write(&mut self, _: u32, _: &[u8]) -> Result<()> {
+        panic!("raw opaque write discarded plan")
+    }
+    async fn erase(&mut self, _: u32, _: u32) -> Result<()> {
+        panic!("raw opaque erase used as capability check")
+    }
+    async fn read_planned(&mut self, plan: &ReadPlan, addr: u32, buf: &mut [u8]) -> Result<()> {
+        for (i, chunk) in buf.chunks_mut(512).enumerate() {
+            let address = addr + (i * 512) as u32;
+            if let AddressPlan::Ear(f) = plan.address {
+                crate::protocol::set_extended_address(self, f, (address >> 24) as u8).await?;
+            }
+            let actual = self.address(
+                plan.op.opcode,
+                address,
+                plan.op.address_width,
+                plan.op.native_4ba,
+            );
+            self.bulk_reads += 1;
+            self.fill(actual, plan.op.io_mode, chunk);
+            self.event(plan.op.opcode).await?;
+            if self.short_read {
+                return Err(Error::SpiTransferFailed);
+            }
+        }
+        Ok(())
+    }
+    async fn write_planned(&mut self, plan: &WritePlan, addr: u32, data: &[u8]) -> Result<()> {
+        io::write_spi(self, plan, addr, data).await
+    }
+    async fn erase_planned(&mut self, plan: &ErasePlan, addr: u32, len: u32) -> Result<()> {
+        self.firmware_erases += 1;
+        self.address(
+            plan.opcode,
+            addr,
+            plan.address.width(),
+            plan.address == AddressPlan::NativeFourByte,
+        );
+        self.erased.push((addr, len));
+        if self.fail_firmware_erase {
+            Err(Error::SpiTransferFailed)
+        } else {
+            Ok(())
+        }
+    }
+}
+fn chip() -> FlashChip {
+    FlashChip {
+        vendor: "Test".into(),
+        name: "Scoped".into(),
+        jedec_manufacturer: 0xef,
+        jedec_device: 0x4018,
+        total_size: 32 << 20,
+        page_size: 256,
+        features: Features::FAST_READ
+            | Features::FAST_READ_QIO
+            | Features::WRSR_WREN
+            | Features::WRSR_EWSR
+            | Features::FOUR_BYTE_ENTER,
+        voltage_min_mv: 2700,
+        voltage_max_mv: 3600,
+        write_granularity: WriteGranularity::Page,
+        erase_blocks: vec![EraseBlock::with_count(0x20, 4096, 8192)],
+        tested: Default::default(),
+        qe_method: QeMethod::Sr2Bit1WriteSr2,
+        dummy_cycles_112: None,
+        dummy_cycles_122: None,
+        dummy_cycles_114: None,
+        dummy_cycles_144: None,
+        dummy_cycles_qpi: None,
+    }
+}
+
+macro_rules! adapter_tests {
+    ($module:ident, $adapter:ident) => {
+        mod $module {
+            use super::*;
+            type Device = $adapter<Master>;
+            fn device() -> Device {
+                Device::new(Master::default(), FlashContext::new(chip()))
+            }
+            async fn assert_blocked(dev: &mut Device) {
+                let before = dev.master().calls.len();
+                assert_eq!(dev.read(0, &mut [0; 1]).await, Err(Error::RecoveryRequired));
+                assert_eq!(dev.write(0, &[0]).await, Err(Error::RecoveryRequired));
+                assert_eq!(dev.erase(0, 4096).await, Err(Error::RecoveryRequired));
+                assert!(dev.read_wp_bits().await.is_err());
+                assert!(dev.read_wp_config().await.is_err());
+                assert!(dev.disable_wp(WriteOptions::default()).await.is_err());
+                assert!(
+                    dev.set_wp_mode(WpMode::Disabled, WriteOptions::default())
+                        .await
+                        .is_err()
+                );
+                assert!(
+                    dev.set_wp_range(&WpRange::none(), WriteOptions::default())
+                        .await
+                        .is_err()
+                );
+                assert!(
+                    dev.write_wp_bits(&WpBits::default(), WriteOptions::default())
+                        .await
+                        .is_err()
+                );
+                assert!(
+                    dev.write_wp_config(&WpConfig::default(), WriteOptions::default())
+                        .await
+                        .is_err()
+                );
+                assert_eq!(
+                    dev.master().calls.len(),
+                    before,
+                    "latched entry touched hardware"
+                );
+            }
+            #[test]
+            fn exact_read_owns_all_chunks_then_persistent_wp_preserves_initial_qe() {
+                futures_lite::future::block_on(async {
+                    for initial_qe in [0, 2] {
+                        let mut dev = device();
+                        dev.master().sr = [0x1c, initial_qe | 0x08, 0];
+                        dev.master().nv = dev.master().sr;
+                        let addr = 0x0100_0003;
+                        let mut buf = [0; 1703];
+                        dev.read(addr, &mut buf).await.unwrap();
+                        for (i, b) in buf.iter().enumerate() {
+                            let at = addr + i as u32;
+                            assert_eq!(*b, (at ^ (at >> 8) ^ (at >> 24)) as u8);
+                        }
+                        assert!(!dev.master().four);
+                        assert_eq!(dev.master().sr[1], initial_qe | 0x08);
+                        let calls = &dev.master().calls;
+                        assert_eq!(calls.iter().filter(|o| **o == opcodes::EN4B).count(), 1);
+                        assert_eq!(calls.iter().filter(|o| **o == opcodes::EX4B).count(), 1);
+                        assert_eq!(
+                            calls.iter().filter(|o| **o == opcodes::WRSR2).count(),
+                            if initial_qe == 0 { 2 } else { 0 }
+                        );
+                        dev.disable_wp(WriteOptions::default()).await.unwrap();
+                        dev.master().sr = dev.master().nv; // power cycle
+                        assert_eq!(dev.master().sr[0] & 0x1c, 0);
+                        assert_eq!(dev.master().sr[1], initial_qe | 0x08);
+                    }
+                });
+            }
+            #[test]
+            fn accepted_setup_writes_reach_cleanup_after_transport_poll_or_readback_failure() {
+                futures_lite::future::block_on(async {
+                    for (opcode, nth) in [
+                        (opcodes::EN4B, 1),
+                        (opcodes::RDSR2, 1),
+                        (opcodes::WRSR2, 1),
+                        (opcodes::RDSR, 1),
+                        (opcodes::RDSR2, 3),
+                        (opcodes::QIOR, 2),
+                    ] {
+                        let mut dev = device();
+                        dev.master().fault = Some((opcode, nth, Failure::Error));
+                        assert!(dev.read(0x0100_0000, &mut [0; 1200]).await.is_err());
+                        if dev.recovery_required() {
+                            // Hybrid transfer failures leave firmware state uncertain.
+                            assert_eq!(opcode, opcodes::QIOR);
+                            assert!(dev.master().four);
+                            continue;
+                        }
+                        assert!(!dev.master().four, "failed EN4B still owned EX4B");
+                        assert_eq!(
+                            dev.master().sr[1] & 2,
+                            0,
+                            "QE ownership recorded before write"
+                        );
+                    }
+                });
+            }
+            #[test]
+            fn cleanup_failure_blocks_all_access_and_attempts_independent_exit() {
+                futures_lite::future::block_on(async {
+                    let mut dev = device();
+                    dev.master().reject_restore = true;
+                    assert_eq!(dev.read(0, &mut [0; 8]).await, Err(Error::RecoveryRequired));
+                    assert!(!dev.master().four, "QE error must not skip EX4B");
+                    assert_blocked(&mut dev).await;
+                    let mut dev = device();
+                    dev.master().fault = Some((opcodes::EX4B, 1, Failure::Error));
+                    assert_eq!(dev.read(0, &mut [0; 8]).await, Err(Error::RecoveryRequired));
+                    assert_blocked(&mut dev).await;
+                });
+            }
+            #[test]
+            fn dropped_operation_rejects_io_and_every_wp_entry() {
+                futures_lite::future::block_on(async {
+                    for (opcode, nth) in [
+                        (opcodes::EN4B, 1),
+                        (opcodes::WRSR2, 1),
+                        (opcodes::QIOR, 1),
+                        (opcodes::WRSR2, 2),
+                        (opcodes::EX4B, 1),
+                    ] {
+                        let mut dev = device();
+                        dev.master().fault = Some((opcode, nth, Failure::Pending));
+                        {
+                            let mut buf = [0; 8];
+                            let mut future = core::pin::pin!(dev.read(0, &mut buf));
+                            assert!(futures_lite::future::poll_once(&mut future).await.is_none());
+                        }
+                        assert!(dev.recovery_required());
+                        assert_blocked(&mut dev).await;
+                    }
+                });
+            }
+            #[test]
+            fn erase_verification_has_fresh_scope_and_program_addressing_is_independent() {
+                futures_lite::future::block_on(async {
+                    let mut dev = device();
+                    dev.context_mut().chip.features |= Features::FOUR_BYTE_QUAD_IO_READ;
+                    dev.read(0x0100_0000, &mut [0; 8]).await.unwrap(); // native read, compatibility PP/erase
+                    for addr in [0x0100_0000, 0x0100_1000] {
+                        dev.erase(addr, 4096).await.unwrap();
+                        assert!(!dev.master().four);
+                    }
+                    dev.write(0x0100_2003, &[0xaa; 300]).await.unwrap();
+                    dev.read(0x0100_2003, &mut [0; 8]).await.unwrap();
+                    let master = dev.master();
+                    assert!(master.addresses.contains(&(0x20, 0x0100_0000)));
+                    assert!(master.addresses.contains(&(0x20, 0x0100_1000)));
+                    assert!(master.addresses.contains(&(0x02, 0x0100_2003)));
+                    assert_eq!(
+                        master.calls.iter().filter(|o| **o == opcodes::EN4B).count(),
+                        5
+                    );
+                    assert_eq!(
+                        master.calls.iter().filter(|o| **o == opcodes::EX4B).count(),
+                        5
+                    );
+                });
+            }
+            #[test]
+            fn ear_is_saved_and_restored_across_bank_boundary() {
+                futures_lite::future::block_on(async {
+                    let mut dev = device();
+                    dev.context_mut().chip.features -= Features::FOUR_BYTE_ENTER;
+                    dev.context_mut().chip.features |= Features::EXT_ADDR_REG_C5C8;
+                    dev.master().ear = 3;
+                    let mut buf = [0; 1024];
+                    dev.read(0x00ff_ff00, &mut buf).await.unwrap();
+                    assert_eq!(dev.master().ear, 3);
+                    dev.write(0x00ff_ff00, &[0x55; 1024]).await.unwrap();
+                    assert_eq!(dev.master().ear, 3);
+                    assert!(
+                        dev.master()
+                            .addresses
+                            .iter()
+                            .any(|(_, addr)| *addr >= 0x0100_0000)
+                    );
+                });
+            }
+            #[test]
+            fn explicit_alternate_ear_overrides_generic_capability_for_save_and_restore() {
+                futures_lite::future::block_on(async {
+                    let mut dev = device();
+                    dev.context_mut().chip.features -= Features::FOUR_BYTE_ENTER;
+                    // This combination is emitted by chip codegen.
+                    dev.context_mut().chip.features |=
+                        Features::EXT_ADDR_REG | Features::EXT_ADDR_REG_1716;
+                    dev.master().ear = 3;
+                    dev.read(0x0100_0000, &mut [0; 8]).await.unwrap();
+                    assert_eq!(dev.master().ear, 3);
+                    let calls = &dev.master().calls;
+                    assert_eq!(
+                        calls.iter().filter(|&&op| op == opcodes::RDEAR_ALT).count(),
+                        2
+                    );
+                    assert_eq!(
+                        calls.iter().filter(|&&op| op == opcodes::WREAR_ALT).count(),
+                        2
+                    );
+                    assert!(!calls.contains(&opcodes::RDEAR));
+                    assert!(!calls.contains(&opcodes::WREAR));
+                });
+            }
+            #[test]
+            fn mandatory_legacy_ewsr_still_persists_wp() {
+                futures_lite::future::block_on(async {
+                    let mut dev = device();
+                    dev.context_mut().chip.features -= Features::WRSR_WREN | Features::ANY_QUAD;
+                    dev.master().legacy = true;
+                    dev.master().sr[0] = 0x1c;
+                    dev.master().nv = dev.master().sr;
+                    dev.disable_wp(WriteOptions::default()).await.unwrap();
+                    assert!(dev.master().calls.contains(&opcodes::EWSR));
+                    assert_eq!(dev.master().nv[0] & 0x1c, 0);
+                });
+            }
+        }
+    };
+}
+adapter_tests!(spi, SpiFlashDevice);
+adapter_tests!(hybrid, HybridFlashDevice);
+
+#[test]
+fn planned_erase_capability_selects_firmware_or_spi_before_io_never_retries_failure() {
+    futures_lite::future::block_on(async {
+        for (supported, failed) in [(false, false), (true, false), (true, true)] {
+            let master = Master {
+                firmware_erase: supported,
+                fail_firmware_erase: failed,
+                ..Default::default()
+            };
+            let mut dev = HybridFlashDevice::new(master, FlashContext::new(chip()));
+            assert_eq!(dev.erase(0x0100_0000, 4096).await.is_ok(), !failed);
+            assert_eq!(dev.master().firmware_erases, usize::from(supported));
+            assert_eq!(dev.master().calls.contains(&0x20), !supported);
+            assert_eq!(dev.recovery_required(), failed);
+        }
+    });
+}
+#[test]
+fn short_planned_read_requires_recovery_without_touching_temporary_state() {
+    futures_lite::future::block_on(async {
+        let mut dev = HybridFlashDevice::new(
+            Master {
+                short_read: true,
+                ..Default::default()
+            },
+            FlashContext::new(chip()),
+        );
+        assert_eq!(
+            dev.read(3, &mut [0; 1600]).await,
+            Err(Error::RecoveryRequired)
+        );
+        assert_eq!(dev.master().sr[1] & 2, 2);
+        assert!(dev.master().four);
+        assert_eq!(dev.master().bulk_reads, 1);
+    });
+}
+#[test]
+fn still_busy_cleanup_does_not_exit_address_mode_or_allow_reuse() {
+    futures_lite::future::block_on(async {
+        let mut dev = SpiFlashDevice::new(
+            Master {
+                busy: true,
+                ..Default::default()
+            },
+            FlashContext::new(chip()),
+        );
+        assert_eq!(
+            dev.write(0x0100_0000, &[0; 8]).await,
+            Err(Error::RecoveryRequired)
+        );
+        assert!(dev.recovery_required());
+        assert!(dev.master().four);
+        assert!(!dev.master().calls.contains(&opcodes::EX4B));
+    });
+}
+
+#[test]
+fn unsupported_bulk_read_selects_single_spi_before_qe_setup() {
+    futures_lite::future::block_on(async {
+        let mut dev = HybridFlashDevice::new(
+            Master {
+                no_bulk_read: true,
+                ..Default::default()
+            },
+            FlashContext::new(chip()),
+        );
+        dev.read(0x0100_0003, &mut [0; 1024]).await.unwrap();
+        assert_eq!(dev.master().bulk_reads, 0);
+        assert!(!dev.master().calls.contains(&opcodes::WRSR2));
+        assert!(
+            dev.master()
+                .addresses
+                .contains(&(opcodes::FAST_READ, 0x0100_0003))
+        );
+        assert!(!dev.master().four);
+    });
+}
+
+#[test]
+fn planned_defaults_reject_without_discarding_plans_but_raw_opaque_still_works() {
+    #[derive(Default)]
+    struct RawOnly(usize);
+    impl OpaqueMaster for RawOnly {
+        fn size(&self) -> usize {
+            4096
+        }
+        async fn read(&mut self, _: u32, buf: &mut [u8]) -> Result<()> {
+            self.0 += 1;
+            buf.fill(0xff);
+            Ok(())
+        }
+        async fn write(&mut self, _: u32, _: &[u8]) -> Result<()> {
+            self.0 += 1;
+            Ok(())
+        }
+        async fn erase(&mut self, _: u32, _: u32) -> Result<()> {
+            self.0 += 1;
+            Ok(())
+        }
+    }
+    futures_lite::future::block_on(async {
+        let ctx = FlashContext::new(chip());
+        let master = Master::default();
+        let read = io::select_read_plan(&master, &ctx, false, |_| true).unwrap();
+        let write = io::select_write_plan(&master, &ctx, |_| true).unwrap();
+        let erase = io::select_erase_plan(&master, &ctx, 0, 4096).unwrap();
+        let mut raw = RawOnly::default();
+        assert!(!raw.supports_read_plan(&read));
+        assert!(!raw.supports_write_plan(&write));
+        assert!(!raw.supports_erase_plan(&erase));
+        assert_eq!(
+            raw.read_planned(&read, 0, &mut [0; 1]).await,
+            Err(Error::ChipNotSupported)
+        );
+        assert_eq!(
+            raw.write_planned(&write, 0, &[0]).await,
+            Err(Error::ChipNotSupported)
+        );
+        assert_eq!(
+            raw.erase_planned(&erase, 0, 4096).await,
+            Err(Error::ChipNotSupported)
+        );
+        assert_eq!(raw.0, 0);
+        let mut device = OpaqueFlashDevice::new(raw, 4096);
+        device.read(0, &mut [0; 1]).await.unwrap();
+        device.write(0, &[0]).await.unwrap();
+        device.erase(0, 4096).await.unwrap();
+    });
+}
+
+#[test]
+fn uncertain_firmware_failure_skips_even_status_cleanup_and_blocks_wp() {
+    futures_lite::future::block_on(async {
+        let mut dev = HybridFlashDevice::new(
+            Master {
+                firmware_erase: true,
+                fail_firmware_erase: true,
+                ..Default::default()
+            },
+            FlashContext::new(chip()),
+        );
+        assert_eq!(
+            dev.erase(0x0100_0000, 4096).await,
+            Err(Error::RecoveryRequired)
+        );
+        assert!(
+            !dev.master().busy,
+            "flash idle does not prove firmware quiescence"
+        );
+        assert!(dev.master().four);
+        // Setup's EN4B is the only ordinary SPI command. No RDSR, WRDI or EX4B.
+        assert_eq!(dev.master().calls, [opcodes::EN4B]);
+        assert!(dev.disable_wp(WriteOptions::default()).await.is_err());
+        assert!(dev.read_wp_config().await.is_err());
+        assert_eq!(dev.master().calls, [opcodes::EN4B]);
+    });
+}

--- a/crates/rflasher-core/src/flash/mod.rs
+++ b/crates/rflasher-core/src/flash/mod.rs
@@ -39,6 +39,7 @@
 mod context;
 mod device;
 mod hybrid_device;
+pub mod io;
 mod opaque_device;
 mod operations;
 mod spi_device;
@@ -60,3 +61,6 @@ pub use operations::{read, select_erase_block, write};
 // Re-export detailed probe result
 #[cfg(feature = "std")]
 pub use operations::{ProbeResult, probe_detailed};
+
+#[cfg(all(test, feature = "alloc"))]
+mod io_tests;

--- a/crates/rflasher-core/src/flash/operations.rs
+++ b/crates/rflasher-core/src/flash/operations.rs
@@ -9,59 +9,14 @@ use alloc::vec::Vec;
 
 #[cfg(feature = "std")]
 use crate::chip::ChipProvider;
-use crate::chip::{EraseBlock, Features, WriteGranularity};
-use crate::error::{EraseFailure, Error, Result};
-use crate::programmer::{SpiFeatures, SpiMaster};
-use crate::protocol::{self, CommandAddressing};
+use crate::chip::EraseBlock;
+#[cfg(feature = "alloc")]
+use crate::chip::WriteGranularity;
+use crate::error::{Error, Result};
+use crate::programmer::SpiMaster;
+use crate::protocol;
 
-use super::context::{AddressMode, FlashContext};
-
-pub(crate) fn compatible_4byte_addressing(
-    chip_features: Features,
-    master_features: SpiFeatures,
-) -> Result<(CommandAddressing, bool)> {
-    if master_features.contains(SpiFeatures::NO_4BA_MODES) {
-        return Err(Error::ChipNotSupported);
-    }
-
-    if master_features.contains(SpiFeatures::FOUR_BYTE_ADDR)
-        && chip_features.supports_4ba_mode_switch()
-    {
-        return Ok((CommandAddressing::FourByte, true));
-    }
-
-    if chip_features.supports_extended_address_register() {
-        return Ok((
-            CommandAddressing::ExtendedAddressRegister(chip_features),
-            false,
-        ));
-    }
-
-    Err(Error::ChipNotSupported)
-}
-
-pub(crate) fn addressing_for_4byte_operation(
-    native_4byte: bool,
-    chip_features: Features,
-    master_features: SpiFeatures,
-) -> Result<(CommandAddressing, bool)> {
-    if native_4byte {
-        Ok((CommandAddressing::FourByte, false))
-    } else {
-        compatible_4byte_addressing(chip_features, master_features)
-    }
-}
-
-pub(crate) fn read_dummy_cycles(io_mode: crate::spi::IoMode) -> u8 {
-    match io_mode {
-        crate::spi::IoMode::Single => 0,
-        crate::spi::IoMode::DualOut => 8,
-        crate::spi::IoMode::DualIo => 4,
-        crate::spi::IoMode::QuadOut => 8,
-        crate::spi::IoMode::QuadIo => 6,
-        crate::spi::IoMode::Qpi => 0,
-    }
-}
+use super::context::FlashContext;
 
 // =============================================================================
 // Smart erase/write support
@@ -776,198 +731,61 @@ where
     })
 }
 
-/// Read flash contents
+/// Read flash contents using plain single-I/O commands.
 ///
-/// Automatically selects the best I/O mode based on programmer and chip capabilities.
-/// Uses dual or quad I/O when both the programmer and chip support it.
+/// This is the low-level standalone entry point: the SPI equivalent of
+/// flashprog's `default_spi_read`. It deliberately never selects multi-IO
+/// opcodes, so it is safe to use wherever the programmer's generic command
+/// path is single-IO-only (notably the Dediprog `CMD_TRANSCEIVE` path,
+/// whose bulk `CMD_READ` path is multi-IO-capable but whose transceive path
+/// rejects non-single framing) and wherever no QE bit has been established
+/// (erase verification, layout probing). Single-IO reads need no QE bit.
+///
+/// Prefer `SpiFlashDevice` / `HybridFlashDevice` for scoped multi-I/O reads and
+/// a retained cancellation latch. This low-level caller owns hardware recovery
+/// after cancellation.
 pub async fn read<M: SpiMaster + ?Sized>(
     master: &mut M,
     ctx: &FlashContext,
     addr: u32,
     buf: &mut [u8],
 ) -> Result<()> {
+    use super::io;
     if !ctx.is_valid_range(addr, buf.len()) {
         return Err(Error::AddressOutOfBounds);
     }
-    let features = ctx.chip.features;
-    let master_features = master.features();
-    let try_native_4byte =
-        ctx.address_mode == AddressMode::FourByte && features.supports_4ba_read();
-
-    let (io_mode, opcode, native_4byte) =
-        protocol::select_read_mode(master_features, features, try_native_4byte, |opcode| {
-            master.probe_opcode(opcode)
-        });
-
-    let (addressing, enter_exit_4byte) = if ctx.address_mode == AddressMode::FourByte {
-        addressing_for_4byte_operation(native_4byte, features, master_features)?
-    } else {
-        (CommandAddressing::ThreeByte, false)
-    };
-
-    if enter_exit_4byte {
-        protocol::enter_4byte_mode_with_features(master, features).await?;
-    }
-
-    let result = protocol::read_io_with_addressing(
-        master,
-        opcode,
-        addr,
-        buf,
-        addressing,
-        io_mode,
-        read_dummy_cycles(io_mode),
-    )
-    .await;
-
-    if enter_exit_4byte
-        && let Err(e) = protocol::exit_4byte_mode_with_features(master, features).await
-    {
-        log::warn!("Failed to exit 4-byte address mode: {}", e);
-    }
-
-    result
+    let plan = io::select_read_plan(master, ctx, true, |_| true)?;
+    io::IoLifecycle::default()
+        .run(
+            master,
+            plan.address,
+            protocol::QuadEnableMethod::None,
+            async |master| io::read_spi(master, &plan, addr, buf).await,
+        )
+        .await
 }
 
-/// Write data to flash
-///
-/// This function handles page alignment and splitting large writes
-/// into page-sized chunks. The target region must be erased first.
-///
-/// Respects the programmer's `max_write_len()` to avoid sending chunks
-/// larger than the hardware can handle (e.g., Intel swseq is limited to
-/// 64 bytes).
+/// Low-level write. The caller must recover hardware after cancellation; use a
+/// flash adapter when a persistent recovery-required latch is needed.
 pub async fn write<M: SpiMaster + ?Sized>(
     master: &mut M,
     ctx: &FlashContext,
     addr: u32,
     data: &[u8],
 ) -> Result<()> {
+    use super::io;
     if !ctx.is_valid_range(addr, data.len()) {
         return Err(Error::AddressOutOfBounds);
     }
-
-    let features = ctx.chip.features;
-    let write_granularity = ctx.chip.write_granularity;
-    let page_size = ctx.page_size();
-
-    // SST25 AAI word program: chip database sets AAI_WORD for SST25VFxxxB/SST25WFxxx.
-    // These chips require a streaming protocol (0xAD) rather than page program (0x02).
-    // AAI uses 3-byte addressing only — 4-byte mode is irrelevant for SST25 chips.
-    // Note: SFDP-probed chips may report WriteGranularity::Byte (BFPT DWORD1 bit[2]=0)
-    // without AAI_WORD being set; those fall through to single-byte page program below.
-    // Masters that cannot transfer two data bytes in one command skip AAI and use
-    // single-byte page program, which SST25 chips also support.
-    if features.contains(crate::chip::Features::AAI_WORD) && master.max_write_len() >= 2 {
-        return protocol::aai_word_program(master, addr, data).await;
-    }
-
-    let use_4byte = ctx.address_mode == AddressMode::FourByte;
-    let master_features = master.features();
-    let use_native = use_4byte
-        && features.supports_4ba_program()
-        && master_features.contains(SpiFeatures::FOUR_BYTE_ADDR)
-        && master.probe_opcode(crate::spi::opcodes::PP_4B);
-    let (addressing, enter_exit_4byte) = if use_4byte {
-        addressing_for_4byte_operation(use_native, features, master_features)?
-    } else {
-        (CommandAddressing::ThreeByte, false)
-    };
-    let opcode = if use_native {
-        crate::spi::opcodes::PP_4B
-    } else {
-        crate::spi::opcodes::PP
-    };
-
-    // Get the master's maximum write length - some controllers have limits
-    // smaller than a full page (e.g., Intel swseq is limited to 64 bytes)
-    let max_write = master.max_write_len();
-    if max_write == 0 {
-        // A zero limit would produce zero-sized chunks and never make progress
-        return Err(Error::ProgrammerError);
-    }
-
-    if enter_exit_4byte {
-        protocol::enter_4byte_mode_with_features(master, features).await?;
-    }
-
-    let mut offset = 0usize;
-    let mut current_addr = addr;
-
-    while offset < data.len() {
-        let remaining = data.len() - offset;
-
-        let chunk_size = if write_granularity == WriteGranularity::Byte {
-            // Single-byte page program: one byte per WREN+PP+WIP cycle.
-            // Used for SFDP-detected chips reporting byte granularity (BFPT DWORD1
-            // bit[2]=0) that don't have AAI_WORD — matches flashprog spi_chip_write_1.
-            1
-        } else {
-            // Page-granularity program: up to a full page per command, respecting
-            // page boundaries and the master's maximum write length.
-            let page_offset = (current_addr as usize) % page_size;
-            let bytes_to_page_end = page_size - page_offset;
-            core::cmp::min(core::cmp::min(bytes_to_page_end, remaining), max_write)
-        };
-
-        let chunk = &data[offset..offset + chunk_size];
-
-        let result =
-            protocol::program_page_with_addressing(master, opcode, current_addr, chunk, addressing)
-                .await;
-
-        if result.is_err() {
-            if enter_exit_4byte
-                && let Err(e) = protocol::exit_4byte_mode_with_features(master, features).await
-            {
-                log::warn!("Failed to exit 4-byte address mode: {}", e);
-            }
-            return result;
-        }
-
-        offset += chunk_size;
-        current_addr += chunk_size as u32;
-    }
-
-    if enter_exit_4byte {
-        protocol::exit_4byte_mode_with_features(master, features).await?;
-    }
-
-    Ok(())
-}
-
-/// Check that a range of flash has been erased (all bytes are 0xFF)
-///
-/// Reads through the full read path (I/O mode selection, 4-byte addressing)
-/// and returns [`Error::EraseError`] with the exact address of the first
-/// non-erased byte on failure.
-pub async fn check_erased_range<M: SpiMaster + ?Sized>(
-    master: &mut M,
-    ctx: &FlashContext,
-    addr: u32,
-    len: u32,
-) -> Result<()> {
-    const CHUNK_SIZE: usize = 4096;
-    let mut buf = [0u8; CHUNK_SIZE];
-
-    let mut offset = 0u32;
-    while offset < len {
-        let chunk_len = core::cmp::min(CHUNK_SIZE as u32, len - offset) as usize;
-        let chunk_buf = &mut buf[..chunk_len];
-
-        read(master, ctx, addr + offset, chunk_buf).await?;
-
-        if let Some((idx, &found)) = chunk_buf.iter().enumerate().find(|&(_, &b)| b != 0xFF) {
-            return Err(Error::EraseError(EraseFailure::VerifyFailed {
-                addr: addr + offset + idx as u32,
-                found,
-            }));
-        }
-
-        offset += chunk_len as u32;
-    }
-
-    Ok(())
+    let plan = io::select_write_plan(master, ctx, |_| true)?;
+    io::IoLifecycle::default()
+        .run(
+            master,
+            plan.address,
+            protocol::QuadEnableMethod::None,
+            async |master| io::write_spi(master, &plan, addr, data).await,
+        )
+        .await
 }
 
 /// Select the best erase block size for the given operation

--- a/crates/rflasher-core/src/flash/spi_device.rs
+++ b/crates/rflasher-core/src/flash/spi_device.rs
@@ -1,266 +1,164 @@
-//! SPI flash device adapter
-//!
-//! This module provides `SpiFlashDevice`, an adapter that implements
-//! `FlashDevice` for SPI-based programmers.
-
+//! SpiFlashDevice: operation-scoped SPI flash access.
 use crate::chip::{EraseBlock, WriteGranularity};
 use crate::error::{Error, Result};
-use crate::flash::context::{AddressMode, FlashContext};
-use crate::flash::device::FlashDevice;
-use crate::flash::operations::addressing_for_4byte_operation;
-use crate::flash::{operations, select_erase_block};
-use crate::programmer::{SpiFeatures, SpiMaster};
-use crate::protocol::{self, CommandAddressing};
+use crate::flash::io::{self, IoLifecycle};
+use crate::flash::{FlashContext, FlashDevice};
+use crate::programmer::SpiMaster;
+use crate::protocol;
 use crate::wp::{
     self, RangeDecoder, WpBits, WpConfig, WpMode, WpRange, WpRegBitMap, WpResult, WriteOptions,
 };
 
-/// Flash device adapter for SPI-based programmers
-///
-/// This wraps a `SpiMaster` implementation along with the `FlashContext`
-/// (chip metadata from JEDEC probing) to provide the unified `FlashDevice`
-/// interface.
-///
-/// # Example
-///
-/// ```ignore
-/// use rflasher_core::flash::{SpiFlashDevice, probe};
-/// use rflasher_core::chip::ChipProvider;
-/// use rflasher_programmers::ch341a::Ch341a;
-///
-/// fn create_flash_handle(db: &dyn ChipProvider) -> SpiFlashDevice<Ch341a> {
-///     let mut master = Ch341a::open().unwrap();
-///     let ctx = probe(&mut master, db).unwrap();
-///     SpiFlashDevice::new(master, ctx)
-/// }
-/// ```
+/// Adapter assuming an externally established ordinary-SPI, three-byte baseline.
+/// Probe does not reset the chip. After cancellation/failed cleanup, explicitly
+/// recover the hardware and reprobe; USB disconnect alone is not recovery.
 pub struct SpiFlashDevice<M: SpiMaster> {
-    /// Owned SPI master
     master: M,
-    /// Flash chip context
     ctx: FlashContext,
+    lifecycle: IoLifecycle,
 }
-
 impl<M: SpiMaster> SpiFlashDevice<M> {
-    /// Create a new SPI flash device adapter
-    ///
-    /// # Arguments
-    /// * `master` - The SPI master to take ownership of
-    /// * `ctx` - Flash context with chip metadata (from probing)
+    /// Construct on a known idle ordinary-SPI, three-byte baseline.
     pub fn new(master: M, ctx: FlashContext) -> Self {
-        SpiFlashDevice { master, ctx }
+        Self {
+            master,
+            ctx,
+            lifecycle: IoLifecycle::default(),
+        }
     }
-
-    /// Get a mutable reference to the underlying SPI master
+    /// Low-level escape: caller owns hardware recovery if the adapter is latched.
     pub fn master(&mut self) -> &mut M {
         &mut self.master
     }
-
-    /// Get a reference to the flash context
+    /// Chip metadata; this does not describe temporary hardware state.
     pub fn context(&self) -> &FlashContext {
         &self.ctx
     }
-
-    /// Get a mutable reference to the flash context
+    /// Mutable chip metadata, not a hardware recovery mechanism.
     pub fn context_mut(&mut self) -> &mut FlashContext {
         &mut self.ctx
     }
-
-    /// Consume the adapter and return the flash context
+    /// Whether explicit hardware recovery and reprobe are required.
+    pub fn recovery_required(&self) -> bool {
+        self.lifecycle.recovery_required()
+    }
+    /// Consume the adapter, discarding its master.
     pub fn into_context(self) -> FlashContext {
         self.ctx
     }
-
-    /// Consume the adapter and return both the SPI master and flash context
+    /// Low-level escape, not recovery. Do not reconstruct an adapter on uncertain hardware.
     pub fn into_parts(self) -> (M, FlashContext) {
         (self.master, self.ctx)
     }
 }
-
 impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
     fn size(&self) -> u32 {
-        self.context().total_size() as u32
+        self.ctx.total_size() as u32
     }
-
     fn erase_granularity(&self) -> u32 {
-        self.context().chip.min_erase_size().unwrap_or(4096) // Default to 4KB if no erase blocks defined
+        self.ctx.chip.min_erase_size().unwrap_or(4096)
     }
-
     fn write_granularity(&self) -> WriteGranularity {
-        self.context().chip.write_granularity
+        self.ctx.chip.write_granularity
     }
-
     fn erase_blocks(&self) -> &[EraseBlock] {
-        self.context().chip.erase_blocks()
+        self.ctx.chip.erase_blocks()
     }
-
     fn page_size(&self) -> u32 {
         self.ctx.page_size() as u32
     }
-
-    // Write protection support
     #[cfg(feature = "alloc")]
     fn wp_supported(&self) -> bool {
         true
     }
-
     #[cfg(feature = "alloc")]
     async fn read_wp_config(&mut self) -> WpResult<WpConfig> {
         SpiFlashDevice::read_wp_config(self).await
     }
-
     #[cfg(feature = "alloc")]
     async fn write_wp_config(&mut self, config: &WpConfig, options: WriteOptions) -> WpResult<()> {
         SpiFlashDevice::write_wp_config(self, config, options).await
     }
-
     #[cfg(feature = "alloc")]
     async fn set_wp_mode(&mut self, mode: WpMode, options: WriteOptions) -> WpResult<()> {
         SpiFlashDevice::set_wp_mode(self, mode, options).await
     }
-
     #[cfg(feature = "alloc")]
     async fn set_wp_range(&mut self, range: &WpRange, options: WriteOptions) -> WpResult<()> {
         SpiFlashDevice::set_wp_range(self, range, options).await
     }
-
     #[cfg(feature = "alloc")]
     async fn disable_wp(&mut self, options: WriteOptions) -> WpResult<()> {
         SpiFlashDevice::disable_wp(self, options).await
     }
-
     #[cfg(feature = "alloc")]
     fn get_available_wp_ranges(&self) -> alloc::vec::Vec<WpRange> {
         SpiFlashDevice::get_available_wp_ranges(self)
     }
 
     async fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
-        if !self.context().is_valid_range(addr, buf.len()) {
+        self.lifecycle.check()?;
+        if !self.ctx.is_valid_range(addr, buf.len()) {
             return Err(Error::AddressOutOfBounds);
         }
-        // Delegate to the canonical free function to avoid divergent duplicates
-        operations::read(&mut self.master, &self.ctx, addr, buf).await
+        let plan = io::select_read_plan(&self.master, &self.ctx, false, |_| true)?;
+        self.lifecycle
+            .run(&mut self.master, plan.address, plan.qe, async |master| {
+                io::read_spi(master, &plan, addr, buf).await
+            })
+            .await
     }
-
     async fn write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
-        if !self.context().is_valid_range(addr, data.len()) {
+        self.lifecycle.check()?;
+        if !self.ctx.is_valid_range(addr, data.len()) {
             return Err(Error::AddressOutOfBounds);
         }
-        // Delegate to the canonical free function (handles AAI word program,
-        // byte-granularity chips, page splitting and 4-byte addressing)
-        operations::write(&mut self.master, &self.ctx, addr, data).await
-    }
-
-    async fn erase(&mut self, addr: u32, len: u32) -> Result<()> {
-        use crate::chip::Features;
-
-        let ctx = self.context();
-        if !ctx.is_valid_range(addr, len as usize) {
-            return Err(Error::AddressOutOfBounds);
-        }
-
-        // Extract what we need from ctx before taking a mutable borrow on self.master()
-        let needs_sst26_unprotect = ctx.chip.features.contains(Features::SST26_BPR);
-
-        // SST26 chips use a per-block protection register (not SR BP bits).
-        // A global unlock (WREN + ULBPR 0x98) is required before any erase succeeds.
-        // This is equivalent to flashprog's ssi_disable_blockprotect_sst26_global_unprotect().
-        if needs_sst26_unprotect {
-            protocol::sst26_global_unprotect(self.master()).await?;
-        }
-
-        // Re-borrow ctx after the mutable borrow above is released
-        let ctx = self.context();
-
-        // Find the best erase block size for this operation
-        let erase_block = select_erase_block(ctx.chip.erase_blocks(), addr, len)
-            .ok_or(Error::InvalidAlignment)?;
-
-        let chip_features = ctx.chip.features;
-        let use_4byte = ctx.address_mode == AddressMode::FourByte;
-        let master_features = self.master.features();
-        let use_native = use_4byte
-            && erase_block.opcode_4b.is_some_and(|opcode| {
-                master_features.contains(SpiFeatures::FOUR_BYTE_ADDR)
-                    && self.master.probe_opcode(opcode)
-            });
-        let opcode = erase_block.opcode_for_address_width(use_native);
-        let (addressing, enter_exit_4byte) = if use_4byte {
-            addressing_for_4byte_operation(use_native, chip_features, master_features)?
-        } else {
-            (CommandAddressing::ThreeByte, false)
-        };
-
-        if enter_exit_4byte {
-            protocol::enter_4byte_mode_with_features(self.master(), chip_features).await?;
-        }
-
-        let mut current_addr = addr;
-        let end_addr = addr + len;
-
-        // For non-uniform erase blocks, use the maximum block size for timeout calculation
-        let max_block_size = erase_block.max_block_size();
-
-        // Poll delay and timeout depend on block size
-        let (poll_delay_us, timeout_us) = match max_block_size {
-            s if s <= 4096 => (10_000, 1_000_000), // 4KB: 10ms poll, 1s timeout
-            s if s <= 32768 => (100_000, 4_000_000), // 32KB: 100ms poll, 4s timeout
-            s if s <= 65536 => (100_000, 4_000_000), // 64KB: 100ms poll, 4s timeout
-            _ => (500_000, 60_000_000),            // Larger: 500ms poll, 60s timeout
-        };
-
-        while current_addr < end_addr {
-            // Get the block size at the current offset within the erase layout
-            let offset_in_layout = current_addr - addr;
-            let block_size = erase_block
-                .block_size_at_offset(offset_in_layout)
-                .unwrap_or(max_block_size);
-
-            let result = protocol::erase_block(
-                self.master(),
-                opcode,
-                current_addr,
-                addressing,
-                poll_delay_us,
-                timeout_us,
+        let plan = io::select_write_plan(&self.master, &self.ctx, |_| true)?;
+        self.lifecycle
+            .run(
+                &mut self.master,
+                plan.address,
+                protocol::QuadEnableMethod::None,
+                async |master| io::write_spi(master, &plan, addr, data).await,
             )
-            .await;
-
-            if result.is_err() {
-                if enter_exit_4byte
-                    && let Err(e) =
-                        protocol::exit_4byte_mode_with_features(self.master(), chip_features).await
-                {
-                    log::warn!("Failed to exit 4-byte address mode: {}", e);
-                }
-                return result;
-            }
-
-            current_addr += block_size;
+            .await
+    }
+    async fn erase(&mut self, addr: u32, len: u32) -> Result<()> {
+        self.lifecycle.check()?;
+        if !self.ctx.is_valid_range(addr, len as usize) {
+            return Err(Error::AddressOutOfBounds);
         }
-
-        if enter_exit_4byte {
-            protocol::exit_4byte_mode_with_features(self.master(), chip_features).await?;
-        }
-
-        // Verify only after the erase loop has left its persistent 4-byte
-        // mode. The read helper manages 4-byte mode itself; calling it inside
-        // the loop would exit that mode and make the next legacy erase opcode
-        // target the wrong address.
-        self.check_erased_range(addr, len).await
+        let plan = io::select_erase_plan(&self.master, &self.ctx, addr, len)?;
+        let verify_plan = io::select_read_plan(&self.master, &self.ctx, true, |_| true)?;
+        let unprotect = self
+            .ctx
+            .chip
+            .features
+            .contains(crate::chip::Features::SST26_BPR);
+        self.lifecycle
+            .run(
+                &mut self.master,
+                plan.address,
+                protocol::QuadEnableMethod::None,
+                async |master| {
+                    if unprotect {
+                        protocol::sst26_global_unprotect(master).await?;
+                    }
+                    io::erase_spi(master, &plan, addr, len).await
+                },
+            )
+            .await?;
+        // Verification owns a fresh, single-I/O scope after erase addressing is restored.
+        io::verify_erased(
+            &mut self.lifecycle,
+            &mut self.master,
+            &verify_plan,
+            addr,
+            len,
+        )
+        .await
     }
 }
-
-impl<M: SpiMaster> SpiFlashDevice<M> {
-    /// Check that a range of flash has been erased (all bytes are 0xFF)
-    async fn check_erased_range(&mut self, addr: u32, len: u32) -> Result<()> {
-        operations::check_erased_range(&mut self.master, &self.ctx, addr, len).await
-    }
-}
-
-// =============================================================================
-// Write Protection Support
-// =============================================================================
 
 impl<M: SpiMaster> SpiFlashDevice<M> {
     /// Get the WP register bit map for this chip
@@ -286,38 +184,47 @@ impl<M: SpiMaster> SpiFlashDevice<M> {
 
     /// Read current write protection bits
     pub async fn read_wp_bits(&mut self) -> WpResult<WpBits> {
+        self.lifecycle.check()?;
         let bit_map = self.wp_bit_map();
-        wp::read_wp_bits(&mut self.master, &bit_map).await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| wp::read_wp_bits(master, &bit_map).await,
+            )
+            .await
     }
 
     /// Read current write protection configuration
     pub async fn read_wp_config(&mut self) -> WpResult<WpConfig> {
+        self.lifecycle.check()?;
         let bit_map = self.wp_bit_map();
         let decoder = self.wp_decoder();
         let total_size = self.ctx.chip.total_size;
-        wp::read_wp_config(&mut self.master, &bit_map, total_size, decoder).await
-    }
-
-    /// Augment `WriteOptions` with chip-specific settings derived from feature flags.
-    ///
-    /// Injects `use_ewsr = true` when the chip has `WRSR_EWSR` (legacy SST25 chips
-    /// that require EWSR (0x50) instead of WREN (0x06) before status register writes).
-    fn chip_write_options(&self, options: WriteOptions) -> WriteOptions {
-        WriteOptions {
-            use_ewsr: self
-                .ctx
-                .chip
-                .features
-                .contains(crate::chip::Features::WRSR_EWSR),
-            ..options
-        }
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| wp::read_wp_config(master, &bit_map, total_size, decoder).await,
+            )
+            .await
     }
 
     /// Write write protection bits
     pub async fn write_wp_bits(&mut self, bits: &WpBits, options: WriteOptions) -> WpResult<()> {
+        self.lifecycle.check()?;
+        let options = wp::chip_write_options(self.ctx.chip.features, options);
         let bit_map = self.wp_bit_map();
-        let options = self.chip_write_options(options);
-        wp::write_wp_bits(&mut self.master, bits, &bit_map, options).await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| wp::write_wp_bits(master, bits, &bit_map, options).await,
+            )
+            .await
     }
 
     /// Write write protection configuration
@@ -326,50 +233,71 @@ impl<M: SpiMaster> SpiFlashDevice<M> {
         config: &WpConfig,
         options: WriteOptions,
     ) -> WpResult<()> {
+        self.lifecycle.check()?;
+        let options = wp::chip_write_options(self.ctx.chip.features, options);
         let bit_map = self.wp_bit_map();
         let decoder = self.wp_decoder();
         let total_size = self.ctx.chip.total_size;
-        let options = self.chip_write_options(options);
-        wp::write_wp_config(
-            &mut self.master,
-            config,
-            &bit_map,
-            total_size,
-            decoder,
-            options,
-        )
-        .await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| {
+                    wp::write_wp_config(master, config, &bit_map, total_size, decoder, options)
+                        .await
+                },
+            )
+            .await
     }
 
     /// Set write protection mode
     pub async fn set_wp_mode(&mut self, mode: WpMode, options: WriteOptions) -> WpResult<()> {
+        self.lifecycle.check()?;
+        let options = wp::chip_write_options(self.ctx.chip.features, options);
         let bit_map = self.wp_bit_map();
-        let options = self.chip_write_options(options);
-        wp::set_wp_mode(&mut self.master, mode, &bit_map, options).await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| wp::set_wp_mode(master, mode, &bit_map, options).await,
+            )
+            .await
     }
 
     /// Set protected range
     pub async fn set_wp_range(&mut self, range: &WpRange, options: WriteOptions) -> WpResult<()> {
+        self.lifecycle.check()?;
+        let options = wp::chip_write_options(self.ctx.chip.features, options);
         let bit_map = self.wp_bit_map();
         let decoder = self.wp_decoder();
         let total_size = self.ctx.chip.total_size;
-        let options = self.chip_write_options(options);
-        wp::set_wp_range(
-            &mut self.master,
-            range,
-            &bit_map,
-            total_size,
-            decoder,
-            options,
-        )
-        .await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| {
+                    wp::set_wp_range(master, range, &bit_map, total_size, decoder, options).await
+                },
+            )
+            .await
     }
 
     /// Disable write protection
     pub async fn disable_wp(&mut self, options: WriteOptions) -> WpResult<()> {
+        self.lifecycle.check()?;
+        let options = wp::chip_write_options(self.ctx.chip.features, options);
         let bit_map = self.wp_bit_map();
-        let options = self.chip_write_options(options);
-        wp::disable_wp(&mut self.master, &bit_map, options).await
+        self.lifecycle
+            .run(
+                &mut self.master,
+                io::AddressPlan::ThreeByte,
+                protocol::QuadEnableMethod::None,
+                async |master| wp::disable_wp(master, &bit_map, options).await,
+            )
+            .await
     }
 
     /// Get all available protection ranges

--- a/crates/rflasher-core/src/programmer/traits.rs
+++ b/crates/rflasher-core/src/programmer/traits.rs
@@ -111,8 +111,7 @@ pub trait SpiMaster {
     /// - `QuadIo` (1-4-4): Opcode single, address and data quad
     /// - `Qpi` (4-4-4): All phases use quad I/O
     ///
-    /// If the requested mode isn't supported, implementations should fall back
-    /// to single I/O mode and optionally log a warning.
+    /// Unsupported framing must be rejected, never silently downgraded.
     async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> Result<()>;
 
     /// Check if an opcode is supported by this programmer
@@ -121,6 +120,12 @@ pub trait SpiMaster {
     /// opcodes can be executed. Returns true if the opcode is allowed.
     fn probe_opcode(&self, _opcode: u8) -> bool {
         true
+    }
+
+    /// Whether the read path can emit this dummy phase without extra clocks.
+    /// Byte-oriented masters use the command header's lane width by default.
+    fn supports_read_dummy_cycles(&self, mode: crate::spi::IoMode, cycles: u8) -> bool {
+        crate::spi::dummy_cycles_representable(mode, cycles)
     }
 
     /// Delay for the specified number of microseconds
@@ -156,6 +161,47 @@ pub trait OpaqueMaster {
     /// * `addr` - Starting address to erase
     /// * `len` - Number of bytes to erase
     async fn erase(&mut self, addr: u32, len: u32) -> Result<()>;
+
+    /// Pure whole-path capability checks; defaults never claim plan support.
+    fn supports_read_plan(&self, _plan: &crate::flash::io::ReadPlan) -> bool {
+        false
+    }
+    /// Whether the complete program path represents this plan, without I/O.
+    fn supports_write_plan(&self, _plan: &crate::flash::io::WritePlan) -> bool {
+        false
+    }
+    /// Whether firmware erase represents this plan, without I/O.
+    fn supports_erase_plan(&self, _plan: &crate::flash::io::ErasePlan) -> bool {
+        false
+    }
+    /// Execute exactly this plan, or fail before I/O. Raw opaque methods do not
+    /// substitute for planned transfers: opaque devices may lack SPI metadata.
+    async fn read_planned(
+        &mut self,
+        _plan: &crate::flash::io::ReadPlan,
+        _addr: u32,
+        _buf: &mut [u8],
+    ) -> Result<()> {
+        Err(crate::error::Error::ChipNotSupported)
+    }
+    /// Execute the explicit program plan, or fail before I/O.
+    async fn write_planned(
+        &mut self,
+        _plan: &crate::flash::io::WritePlan,
+        _addr: u32,
+        _data: &[u8],
+    ) -> Result<()> {
+        Err(crate::error::Error::ChipNotSupported)
+    }
+    /// Execute the explicit erase plan, or fail before I/O; never retry on failure.
+    async fn erase_planned(
+        &mut self,
+        _plan: &crate::flash::io::ErasePlan,
+        _addr: u32,
+        _len: u32,
+    ) -> Result<()> {
+        Err(crate::error::Error::ChipNotSupported)
+    }
 }
 
 // Note: `SpiMaster` uses `async fn` and is therefore not directly usable as
@@ -196,6 +242,9 @@ where
     use crate::spi::check_io_mode_supported;
 
     check_io_mode_supported(cmd.io_mode, features)?;
+    if !crate::spi::dummy_cycles_representable(cmd.io_mode, cmd.dummy_cycles) {
+        return Err(crate::error::Error::ProgrammerError);
+    }
 
     let header_len = cmd.header_len();
     let mut write_data = alloc::vec![0u8; header_len + cmd.write_data.len()];
@@ -231,6 +280,9 @@ where
     use crate::spi::check_io_mode_supported;
 
     check_io_mode_supported(cmd.io_mode, features)?;
+    if !crate::spi::dummy_cycles_representable(cmd.io_mode, cmd.dummy_cycles) {
+        return Err(crate::error::Error::ProgrammerError);
+    }
 
     let header_len = cmd.header_len();
     let mut write_data = alloc::vec![0u8; header_len + cmd.write_data.len()];

--- a/crates/rflasher-core/src/protocol/spi25.rs
+++ b/crates/rflasher-core/src/protocol/spi25.rs
@@ -491,13 +491,17 @@ pub async fn exit_4byte_mode<M: SpiMaster + ?Sized>(master: &mut M) -> Result<()
     master.execute(&mut cmd).await
 }
 
-fn extended_address_write_opcode(features: crate::chip::Features) -> Result<u8> {
+/// EAR read/write opcodes. Codegen also sets the generic capability for explicit
+/// variants, so the legacy C8/C5 fallback must not override an explicit 16/17 pair.
+pub(crate) fn extended_address_opcodes(features: crate::chip::Features) -> Result<(u8, u8)> {
     use crate::chip::Features;
 
-    if features.contains(Features::EXT_ADDR_REG_C5C8) || features.contains(Features::EXT_ADDR_REG) {
-        Ok(opcodes::WREAR)
+    if features.contains(Features::EXT_ADDR_REG_C5C8) {
+        Ok((opcodes::RDEAR, opcodes::WREAR))
     } else if features.contains(Features::EXT_ADDR_REG_1716) {
-        Ok(opcodes::WREAR_ALT)
+        Ok((opcodes::RDEAR_ALT, opcodes::WREAR_ALT))
+    } else if features.contains(Features::EXT_ADDR_REG) {
+        Ok((opcodes::RDEAR, opcodes::WREAR))
     } else {
         Err(Error::ChipNotSupported)
     }
@@ -509,7 +513,7 @@ pub async fn set_extended_address<M: SpiMaster + ?Sized>(
     features: crate::chip::Features,
     addr_high: u8,
 ) -> Result<()> {
-    let opcode = extended_address_write_opcode(features)?;
+    let (_, opcode) = extended_address_opcodes(features)?;
     write_enable(master).await?;
     let data = [addr_high];
     let mut cmd = SpiCommand::write_reg(opcode, &data);
@@ -619,8 +623,25 @@ async fn read_multi_io<M: SpiMaster + ?Sized>(
     io_mode: IoMode,
     dummy_cycles: u8,
 ) -> Result<()> {
+    if !master.supports_read_dummy_cycles(io_mode, dummy_cycles) {
+        return Err(Error::ProgrammerError);
+    }
+    if addressing == CommandAddressing::ThreeByte && addr as u64 + buf.len() as u64 > 0x01_00_00_00
+    {
+        // A 24-bit address cannot reach beyond 16 MiB: the transfer would
+        // silently alias into the low 16 MiB. Fail closed instead.
+        return Err(Error::AddressOutOfBounds);
+    }
+
     let max_len = master.max_read_len();
+    if max_len == 0 {
+        return Err(Error::ProgrammerError);
+    }
     let mut offset = 0;
+    // The extended-address register is sticky: only rewrite it (WREN +
+    // WREAR) when the high address byte actually changes, mirroring
+    // flashprog's caching of the high byte across chunks in one bank.
+    let mut last_ear: Option<u8> = None;
 
     while offset < buf.len() {
         let current_addr = addr + offset as u32;
@@ -629,7 +650,11 @@ async fn read_multi_io<M: SpiMaster + ?Sized>(
         let chunk = &mut buf[offset..offset + chunk_len];
 
         if let CommandAddressing::ExtendedAddressRegister(features) = addressing {
-            set_extended_address(master, features, (current_addr >> 24) as u8).await?;
+            let ear = (current_addr >> 24) as u8;
+            if last_ear != Some(ear) {
+                set_extended_address(master, features, ear).await?;
+                last_ear = Some(ear);
+            }
         }
 
         let mut cmd = SpiCommand {
@@ -803,6 +828,44 @@ pub async fn read_quad_io_4b<M: SpiMaster + ?Sized>(
 }
 
 // ============================================================================
+// QPI Mode Entry / Exit
+// ============================================================================
+
+/// Enter QPI mode by sending the specified enter opcode.
+///
+/// Common values:
+/// - `0x35` (Macronix, AMIC, ISSI) — exit with `0xF5`
+/// - `0x38` (Winbond, GigaDevice, Eon, Fudan, Puya and others) — exit with `0xFF`
+pub async fn enter_qpi_with<M: SpiMaster + ?Sized>(master: &mut M, enter_opcode: u8) -> Result<()> {
+    let mut cmd = SpiCommand::simple(enter_opcode);
+    master.execute(&mut cmd).await
+}
+
+/// Exit QPI mode by sending the specified exit opcode in QPI framing.
+pub async fn exit_qpi_with<M: SpiMaster + ?Sized>(master: &mut M, exit_opcode: u8) -> Result<()> {
+    let mut cmd = SpiCommand::simple(exit_opcode).with_io_mode(IoMode::Qpi);
+    master.execute(&mut cmd).await
+}
+
+/// Set Read Parameters (SRP, 0xC0) to configure QPI dummy cycles.
+///
+/// Parameter byte encodes burst length and dummy cycles (chip-specific).
+/// Chips supporting this command: Macronix MX25L, ISSI IS25WP, some Spansion.
+pub async fn set_read_params<M: SpiMaster + ?Sized>(master: &mut M, params: u8) -> Result<()> {
+    let data = [params];
+    let mut cmd = SpiCommand {
+        opcode: 0xC0,
+        address: None,
+        address_width: AddressWidth::None,
+        io_mode: IoMode::Qpi,
+        dummy_cycles: 0,
+        write_data: &data,
+        read_buf: &mut [],
+    };
+    master.execute(&mut cmd).await
+}
+
+// ============================================================================
 // Quad Enable (QE) Functions
 // ============================================================================
 
@@ -818,13 +881,23 @@ pub enum QuadEnableMethod {
     Sr2Bit1WriteSr,
     /// QE is bit 6 of SR1
     Sr1Bit6,
-    /// QE is bit 7 of SR2 (use special sequence)
+    /// QE is bit 7 of SR2, written with the dedicated 0x31 command.
+    ///
+    /// This covers SFDP JESD216 requirement 0b011. Despite the historical
+    /// "special sequence" label, the wire format is a plain WREN + WRSR2
+    /// (0x31) write like [`QuadEnableMethod::Sr2Bit1WriteSr2`], only the bit
+    /// position differs.
     Sr2Bit7,
     /// QE is bit 1 of SR2, use dedicated 0x31 command
     Sr2Bit1WriteSr2,
 }
 
-/// Enable quad mode using the appropriate method for the chip
+/// Enable quad mode using the appropriate method for the chip.
+///
+/// This programs the QE bit **non-volatile** (WREN-prefixed write). Prefer
+/// `enable_quad_mode_volatile` for session QE establishment — the
+/// non-volatile form persists across power cycles and is kept only for
+/// callers that explicitly manage sticky QE state.
 pub async fn enable_quad_mode<M: SpiMaster + ?Sized>(
     master: &mut M,
     method: QuadEnableMethod,
@@ -867,7 +940,10 @@ pub async fn enable_quad_mode<M: SpiMaster + ?Sized>(
     }
 }
 
-/// Disable quad mode using the appropriate method for the chip
+/// Disable quad mode using the appropriate method for the chip.
+///
+/// Non-volatile counterpart of [`enable_quad_mode`]; see its docs on when
+/// (not) to use it. Session teardown uses `disable_quad_mode_volatile`.
 pub async fn disable_quad_mode<M: SpiMaster + ?Sized>(
     master: &mut M,
     method: QuadEnableMethod,
@@ -906,6 +982,131 @@ pub async fn disable_quad_mode<M: SpiMaster + ?Sized>(
     }
 }
 
+/// Write SR2 directly using opcode 0x31 with a volatile write enable.
+///
+/// Sends EWSR (0x50) instead of WREN (0x06) so the QE bit is set volatile
+/// and does not survive power cycles — mirrors flashprog's
+/// `spi_write_register(..., WRSR_VOLATILE_BITS)` used by `spi_prepare_quad_io`.
+async fn write_status2_direct_volatile<M: SpiMaster + ?Sized>(
+    master: &mut M,
+    value: u8,
+) -> Result<()> {
+    write_enable_ewsr(master).await?;
+    let data = [value];
+    let mut cmd = SpiCommand::write_reg(opcodes::WRSR2, &data);
+    master.execute(&mut cmd).await?;
+    wait_ready(master, WRSR_POLL_US, WRSR_TIMEOUT_US).await
+}
+
+/// Write status registers 1 and 2 together with a volatile write enable.
+///
+/// EWSR-prefixed variant of [`write_status12`]; the written bits do not
+/// persist across power cycles.
+async fn write_status12_volatile<M: SpiMaster + ?Sized>(
+    master: &mut M,
+    sr1: u8,
+    sr2: u8,
+) -> Result<()> {
+    write_status12_ewsr(master, sr1, sr2).await
+}
+
+/// Write status register 1 with a volatile write enable.
+///
+/// EWSR-prefixed variant of [`write_status1`]; the written bits do not
+/// persist across power cycles.
+async fn write_status1_volatile<M: SpiMaster + ?Sized>(master: &mut M, value: u8) -> Result<()> {
+    write_status1_ewsr(master, value).await
+}
+
+/// Enable quad mode with a volatile (non-persistent) status-register write.
+///
+/// Mirrors flashprog's `spi_prepare_quad_io`: the QE bit is set with an
+/// EWSR-prefixed write so it is lost on power cycle, and the caller is
+/// expected to confirm the bit afterwards and restore (clear) it in
+/// `finish` — see `disable_quad_mode_volatile`.
+///
+/// Returns `Ok` after issuing the write; like [`enable_quad_mode`] this does
+/// not itself confirm the bit — use [`is_quad_enabled`] afterwards.
+pub(crate) async fn enable_quad_mode_volatile<M: SpiMaster + ?Sized>(
+    master: &mut M,
+    method: QuadEnableMethod,
+) -> Result<()> {
+    match method {
+        QuadEnableMethod::None => Ok(()),
+        QuadEnableMethod::Sr2Bit1WriteSr => {
+            let sr1 = read_status1(master).await?;
+            let sr2 = read_status2(master).await?;
+            if sr2 & opcodes::SR2_QE != 0 {
+                return Ok(()); // Already enabled
+            }
+            write_status12_volatile(master, sr1, sr2 | opcodes::SR2_QE).await
+        }
+        QuadEnableMethod::Sr1Bit6 => {
+            let sr1 = read_status1(master).await?;
+            if sr1 & 0x40 != 0 {
+                return Ok(()); // Already enabled
+            }
+            write_status1_volatile(master, sr1 | 0x40).await
+        }
+        QuadEnableMethod::Sr2Bit7 => {
+            let sr2 = read_status2(master).await?;
+            if sr2 & 0x80 != 0 {
+                return Ok(()); // Already enabled
+            }
+            write_status2_direct_volatile(master, sr2 | 0x80).await
+        }
+        QuadEnableMethod::Sr2Bit1WriteSr2 => {
+            let sr2 = read_status2(master).await?;
+            if sr2 & opcodes::SR2_QE != 0 {
+                return Ok(()); // Already enabled
+            }
+            write_status2_direct_volatile(master, sr2 | opcodes::SR2_QE).await
+        }
+    }
+}
+
+/// Clear the QE bit with a volatile (non-persistent) status-register write.
+///
+/// Counterpart of `enable_quad_mode_volatile`, used to restore the
+/// pre-session QE state. Like flashprog's `spi_finish_io`, the caller tracks
+/// whether this session set the bit and only then calls this.
+pub(crate) async fn disable_quad_mode_volatile<M: SpiMaster + ?Sized>(
+    master: &mut M,
+    method: QuadEnableMethod,
+) -> Result<()> {
+    match method {
+        QuadEnableMethod::None => Ok(()),
+        QuadEnableMethod::Sr2Bit1WriteSr => {
+            let sr1 = read_status1(master).await?;
+            let sr2 = read_status2(master).await?;
+            if sr2 & opcodes::SR2_QE == 0 {
+                return Ok(()); // Already disabled
+            }
+            write_status12_volatile(master, sr1, sr2 & !opcodes::SR2_QE).await
+        }
+        QuadEnableMethod::Sr1Bit6 => {
+            let sr1 = read_status1(master).await?;
+            if sr1 & 0x40 == 0 {
+                return Ok(()); // Already disabled
+            }
+            write_status1_volatile(master, sr1 & !0x40).await
+        }
+        QuadEnableMethod::Sr2Bit7 => {
+            let sr2 = read_status2(master).await?;
+            if sr2 & 0x80 == 0 {
+                return Ok(()); // Already disabled
+            }
+            write_status2_direct_volatile(master, sr2 & !0x80).await
+        }
+        QuadEnableMethod::Sr2Bit1WriteSr2 => {
+            let sr2 = read_status2(master).await?;
+            if sr2 & opcodes::SR2_QE == 0 {
+                return Ok(()); // Already disabled
+            }
+            write_status2_direct_volatile(master, sr2 & !opcodes::SR2_QE).await
+        }
+    }
+}
 /// Write SR2 directly using opcode 0x31
 async fn write_status2_direct<M: SpiMaster + ?Sized>(master: &mut M, value: u8) -> Result<()> {
     write_enable(master).await?;
@@ -942,122 +1143,670 @@ pub async fn is_quad_enabled<M: SpiMaster + ?Sized>(
 // QPI Mode Functions
 // ============================================================================
 
-/// Enter QPI mode (4-4-4)
+/// Enter QPI mode (4-4-4). Delegates to [`enter_qpi_with`].
 ///
 /// Different chips use different opcodes - common ones are 0x35 and 0x38.
 pub async fn enter_qpi_mode<M: SpiMaster + ?Sized>(master: &mut M, opcode: u8) -> Result<()> {
-    let mut cmd = SpiCommand::simple(opcode);
-    master.execute(&mut cmd).await
+    enter_qpi_with(master, opcode).await
 }
 
-/// Exit QPI mode
+/// Exit QPI mode. Delegates to [`exit_qpi_with`].
 ///
 /// Common exit opcodes are 0xF5 and 0xFF.
 /// Note: This command must be sent in QPI mode (4-4-4).
 pub async fn exit_qpi_mode<M: SpiMaster + ?Sized>(master: &mut M, opcode: u8) -> Result<()> {
-    let mut cmd = SpiCommand {
-        opcode,
-        address: None,
-        address_width: AddressWidth::None,
-        io_mode: IoMode::Qpi,
-        dummy_cycles: 0,
-        write_data: &[],
-        read_buf: &mut [],
-    };
-    master.execute(&mut cmd).await
+    exit_qpi_with(master, opcode).await
 }
 
 // ============================================================================
 // Read Mode Selection Helper
 // ============================================================================
 
-/// Select the best available read mode based on programmer and chip capabilities.
+/// A chosen read operation.
 ///
-/// Returns the I/O mode, opcode, and whether the selected opcode is a native
-/// 4-byte-address opcode. Prefers higher bandwidth modes:
-/// Quad I/O > Quad Out > Dual I/O > Dual Out > Single.
-pub fn select_read_mode(
-    master_features: SpiFeatures,
-    chip_features: crate::chip::Features,
-    try_native_4byte: bool,
-    mut opcode_supported: impl FnMut(u8) -> bool,
-) -> (IoMode, u8, bool) {
-    let chip_has_dual = chip_features.contains(crate::chip::Features::DUAL_IO);
-    let chip_has_quad = chip_features.contains(crate::chip::Features::QUAD_IO);
+/// Carries everything a programmer needs to issue a flash read:
+/// - `opcode`: the SPI command byte
+/// - `io_mode`: the wire format (Single / DualOut / DualIo / QuadOut / QuadIo / Qpi)
+/// - `dummy_cycles`: total number of clock cycles (at the I/O mode's lane
+///   count) between end-of-address and start-of-data. For 1-2-2 / 1-4-4 /
+///   4-4-4 reads this includes the mode-byte (M7-M0) time. Programmers
+///   emit these clocks as 0xFF on the wire, which is safe as an M byte
+///   (top nibble ≠ 0xA, so continuous-read mode is not enabled on
+///   Winbond-family chips).
+/// - `native_4ba`: true if the opcode is the native 4-byte-address variant
+///   (chip already expects a 4-byte address, no EN4B needed)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpiReadOp {
+    /// SPI opcode byte
+    pub opcode: u8,
+    /// IO mode for the transaction
+    pub io_mode: IoMode,
+    /// Dummy clock cycles between address and data (includes M byte time)
+    pub dummy_cycles: u8,
+    /// Number of address bytes emitted for the command.
+    ///
+    /// This is independent of `native_4ba`: regular opcodes use four address
+    /// bytes while the chip is in EN4B compatibility mode.
+    pub address_width: AddressWidth,
+    /// True if `opcode` is a native 4-byte-address variant
+    pub native_4ba: bool,
+}
 
-    if try_native_4byte && master_features.contains(SpiFeatures::FOUR_BYTE_ADDR) {
-        let native_candidates: [(bool, SpiFeatures, IoMode, u8); 4] = [
-            (
-                chip_features.supports_4ba_quad_io_read(),
-                SpiFeatures::QUAD_IO,
-                IoMode::QuadIo,
-                opcodes::QIOR_4B,
-            ),
-            (
-                chip_features.supports_4ba_quad_out_read(),
-                SpiFeatures::QUAD_IN,
-                IoMode::QuadOut,
-                opcodes::QOR_4B,
-            ),
-            (
-                chip_features.supports_4ba_dual_io_read(),
-                SpiFeatures::DUAL_IO,
-                IoMode::DualIo,
-                opcodes::DIOR_4B,
-            ),
-            (
-                chip_features.supports_4ba_dual_out_read(),
-                SpiFeatures::DUAL_IN,
-                IoMode::DualOut,
-                opcodes::DOR_4B,
-            ),
-        ];
-
-        for (chip_capable, feature, mode, opcode) in native_candidates {
-            if chip_capable && master_features.contains(feature) && opcode_supported(opcode) {
-                return (mode, opcode, true);
-            }
-        }
-
-        if chip_features.supports_4ba_read() && opcode_supported(opcodes::READ_4B) {
-            return (IoMode::Single, opcodes::READ_4B, true);
+impl SpiReadOp {
+    /// Default `READ` (0x03), single I/O, 3-byte address, no dummy.
+    pub const fn sio_read() -> Self {
+        Self {
+            opcode: opcodes::READ,
+            io_mode: IoMode::Single,
+            dummy_cycles: 0,
+            address_width: AddressWidth::ThreeByte,
+            native_4ba: false,
         }
     }
 
-    // Compatibility-mode candidates. These opcodes may still be sent with a
-    // 32-bit address when the chip has been switched into 4BA mode.
-    let candidates: [(bool, SpiFeatures, IoMode, u8); 4] = [
-        (
-            chip_has_quad,
-            SpiFeatures::QUAD_IO,
-            IoMode::QuadIo,
-            opcodes::QIOR,
-        ),
-        (
-            chip_has_quad,
-            SpiFeatures::QUAD_IN,
-            IoMode::QuadOut,
-            opcodes::QOR,
-        ),
-        (
-            chip_has_dual,
-            SpiFeatures::DUAL_IO,
-            IoMode::DualIo,
-            opcodes::DIOR,
-        ),
-        (
-            chip_has_dual,
-            SpiFeatures::DUAL_IN,
-            IoMode::DualOut,
-            opcodes::DOR,
-        ),
+    /// Default `READ_4B` (0x13), single I/O, 4-byte address, no dummy.
+    pub const fn sio_read_4b() -> Self {
+        Self {
+            opcode: opcodes::READ_4B,
+            io_mode: IoMode::Single,
+            dummy_cycles: 0,
+            address_width: AddressWidth::FourByte,
+            native_4ba: true,
+        }
+    }
+
+    /// Address width implied by this read op.
+    pub const fn address_width(&self) -> AddressWidth {
+        self.address_width
+    }
+}
+
+/// Fine-grained chip capabilities for read-op selection.
+///
+/// This struct mirrors the relevant subset of `chip::Features` plus QPI mode
+/// state. It lets `select_read_op` stay free of direct chip-struct coupling
+/// (keeping `protocol` usable without the chip module).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ChipReadCapabilities {
+    /// Chip supports `FAST_READ` (0x0B / 0x0C)
+    pub fast_read: bool,
+    /// Chip supports 1-1-2 fast read (0x3B / 0x3C)
+    pub dout: bool,
+    /// Chip supports 1-2-2 fast read (0xBB / 0xBC)
+    pub dio: bool,
+    /// Chip supports 1-1-4 fast read (0x6B / 0x6C)
+    pub qout: bool,
+    /// Chip supports 1-4-4 fast read (0xEB / 0xEC)
+    pub qio: bool,
+    /// Chip supports 4-4-4 QPI fast read
+    pub qpi_fast_read: bool,
+    /// Chip supports native 4BA QPI read (0xEC)
+    pub qpi4b: bool,
+    /// Chip has a native 4-byte-addr single-IO read (0x0C / 0x13)
+    pub native_4ba_read: bool,
+    /// Chip has native 4BA fast read (0x0C).
+    pub native_4ba_fast_read: bool,
+    /// Chip has native 4BA dual-output read (0x3C).
+    pub native_4ba_dout: bool,
+    /// Chip has native 4BA dual-I/O read (0xBC).
+    pub native_4ba_dio: bool,
+    /// Chip has native 4BA quad-output read (0x6C).
+    pub native_4ba_qout: bool,
+    /// Chip has native 4BA quad-I/O read (0xEC).
+    pub native_4ba_qio: bool,
+    /// Chip currently in QPI mode (4-4-4)
+    pub in_qpi_mode: bool,
+}
+
+/// Dummy-cycle overrides: `None` uses the JEDEC default; `Some(n)` is exact, including zero.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DummyCycleOverrides {
+    /// 1-1-2 dummy cycles (default 8)
+    pub dc_112: Option<u8>,
+    /// 1-2-2 dummy cycles (default 4)
+    pub dc_122: Option<u8>,
+    /// 1-1-4 dummy cycles (default 8)
+    pub dc_114: Option<u8>,
+    /// 1-4-4 dummy cycles (default 6)
+    pub dc_144: Option<u8>,
+    /// QPI fast-read dummy cycles, in total clocks (mode + dummy).
+    ///
+    /// Default 8 for QPI-framed 0x0B, 6 for QPI-framed 0xEB (the JEDEC 0xEB
+    /// default: 2 mode clocks + 4 dummy clocks).
+    pub dc_qpi: Option<u8>,
+}
+
+/// JEDEC-default dummy cycle counts for each multi-IO read mode.
+///
+/// These mirror the values used in `read_dual_out_*`, `read_dual_io_*`,
+/// `read_quad_out_*`, `read_quad_io_*` helpers below.
+pub const DEFAULT_DUMMY_CYCLES_112: u8 = 8;
+/// JEDEC default dummy cycles for 1-2-2 dual-I/O read (0xBB)
+pub const DEFAULT_DUMMY_CYCLES_122: u8 = 4;
+/// JEDEC default dummy cycles for 1-1-4 quad-output read (0x6B)
+pub const DEFAULT_DUMMY_CYCLES_114: u8 = 8;
+/// JEDEC default dummy cycles for 1-4-4 quad-I/O read (0xEB)
+pub const DEFAULT_DUMMY_CYCLES_144: u8 = 6;
+/// Default dummy cycles for QPI (4-4-4) FAST_READ (0x0B).
+pub const DEFAULT_DUMMY_CYCLES_QPI_FAST_READ: u8 = 8;
+
+fn effective_dc(override_val: Option<u8>, default: u8) -> u8 {
+    override_val.unwrap_or(default)
+}
+
+/// Select the best available read operation based on programmer and chip capabilities.
+///
+/// Mirrors flashprog's `select_qpi_fast_read` and `select_multi_io_fast_read`
+/// in `spi25_prepare.c`. Prefers QPI > quad > dual > single with 4BA-native
+/// variants preferred when the address needs 4 bytes.
+pub fn select_read_op(
+    master_features: SpiFeatures,
+    chip: ChipReadCapabilities,
+    dc: DummyCycleOverrides,
+    use_4byte: bool,
+    allow_compatibility_4ba: bool,
+    mut opcode_supported: impl FnMut(u8) -> bool,
+) -> Option<SpiReadOp> {
+    let address_width = if use_4byte {
+        AddressWidth::FourByte
+    } else {
+        AddressWidth::ThreeByte
+    };
+
+    // QPI mode: all phases use four data lines.
+    if chip.in_qpi_mode && master_features.contains(SpiFeatures::QPI) {
+        if use_4byte
+            && chip.qpi4b
+            && master_features.contains(SpiFeatures::FOUR_BYTE_ADDR)
+            && opcode_supported(opcodes::QIOR_4B)
+        {
+            return Some(SpiReadOp {
+                opcode: opcodes::QIOR_4B,
+                io_mode: IoMode::Qpi,
+                dummy_cycles: effective_dc(dc.dc_qpi, DEFAULT_DUMMY_CYCLES_144),
+                address_width,
+                native_4ba: true,
+            });
+        }
+        if chip.qpi_fast_read
+            && (!use_4byte || allow_compatibility_4ba)
+            && opcode_supported(opcodes::QIOR)
+        {
+            return Some(SpiReadOp {
+                opcode: opcodes::QIOR,
+                io_mode: IoMode::Qpi,
+                dummy_cycles: effective_dc(dc.dc_qpi, DEFAULT_DUMMY_CYCLES_144),
+                address_width,
+                native_4ba: false,
+            });
+        }
+        if chip.fast_read
+            && (!use_4byte || allow_compatibility_4ba)
+            && opcode_supported(opcodes::FAST_READ)
+        {
+            return Some(SpiReadOp {
+                opcode: opcodes::FAST_READ,
+                io_mode: IoMode::Qpi,
+                dummy_cycles: effective_dc(dc.dc_qpi, DEFAULT_DUMMY_CYCLES_QPI_FAST_READ),
+                address_width,
+                native_4ba: false,
+            });
+        }
+    }
+
+    // A chip in QPI mode cannot execute single- or SPI-framed commands at
+    // all; unlike the SPI-mode fallbacks below, there is no degraded op to
+    // offer. flashprog instead exits QPI and retries (`spi_prepare_io`).
+    // Return None so the caller can do the same rather than bless a bogus op.
+    if chip.in_qpi_mode {
+        return None;
+    }
+
+    struct Candidate {
+        chip_capable: bool,
+        native_4ba_capable: bool,
+        master_feature: SpiFeatures,
+        io_mode: IoMode,
+        opcode: u8,
+        opcode_4ba: u8,
+        default_dummy_cycles: u8,
+        dummy_cycles_override: Option<u8>,
+    }
+
+    let candidates = [
+        Candidate {
+            chip_capable: chip.qio,
+            native_4ba_capable: chip.native_4ba_qio,
+            master_feature: SpiFeatures::QUAD_IO,
+            io_mode: IoMode::QuadIo,
+            opcode: opcodes::QIOR,
+            opcode_4ba: opcodes::QIOR_4B,
+            default_dummy_cycles: DEFAULT_DUMMY_CYCLES_144,
+            dummy_cycles_override: dc.dc_144,
+        },
+        Candidate {
+            chip_capable: chip.qout,
+            native_4ba_capable: chip.native_4ba_qout,
+            master_feature: SpiFeatures::QUAD_IN,
+            io_mode: IoMode::QuadOut,
+            opcode: opcodes::QOR,
+            opcode_4ba: opcodes::QOR_4B,
+            default_dummy_cycles: DEFAULT_DUMMY_CYCLES_114,
+            dummy_cycles_override: dc.dc_114,
+        },
+        Candidate {
+            chip_capable: chip.dio,
+            native_4ba_capable: chip.native_4ba_dio,
+            master_feature: SpiFeatures::DUAL_IO,
+            io_mode: IoMode::DualIo,
+            opcode: opcodes::DIOR,
+            opcode_4ba: opcodes::DIOR_4B,
+            default_dummy_cycles: DEFAULT_DUMMY_CYCLES_122,
+            dummy_cycles_override: dc.dc_122,
+        },
+        Candidate {
+            chip_capable: chip.dout,
+            native_4ba_capable: chip.native_4ba_dout,
+            master_feature: SpiFeatures::DUAL_IN,
+            io_mode: IoMode::DualOut,
+            opcode: opcodes::DOR,
+            opcode_4ba: opcodes::DOR_4B,
+            default_dummy_cycles: DEFAULT_DUMMY_CYCLES_112,
+            dummy_cycles_override: dc.dc_112,
+        },
     ];
 
-    for (chip_capable, feature, mode, opcode) in candidates {
-        if chip_capable && master_features.contains(feature) && opcode_supported(opcode) {
-            return (mode, opcode, false);
+    for candidate in candidates {
+        if !candidate.chip_capable || !master_features.contains(candidate.master_feature) {
+            continue;
+        }
+
+        if use_4byte
+            && candidate.native_4ba_capable
+            && master_features.contains(SpiFeatures::FOUR_BYTE_ADDR)
+            && opcode_supported(candidate.opcode_4ba)
+        {
+            return Some(SpiReadOp {
+                opcode: candidate.opcode_4ba,
+                io_mode: candidate.io_mode,
+                dummy_cycles: effective_dc(
+                    candidate.dummy_cycles_override,
+                    candidate.default_dummy_cycles,
+                ),
+                address_width,
+                native_4ba: true,
+            });
+        }
+
+        if (!use_4byte || allow_compatibility_4ba) && opcode_supported(candidate.opcode) {
+            return Some(SpiReadOp {
+                opcode: candidate.opcode,
+                io_mode: candidate.io_mode,
+                dummy_cycles: effective_dc(
+                    candidate.dummy_cycles_override,
+                    candidate.default_dummy_cycles,
+                ),
+                address_width,
+                native_4ba: false,
+            });
         }
     }
 
-    (IoMode::Single, opcodes::READ, false)
+    if use_4byte && master_features.contains(SpiFeatures::FOUR_BYTE_ADDR) {
+        if chip.native_4ba_read && opcode_supported(opcodes::READ_4B) {
+            return Some(SpiReadOp::sio_read_4b());
+        }
+        if chip.fast_read && chip.native_4ba_fast_read && opcode_supported(opcodes::FAST_READ_4B) {
+            return Some(SpiReadOp {
+                opcode: opcodes::FAST_READ_4B,
+                io_mode: IoMode::Single,
+                dummy_cycles: 8,
+                address_width,
+                native_4ba: true,
+            });
+        }
+    }
+
+    if chip.fast_read
+        && (!use_4byte || allow_compatibility_4ba)
+        && opcode_supported(opcodes::FAST_READ)
+    {
+        return Some(SpiReadOp {
+            opcode: opcodes::FAST_READ,
+            io_mode: IoMode::Single,
+            dummy_cycles: 8,
+            address_width,
+            native_4ba: false,
+        });
+    }
+
+    if (use_4byte && !allow_compatibility_4ba) || !opcode_supported(opcodes::READ) {
+        return None;
+    }
+
+    Some(SpiReadOp {
+        opcode: opcodes::READ,
+        io_mode: IoMode::Single,
+        dummy_cycles: 0,
+        address_width,
+        native_4ba: false,
+    })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn all_mio_caps() -> ChipReadCapabilities {
+        ChipReadCapabilities {
+            fast_read: true,
+            dout: true,
+            dio: true,
+            qout: true,
+            qio: true,
+            qpi_fast_read: false,
+            qpi4b: false,
+            native_4ba_read: true,
+            native_4ba_fast_read: true,
+            native_4ba_dout: true,
+            native_4ba_dio: true,
+            native_4ba_qout: true,
+            native_4ba_qio: true,
+            in_qpi_mode: false,
+        }
+    }
+
+    #[test]
+    fn select_quad_io_when_both_sides_support() {
+        let master = SpiFeatures::FOUR_BYTE_ADDR
+            | SpiFeatures::DUAL_IN
+            | SpiFeatures::DUAL_IO
+            | SpiFeatures::QUAD_IN
+            | SpiFeatures::QUAD_IO;
+        let op = select_read_op(
+            master,
+            all_mio_caps(),
+            DummyCycleOverrides::default(),
+            false,
+            true,
+            |_| true,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.io_mode, IoMode::QuadIo);
+        assert_eq!(op.opcode, opcodes::QIOR);
+        assert_eq!(op.dummy_cycles, DEFAULT_DUMMY_CYCLES_144);
+        assert!(!op.native_4ba);
+    }
+
+    #[test]
+    fn select_quad_io_4b_when_4byte_addressing() {
+        let master = SpiFeatures::FOUR_BYTE_ADDR | SpiFeatures::QUAD_IN | SpiFeatures::QUAD_IO;
+        let op = select_read_op(
+            master,
+            all_mio_caps(),
+            DummyCycleOverrides::default(),
+            true,
+            true,
+            |_| true,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.io_mode, IoMode::QuadIo);
+        assert_eq!(op.opcode, opcodes::QIOR_4B);
+        assert_eq!(op.address_width, AddressWidth::FourByte);
+        assert!(op.native_4ba);
+    }
+
+    #[test]
+    fn four_byte_quad_io_falls_back_to_regular_opcode_in_en4b_mode() {
+        let master = SpiFeatures::FOUR_BYTE_ADDR | SpiFeatures::QUAD_IO;
+        let mut caps = all_mio_caps();
+        caps.native_4ba_qio = false;
+        let op = select_read_op(
+            master,
+            caps,
+            DummyCycleOverrides::default(),
+            true,
+            true,
+            |_| true,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.opcode, opcodes::QIOR);
+        assert_eq!(op.address_width, AddressWidth::FourByte);
+        assert!(!op.native_4ba);
+    }
+
+    #[test]
+    fn rejected_native_opcode_falls_back_to_regular_opcode() {
+        let master = SpiFeatures::FOUR_BYTE_ADDR | SpiFeatures::QUAD_IO;
+        let op = select_read_op(
+            master,
+            all_mio_caps(),
+            DummyCycleOverrides::default(),
+            true,
+            true,
+            |opcode| opcode != opcodes::QIOR_4B,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.opcode, opcodes::QIOR);
+        assert_eq!(op.address_width, AddressWidth::FourByte);
+        assert!(!op.native_4ba);
+    }
+
+    #[test]
+    fn four_byte_selection_fails_without_native_or_compatibility_addressing() {
+        let caps = ChipReadCapabilities {
+            fast_read: true,
+            ..Default::default()
+        };
+        let op = select_read_op(
+            SpiFeatures::empty(),
+            caps,
+            DummyCycleOverrides::default(),
+            true,
+            false,
+            |_| true,
+        );
+        assert!(op.is_none());
+    }
+
+    #[test]
+    fn fallback_to_dual_io_when_master_lacks_quad() {
+        let master = SpiFeatures::DUAL_IN | SpiFeatures::DUAL_IO;
+        let op = select_read_op(
+            master,
+            all_mio_caps(),
+            DummyCycleOverrides::default(),
+            false,
+            true,
+            |_| true,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.io_mode, IoMode::DualIo);
+        assert_eq!(op.opcode, opcodes::DIOR);
+        assert_eq!(op.dummy_cycles, DEFAULT_DUMMY_CYCLES_122);
+    }
+
+    #[test]
+    fn fallback_to_dual_out_when_chip_lacks_dio() {
+        let master = SpiFeatures::DUAL_IN | SpiFeatures::DUAL_IO;
+        let mut caps = all_mio_caps();
+        caps.dio = false;
+        caps.qio = false;
+        caps.qout = false;
+        let op = select_read_op(
+            master,
+            caps,
+            DummyCycleOverrides::default(),
+            false,
+            true,
+            |_| true,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.io_mode, IoMode::DualOut);
+        assert_eq!(op.opcode, opcodes::DOR);
+    }
+
+    #[test]
+    fn fallback_to_single_when_no_multiio() {
+        let master = SpiFeatures::empty();
+        let caps = ChipReadCapabilities {
+            fast_read: true,
+            ..Default::default()
+        };
+        let op = select_read_op(
+            master,
+            caps,
+            DummyCycleOverrides::default(),
+            false,
+            true,
+            |_| true,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.io_mode, IoMode::Single);
+        assert_eq!(op.opcode, opcodes::FAST_READ);
+    }
+
+    #[test]
+    fn dummy_cycle_overrides_apply() {
+        let master = SpiFeatures::QUAD_IN | SpiFeatures::QUAD_IO;
+        let dc = DummyCycleOverrides {
+            dc_144: Some(10),
+            ..Default::default()
+        };
+        let op = select_read_op(master, all_mio_caps(), dc, false, true, |_| true)
+            .expect("read operation should be selectable");
+        assert_eq!(op.io_mode, IoMode::QuadIo);
+        assert_eq!(op.dummy_cycles, 10);
+    }
+
+    #[test]
+    fn qpi_mode_uses_qpi_framing() {
+        let master = SpiFeatures::QPI | SpiFeatures::QUAD_IN | SpiFeatures::QUAD_IO;
+        let mut caps = all_mio_caps();
+        caps.in_qpi_mode = true;
+        caps.qpi_fast_read = true;
+        let op = select_read_op(
+            master,
+            caps,
+            DummyCycleOverrides::default(),
+            false,
+            true,
+            |_| true,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.io_mode, IoMode::Qpi);
+        assert_eq!(op.opcode, opcodes::QIOR);
+    }
+
+    #[test]
+    fn qpi_mode_uses_4b_opcode_when_supported_and_addr_4byte() {
+        let master = SpiFeatures::QPI | SpiFeatures::FOUR_BYTE_ADDR;
+        let mut caps = all_mio_caps();
+        caps.in_qpi_mode = true;
+        caps.qpi_fast_read = true;
+        caps.qpi4b = true;
+        let op = select_read_op(
+            master,
+            caps,
+            DummyCycleOverrides::default(),
+            true,
+            true,
+            |_| true,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.io_mode, IoMode::Qpi);
+        assert_eq!(op.opcode, opcodes::QIOR_4B);
+        assert!(op.native_4ba);
+    }
+
+    #[test]
+    fn qpi_dummy_cycles_default_per_opcode() {
+        let master = SpiFeatures::QPI | SpiFeatures::FOUR_BYTE_ADDR;
+        let mut caps = all_mio_caps();
+        caps.in_qpi_mode = true;
+        caps.qpi_fast_read = true;
+        caps.qpi4b = true;
+
+        // QIOR_4B falls back to the 1-4-4 default.
+        let op = select_read_op(
+            master,
+            caps,
+            DummyCycleOverrides::default(),
+            true,
+            true,
+            |_| true,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.opcode, opcodes::QIOR_4B);
+        assert_eq!(op.dummy_cycles, DEFAULT_DUMMY_CYCLES_144);
+
+        // QPI FAST_READ (no QIOR support) falls back to its own 8-cycle default.
+        let op = select_read_op(
+            master,
+            caps,
+            DummyCycleOverrides::default(),
+            false,
+            true,
+            |opcode| opcode != opcodes::QIOR,
+        )
+        .expect("read operation should be selectable");
+        assert_eq!(op.opcode, opcodes::FAST_READ);
+        assert_eq!(op.io_mode, IoMode::Qpi);
+        assert_eq!(op.dummy_cycles, DEFAULT_DUMMY_CYCLES_QPI_FAST_READ);
+
+        // A dc_qpi override wins over both opcode-specific defaults.
+        let dc = DummyCycleOverrides {
+            dc_qpi: Some(10),
+            ..Default::default()
+        };
+        let op = select_read_op(master, caps, dc, true, true, |_| true)
+            .expect("read operation should be selectable");
+        assert_eq!(op.opcode, opcodes::QIOR_4B);
+        assert_eq!(op.dummy_cycles, 10);
+    }
+
+    #[test]
+    fn qpi_fast_read_requires_chip_fast_read() {
+        let master = SpiFeatures::QPI;
+        let mut caps = all_mio_caps();
+        caps.in_qpi_mode = true;
+        caps.fast_read = false;
+        // No QPI-suitable op exists for this chip (no qpi_fast_read, no
+        // fast_read to reframe): selection must fail rather than hand back
+        // a single-IO 0x03 the QPI-mode chip could not execute. Callers
+        // (mirroring flashprog's spi_prepare_io) exit QPI and retry.
+        assert!(
+            select_read_op(
+                master,
+                caps,
+                DummyCycleOverrides::default(),
+                false,
+                true,
+                |_| true,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn sio_read_defaults() {
+        let op = SpiReadOp::sio_read();
+        assert_eq!(op.opcode, opcodes::READ);
+        assert_eq!(op.io_mode, IoMode::Single);
+        assert_eq!(op.dummy_cycles, 0);
+        assert!(!op.native_4ba);
+        assert_eq!(op.address_width(), AddressWidth::ThreeByte);
+    }
+
+    #[test]
+    fn sio_read_4b_defaults() {
+        let op = SpiReadOp::sio_read_4b();
+        assert_eq!(op.opcode, opcodes::READ_4B);
+        assert!(op.native_4ba);
+        assert_eq!(op.address_width(), AddressWidth::FourByte);
+    }
 }

--- a/crates/rflasher-core/src/sfdp/parser.rs
+++ b/crates/rflasher-core/src/sfdp/parser.rs
@@ -318,8 +318,10 @@ async fn parse_bfpt<M: SpiMaster + ?Sized>(
     }
 
     // Parse JESD216B+ additions (DWORDs 15-16)
-    if len >= 64 {
+    if len >= 60 {
         parse_bfpt_dword15(get_dword(56), &mut params); // DWORD 15
+    }
+    if len >= 64 {
         parse_bfpt_dword16(get_dword(60), &mut params); // DWORD 16
     }
 
@@ -469,7 +471,7 @@ pub async fn is_supported<M: SpiMaster + ?Sized>(master: &mut M) -> bool {
 use alloc::{string::String, vec::Vec};
 
 #[cfg(feature = "alloc")]
-use crate::chip::{EraseBlock, EraseRegion, Features, FlashChip, WriteGranularity};
+use crate::chip::{EraseBlock, EraseRegion, Features, FlashChip, QeMethod, WriteGranularity};
 
 /// Convert SFDP info to a FlashChip structure
 ///
@@ -483,11 +485,23 @@ pub fn to_flash_chip(info: &SfdpInfo, jedec_manufacturer: u8, jedec_device: u16)
     // Build feature flags from SFDP data
     let mut features = Features::SFDP;
 
-    if params.fast_read_112 || params.fast_read_122 {
-        features |= Features::DUAL_IO;
+    if params.fast_read_112 {
+        features |= Features::FAST_READ_DOUT;
     }
-    if params.fast_read_114 || params.fast_read_144 || params.fast_read_444 {
-        features |= Features::QUAD_IO;
+    if params.fast_read_122 {
+        features |= Features::FAST_READ_DIO;
+    }
+    if params.fast_read_114 {
+        features |= Features::FAST_READ_QOUT;
+    }
+    if params.fast_read_144 {
+        features |= Features::FAST_READ_QIO;
+    }
+    if params.fast_read_444 {
+        // 4-4-4 read capability only — it does not imply support for a
+        // specific QPI entry/exit mechanism (0x38/0xFF, 0x35/0xF5), so do
+        // not set QPI_38_FF here.
+        features |= Features::QPI;
     }
     if params.address_mode.supports_4byte() {
         features |= Features::FOUR_BYTE_ADDR;
@@ -550,14 +564,25 @@ pub fn to_flash_chip(info: &SfdpInfo, jedec_manufacturer: u8, jedec_device: u16)
     if params.soft_reset.supports_66_99() {
         // Mark that soft reset is supported (could add a feature flag)
     }
-    if params.volatile_sr_write_enable == WriteEnableForVolatileSr::Wren {
-        features |= Features::WRSR_WREN;
-    } else {
+    // Volatile-write support supplements, not replaces, persistent WREN.
+    features |= Features::WRSR_WREN;
+    if params.volatile_sr_write_enable == WriteEnableForVolatileSr::Ewsr {
         features |= Features::WRSR_EWSR;
     }
-    if params.quad_enable.is_needed() {
-        features |= Features::QE_SR2;
-    }
+    let qe_method = match params.quad_enable {
+        QuadEnableRequirement::None => QeMethod::None,
+        QuadEnableRequirement::Sr2Bit1_WriteCmd01
+        | QuadEnableRequirement::Sr2Bit1_WriteCmd01_StatusSplit => QeMethod::Sr2Bit1WriteSr,
+        QuadEnableRequirement::Sr1Bit6_WriteCmd01 => QeMethod::Sr1Bit6,
+        QuadEnableRequirement::Unknown
+        | QuadEnableRequirement::Sr2Bit7_WriteCmdSpecial
+        | QuadEnableRequirement::Sr2Bit1_NoRead => {
+            // No speculative register sequence: 011 needs 0x3F/0x3E,
+            // and 100 does not specify a usable SR2 read instruction.
+            features &= !Features::ANY_QUAD;
+            QeMethod::None
+        }
+    };
 
     // Build erase blocks from SFDP data.
     // Each BFPT erase type covers the entire chip uniformly; the optional 4BA
@@ -597,6 +622,16 @@ pub fn to_flash_chip(info: &SfdpInfo, jedec_manufacturer: u8, jedec_device: u16)
         WriteGranularity::Byte
     };
 
+    // Per-mode dummy-cycle overrides from the BFPT instruction tables.
+    // SpiReadOp::dummy_cycles counts total clocks (mode + dummy), matching
+    // how backends split them into a mode byte plus high-Z clocks — the
+    // same convention as flashprog's spi_dummy_cycles(). A supported descriptor
+    // supplies an exact count, including zero; an absent descriptor keeps defaults.
+    let total_clocks = |p: FastReadParams| {
+        p.is_supported()
+            .then_some(p.mode_clocks.saturating_add(p.dummy_clocks))
+    };
+
     FlashChip {
         vendor: String::from("SFDP"),
         name: String::from("Unknown"),
@@ -610,6 +645,14 @@ pub fn to_flash_chip(info: &SfdpInfo, jedec_manufacturer: u8, jedec_device: u16)
         write_granularity,
         erase_blocks,
         tested: Default::default(),
+        qe_method,
+        dummy_cycles_112: total_clocks(params.fast_read_112_params),
+        dummy_cycles_122: total_clocks(params.fast_read_122_params),
+        dummy_cycles_114: total_clocks(params.fast_read_114_params),
+        dummy_cycles_144: total_clocks(params.fast_read_144_params),
+        // No parsed source for QPI (4-4-4) dummy clocks yet; the JEDEC
+        // default applies via effective_dc().
+        dummy_cycles_qpi: None,
     }
 }
 
@@ -908,6 +951,158 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn explicit_zero_latency_survives_bfpt_selection_and_differs_from_absent_default() {
+        use crate::flash::{FlashContext, io::select_read_plan};
+        use crate::programmer::SpiFeatures;
+        use crate::spi::{IoMode, SpiCommand};
+        struct Master;
+        impl SpiMaster for Master {
+            fn features(&self) -> SpiFeatures {
+                SpiFeatures::DUAL_IO
+            }
+            fn max_read_len(&self) -> usize {
+                256
+            }
+            fn max_write_len(&self) -> usize {
+                256
+            }
+            async fn execute(&mut self, _: &mut SpiCommand<'_>) -> Result<()> {
+                panic!("selection must be pure")
+            }
+            async fn delay_us(&mut self, _: u32) {}
+        }
+        for (descriptor, stored, clocks) in [
+            (Some(0xbb00_0000), Some(0), 0),
+            (Some(0xbb04_0000), Some(4), 4),
+            (None, None, 4),
+        ] {
+            let mut params = BasicFlashParams::default();
+            parse_bfpt_dword1(1 << 20, &mut params);
+            parse_bfpt_dword2(0x007f_ffff, &mut params);
+            if let Some(dword) = descriptor {
+                parse_bfpt_dword4(dword, &mut params);
+            }
+            let info = SfdpInfo {
+                header: SfdpHeader::parse(&[0x53, 0x46, 0x44, 0x50, 6, 1, 0, 0xff]),
+                basic_params: params,
+                num_param_headers: 1,
+                four_byte_addr_table: None,
+            };
+            let ctx = FlashContext::new(to_flash_chip(&info, 0, 0));
+            assert_eq!(ctx.chip.dummy_cycles_122, stored);
+            assert_eq!(ctx.chip.dummy_cycles_112, None);
+            let plan = select_read_plan(&Master, &ctx, false, |_| true).unwrap();
+            assert_eq!(
+                (plan.op.opcode, plan.op.io_mode, plan.op.dummy_cycles),
+                (0xbb, IoMode::DualIo, clocks)
+            );
+            let mut buf = [0; 1];
+            let cmd = SpiCommand::read_3b(plan.op.opcode, 0, &mut buf)
+                .with_io_mode(plan.op.io_mode)
+                .with_dummy_cycles(plan.op.dummy_cycles);
+            assert_eq!(cmd.header_len(), if clocks == 0 { 4 } else { 5 });
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn qer_encodings_and_missing_dword15_gate_scoped_reads() {
+        use crate::{
+            flash::{FlashContext, FlashDevice, SpiFlashDevice, io::select_read_plan},
+            programmer::SpiFeatures,
+            spi::{SpiCommand, opcodes},
+        };
+        struct Master {
+            table: [u8; 64],
+            commands: alloc::vec::Vec<u8>,
+        }
+        impl SpiMaster for Master {
+            fn features(&self) -> SpiFeatures {
+                SpiFeatures::QUAD_IO | SpiFeatures::QUAD_IN
+            }
+            fn max_read_len(&self) -> usize {
+                256
+            }
+            fn max_write_len(&self) -> usize {
+                256
+            }
+            async fn delay_us(&mut self, _: u32) {}
+            async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> Result<()> {
+                self.commands.push(cmd.opcode);
+                if cmd.opcode == opcodes::RDSFDP {
+                    let start = cmd.address.unwrap() as usize;
+                    cmd.read_buf
+                        .copy_from_slice(&self.table[start..start + cmd.read_buf.len()]);
+                } else {
+                    // Known methods can confirm pre-existing QE, no writes needed.
+                    cmd.read_buf
+                        .fill(if cmd.opcode == opcodes::RDSR { 0x40 } else { 2 });
+                }
+                Ok(())
+            }
+        }
+        futures_lite::future::block_on(async {
+            for length in [9, 15, 16] {
+                for qer in 0..8 {
+                    let mut master = Master {
+                        table: [0; 64],
+                        commands: alloc::vec::Vec::new(),
+                    };
+                    master.table[0..4].copy_from_slice(&(1u32 << 21).to_le_bytes());
+                    master.table[4..8].copy_from_slice(&0x007f_ffffu32.to_le_bytes());
+                    master.table[8..12].copy_from_slice(&0x0000_eb44u32.to_le_bytes());
+                    master.table[56..60].copy_from_slice(&((qer as u32) << 20).to_le_bytes());
+                    let header = ParameterHeader::parse(&[0, 6, 1, length, 0, 0, 0, 0xff]);
+                    let basic_params = parse_bfpt(&mut master, &header).await.unwrap();
+                    if length == 9 {
+                        assert_eq!(basic_params.quad_enable, QuadEnableRequirement::Unknown);
+                    } else {
+                        assert_eq!(
+                            basic_params.quad_enable,
+                            QuadEnableRequirement::from_bfpt(qer)
+                        );
+                    }
+                    let info = SfdpInfo {
+                        header: SfdpHeader::parse(&[0x53, 0x46, 0x44, 0x50, 6, 1, 0, 0xff]),
+                        basic_params,
+                        num_param_headers: 1,
+                        four_byte_addr_table: None,
+                    };
+                    let mut ctx = FlashContext::new(to_flash_chip(&info, 0, 0));
+                    // Test register sequence ownership separately from whether the
+                    // SFDP descriptor supplies volatile-write capability.
+                    ctx.chip.features |= crate::chip::Features::WRSR_EWSR;
+                    master.commands.clear();
+                    let plan = select_read_plan(&master, &ctx, false, |_| true).unwrap();
+                    let safe = length >= 15 && matches!(qer, 0 | 1 | 2 | 5);
+                    assert_eq!(
+                        plan.op.io_mode.requires_quad(),
+                        safe,
+                        "length={length}, QER={qer}"
+                    );
+                    let mut device = SpiFlashDevice::new(master, ctx);
+                    device.read(0, &mut [0; 8]).await.unwrap();
+                    let (master, _) = device.into_parts();
+                    assert!(!master.commands.contains(&opcodes::WRSR));
+                    assert!(!master.commands.contains(&opcodes::WRSR2));
+                    if !safe || qer == 0 {
+                        assert!(!master.commands.contains(&opcodes::RDSR2));
+                    }
+                }
+            }
+            assert_eq!(
+                QuadEnableRequirement::from_bfpt(4),
+                QuadEnableRequirement::Sr2Bit1_NoRead
+            );
+            assert_eq!(
+                QuadEnableRequirement::from_bfpt(3),
+                QuadEnableRequirement::Sr2Bit7_WriteCmdSpecial
+            );
+        });
+    }
 
     #[test]
     fn test_sfdp_header_parse() {

--- a/crates/rflasher-core/src/sfdp/types.rs
+++ b/crates/rflasher-core/src/sfdp/types.rs
@@ -324,8 +324,10 @@ pub enum WriteEnableForVolatileSr {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[allow(non_camel_case_types)]
 pub enum QuadEnableRequirement {
-    /// No QE bit; device does not have a QE bit
+    /// Missing or reserved descriptor: quad cannot be assumed safe.
     #[default]
+    Unknown,
+    /// Explicit QER 000: device does not have a QE bit.
     None,
     /// QE is bit 1 of SR2; write SR1 and SR2 with 0x01 (2 bytes)
     Sr2Bit1_WriteCmd01,
@@ -333,8 +335,8 @@ pub enum QuadEnableRequirement {
     Sr1Bit6_WriteCmd01,
     /// QE is bit 7 of SR2; write SR2 with 0x3E, read with 0x3F
     Sr2Bit7_WriteCmdSpecial,
-    /// QE is bit 1 of SR2; write SR2 with 0x31
-    Sr2Bit1_WriteCmd31,
+    /// QER 100: two-byte 0x01 write, but no established SR2 read command.
+    Sr2Bit1_NoRead,
     /// QE is bit 1 of SR2; write SR1 and SR2 with 0x01; status read with 0x05/0x35
     Sr2Bit1_WriteCmd01_StatusSplit,
 }
@@ -347,9 +349,9 @@ impl QuadEnableRequirement {
             0b001 => Self::Sr2Bit1_WriteCmd01,
             0b010 => Self::Sr1Bit6_WriteCmd01,
             0b011 => Self::Sr2Bit7_WriteCmdSpecial,
-            0b100 => Self::Sr2Bit1_WriteCmd31,
+            0b100 => Self::Sr2Bit1_NoRead,
             0b101 => Self::Sr2Bit1_WriteCmd01_StatusSplit,
-            _ => Self::None,
+            _ => Self::Unknown,
         }
     }
 

--- a/crates/rflasher-core/src/spi/command.rs
+++ b/crates/rflasher-core/src/spi/command.rs
@@ -174,14 +174,38 @@ impl<'a> SpiCommand<'a> {
         self.address.is_some()
     }
 
+    /// Number of dummy bytes to emit between the address phase and the
+    /// read/write data phase, in this command's I/O mode.
+    ///
+    /// The dummy phase is encoded as N clock cycles in the I/O mode's lane
+    /// count, so the number of bytes on the wire depends on how many lanes
+    /// are active:
+    ///
+    /// - Single / DualOut / QuadOut: the dummy is on a single line → each
+    ///   byte on the wire covers 8 clock cycles.
+    /// - DualIo: 2 lines active → each byte covers 4 clock cycles.
+    /// - QuadIo / Qpi: 4 lines active → each byte covers 2 clock cycles.
+    ///
+    /// Dummy clocks for fast-read opcodes conventionally include the mode
+    /// byte (M7-M0) for 1-2-2 / 1-4-4 / 4-4-4 commands; the bytes are
+    /// filled with 0xFF which both acts as a safe "no continuous mode"
+    /// M-byte on typical chips and as harmless dummy clocks.
+    /// This is a storage size, not permission to round clock counts. Execution
+    /// must first validate exact representability for the controller.
+    pub fn dummy_bytes(&self) -> usize {
+        let clocks = self.dummy_cycles as usize;
+        match self.io_mode {
+            IoMode::Single | IoMode::DualOut | IoMode::QuadOut => clocks.div_ceil(8),
+            IoMode::DualIo => (clocks * 2).div_ceil(8),
+            IoMode::QuadIo | IoMode::Qpi => (clocks * 4).div_ceil(8),
+        }
+    }
+
     /// Calculate the total number of bytes to transfer (for timing/buffer allocation)
     pub fn total_bytes(&self) -> usize {
         let mut total = 1; // opcode
         total += self.address_width.bytes() as usize;
-        // Dummy cycles are in clock cycles, not bytes - depends on I/O mode.
-        // Round up like header_len()/encode_header() do: a partial dummy byte
-        // still occupies a full byte on the wire.
-        total += self.dummy_cycles.div_ceil(8) as usize;
+        total += self.dummy_bytes();
         total += self.write_data.len();
         total += self.read_buf.len();
         total
@@ -191,7 +215,7 @@ impl<'a> SpiCommand<'a> {
     ///
     /// This is useful for pre-allocating buffers in programmer implementations.
     pub fn header_len(&self) -> usize {
-        1 + self.address_width.bytes() as usize + self.dummy_cycles.div_ceil(8) as usize
+        1 + self.address_width.bytes() as usize + self.dummy_bytes()
     }
 
     /// Encode the command header (opcode + address + dummy bytes) into a buffer
@@ -228,11 +252,21 @@ impl<'a> SpiCommand<'a> {
             offset += self.address_width.bytes() as usize;
         }
 
-        // Dummy bytes (cycles / 8, rounded up, filled with 0xFF)
-        let dummy_bytes = self.dummy_cycles.div_ceil(8) as usize;
+        // Dummy bytes (io-mode-dependent, filled with 0xFF).
+        let dummy_bytes = self.dummy_bytes();
         buf[offset..offset + dummy_bytes].fill(0xFF);
         offset += dummy_bytes;
 
         offset
     }
+}
+
+/// Exact dummy phase representability for byte-oriented command headers.
+pub fn dummy_cycles_representable(mode: IoMode, cycles: u8) -> bool {
+    let clocks_per_byte = match mode {
+        IoMode::Single | IoMode::DualOut | IoMode::QuadOut => 8,
+        IoMode::DualIo => 4,
+        IoMode::QuadIo | IoMode::Qpi => 2,
+    };
+    cycles.is_multiple_of(clocks_per_byte)
 }

--- a/crates/rflasher-core/src/spi/mod.rs
+++ b/crates/rflasher-core/src/spi/mod.rs
@@ -9,6 +9,6 @@ mod io_mode;
 pub mod opcodes;
 
 pub use address::AddressWidth;
-pub use command::SpiCommand;
+pub use command::{SpiCommand, dummy_cycles_representable};
 pub use io_mode::{IoMode, check_io_mode_supported};
 pub use opcodes::*;

--- a/crates/rflasher-core/src/wp/mod.rs
+++ b/crates/rflasher-core/src/wp/mod.rs
@@ -40,3 +40,5 @@ mod types;
 pub use ops::*;
 pub use ranges::*;
 pub use types::*;
+
+pub(crate) use ops::chip_write_options;

--- a/crates/rflasher-core/src/wp/ops.rs
+++ b/crates/rflasher-core/src/wp/ops.rs
@@ -461,6 +461,19 @@ pub fn get_available_ranges(
     super::ranges::get_all_ranges(&template, total_size, decoder)
 }
 
+/// Prefer persistent WREN when available; EWSR is mandatory only on legacy parts.
+pub(crate) fn chip_write_options(
+    features: crate::chip::Features,
+    options: WriteOptions,
+) -> WriteOptions {
+    use crate::chip::Features;
+    WriteOptions {
+        use_ewsr: options.use_ewsr
+            || (features.contains(Features::WRSR_EWSR) && !features.contains(Features::WRSR_WREN)),
+        ..options
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rflasher-programmers/Cargo.toml
+++ b/crates/rflasher-programmers/Cargo.toml
@@ -64,7 +64,7 @@ portable-programmers = [
 
 [dependencies]
 rflasher-core.workspace = true
-rflasher-internal = { version = "0.1.0", path = "../rflasher-internal", optional = true }
+rflasher-internal = { version = "0.2.0", path = "../rflasher-internal", optional = true }
 log.workspace = true
 thiserror = { workspace = true, optional = true }
 zerocopy = { workspace = true, optional = true }

--- a/crates/rflasher-programmers/src/backends/dediprog/device.rs
+++ b/crates/rflasher-programmers/src/backends/dediprog/device.rs
@@ -11,8 +11,10 @@ use std::time::Duration;
 use nusb::Endpoint;
 use nusb::transfer::{Buffer, Bulk, In, Out};
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
+use rflasher_core::flash::io::{self, AddressPlan, ReadPlan, WritePlan};
 use rflasher_core::programmer::{OpaqueMaster, SpiFeatures, SpiMaster};
-use rflasher_core::spi::{SpiCommand, check_io_mode_supported, opcodes};
+use rflasher_core::protocol::SpiReadOp;
+use rflasher_core::spi::{IoMode as CoreIoMode, SpiCommand, check_io_mode_supported, opcodes};
 
 use super::error::{DediprogError, Result};
 use super::protocol::*;
@@ -66,6 +68,20 @@ macro_rules! platform_sleep {
     }};
 }
 
+/// User-facing I/O-mode override policy for the programmer.
+///
+/// - `Auto`: advertise full multi-IO capability to the flash layer and let it
+///   pick the best op from chip features (the default; matches `iomode=auto`).
+/// - `Force(m)`: cap at the given mode regardless of chip capabilities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IoModePolicy {
+    /// Let the flash layer decide based on chip + programmer capabilities.
+    #[default]
+    Auto,
+    /// Force a specific upper bound.
+    Force(DpIoMode),
+}
+
 /// Configuration options for opening a Dediprog device
 #[derive(Debug, Clone)]
 pub struct DediprogConfig {
@@ -79,8 +95,8 @@ pub struct DediprogConfig {
     pub spi_speed_index: usize,
     /// Voltage in millivolts (0, 1800, 2500, 3500)
     pub voltage_mv: u16,
-    /// I/O mode (Single, Dual, Quad)
-    pub io_mode: DpIoMode,
+    /// I/O mode policy (auto or forced cap)
+    pub io_mode_policy: IoModePolicy,
 }
 
 impl Default for DediprogConfig {
@@ -91,7 +107,7 @@ impl Default for DediprogConfig {
             target: Target::ApplicationFlash1,
             spi_speed_index: DEFAULT_SPI_SPEED_INDEX,
             voltage_mv: DEFAULT_VOLTAGE_MV,
-            io_mode: DpIoMode::Single,
+            io_mode_policy: IoModePolicy::Auto,
         }
     }
 }
@@ -127,17 +143,20 @@ pub fn parse_options(options: &[(&str, &str)]) -> Result<DediprogConfig> {
                     DediprogError::InvalidParameter(format!("voltage: {}", value))
                 })?;
             }
-            "iomode" => match value.to_lowercase().as_str() {
-                "single" | "1" => config.io_mode = DpIoMode::Single,
-                "dual" | "2" => config.io_mode = DpIoMode::DualIo,
-                "quad" | "4" => config.io_mode = DpIoMode::QuadIo,
-                _ => {
-                    return Err(DediprogError::InvalidParameter(format!(
-                        "iomode: {}",
-                        value
-                    )));
-                }
-            },
+            "iomode" => {
+                config.io_mode_policy = match value.to_lowercase().as_str() {
+                    "auto" => IoModePolicy::Auto,
+                    "single" | "1" => IoModePolicy::Force(DpIoMode::Single),
+                    "dual" | "2" => IoModePolicy::Force(DpIoMode::DualIo),
+                    "quad" | "4" => IoModePolicy::Force(DpIoMode::QuadIo),
+                    _ => {
+                        return Err(DediprogError::InvalidParameter(format!(
+                            "iomode: {}",
+                            value
+                        )));
+                    }
+                };
+            }
             _ => {
                 return Err(DediprogError::InvalidParameter(format!(
                     "unknown option: {}",
@@ -174,6 +193,8 @@ pub struct Dediprog {
     io_mode: DpIoMode,
     /// Configured maximum I/O mode
     max_io_mode: DpIoMode,
+    /// User-selected I/O-mode policy (auto or forced)
+    io_mode_policy: IoModePolicy,
     /// Flash size in bytes (set after probing, needed for OpaqueMaster)
     flash_size: Option<u32>,
 }
@@ -272,7 +293,8 @@ impl Dediprog {
             device_string: String::new(),
             protocol: Protocol::Unknown,
             io_mode: DpIoMode::Single,
-            max_io_mode: config.io_mode,
+            max_io_mode: DpIoMode::Single, // set by init_device() below
+            io_mode_policy: config.io_mode_policy,
             flash_size: None,
         };
 
@@ -391,7 +413,8 @@ impl Dediprog {
             device_string: String::new(),
             protocol: Protocol::Unknown,
             io_mode: DpIoMode::Single,
-            max_io_mode: config.io_mode,
+            max_io_mode: DpIoMode::Single, // set by init_device() below
+            io_mode_policy: config.io_mode_policy,
             flash_size: None,
         };
 
@@ -461,9 +484,22 @@ impl Dediprog {
             self.leave_standalone_mode().await?;
         }
 
-        // Determine multi-I/O support
+        // Determine multi-I/O support. Mirror flashprog's default: multi-I/O
+        // is only enabled by default on SF600Plus-G2 (dual); every other
+        // model defaults to single-I/O and opts in explicitly via
+        // iomode=dual/quad ("Multi i/o is only tested with SF600Plus-G2,
+        // not enabling by default").
         if self.device_type.is_sf600_class() && self.protocol >= Protocol::V2 {
-            self.max_io_mode = config.io_mode;
+            self.max_io_mode = match self.io_mode_policy {
+                IoModePolicy::Auto => {
+                    if self.device_type == DeviceType::SF600PG2 {
+                        DpIoMode::DualIo
+                    } else {
+                        DpIoMode::Single
+                    }
+                }
+                IoModePolicy::Force(m) => m,
+            };
         } else {
             self.max_io_mode = DpIoMode::Single;
         }
@@ -886,13 +922,14 @@ impl Dediprog {
             ))
             .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
 
-            let len = data.len().min(to_read);
-            buf[total_read..total_read + len].copy_from_slice(&data[..len]);
-            total_read += len;
-
-            if data.len() < to_read {
-                break;
+            if data.len() != to_read {
+                return Err(DediprogError::TransferFailed(format!(
+                    "Short SPI response: expected {to_read} bytes, got {}",
+                    data.len()
+                )));
             }
+            buf[total_read..total_read + to_read].copy_from_slice(&data);
+            total_read += to_read;
         }
 
         Ok(buf)
@@ -927,93 +964,12 @@ impl Dediprog {
     // Bulk Read/Write (CMD_READ/CMD_WRITE with USB bulk transfers)
     // =========================================================================
 
-    /// Prepare a read/write command packet for the given protocol version.
-    ///
-    /// Returns the command packet size. The packet is written into `cmd_buf`.
-    /// `value` and `idx` are the USB control transfer wValue/wIndex fields.
-    #[allow(clippy::too_many_arguments)]
-    fn prepare_rw_cmd(
-        &self,
-        cmd_buf: &mut [u8; MAX_CMD_SIZE],
-        value: &mut u16,
-        idx: &mut u16,
-        is_read: bool,
-        mode: u8,
-        start: u32,
-        count: u16,
-    ) -> Result<usize> {
-        // Common header (all protocol versions)
-        cmd_buf[0] = (count & 0xFF) as u8;
-        cmd_buf[1] = ((count >> 8) & 0xFF) as u8;
-        cmd_buf[2] = 0; // RFU
-        cmd_buf[3] = mode;
-        cmd_buf[4] = 0; // Opcode (overridden below for V2/V3)
-
-        match self.protocol {
-            Protocol::V1 => {
-                // V1: address in wValue/wIndex, 5-byte command packet
-                if start >> 24 != 0 {
-                    return Err(DediprogError::Unsupported(
-                        "4-byte address not supported on V1 protocol".to_string(),
-                    ));
-                }
-                *value = (start & 0xFFFF) as u16;
-                *idx = ((start >> 16) & 0xFF) as u16;
-                Ok(5)
-            }
-            Protocol::V2 => {
-                *value = 0;
-                *idx = 0;
-
-                if is_read {
-                    // For V2 reads, use standard read mode with fast read opcode
-                    // The firmware handles the SPI read command internally
-                    cmd_buf[3] = ReadMode::Fast as u8;
-                    cmd_buf[4] = opcodes::FAST_READ;
-                } else {
-                    // For V2 writes, use page program mode
-                    cmd_buf[3] = WriteMode::PagePgm as u8;
-                    cmd_buf[4] = 0;
-                }
-
-                cmd_buf[5] = 0; // RFU
-                cmd_buf[6] = (start & 0xFF) as u8;
-                cmd_buf[7] = ((start >> 8) & 0xFF) as u8;
-                cmd_buf[8] = ((start >> 16) & 0xFF) as u8;
-                cmd_buf[9] = ((start >> 24) & 0xFF) as u8;
-                Ok(10)
-            }
-            Protocol::V3 => {
-                *value = 0;
-                *idx = 0;
-
-                cmd_buf[5] = 0; // RFU
-                cmd_buf[6] = (start & 0xFF) as u8;
-                cmd_buf[7] = ((start >> 8) & 0xFF) as u8;
-                cmd_buf[8] = ((start >> 16) & 0xFF) as u8;
-                cmd_buf[9] = ((start >> 24) & 0xFF) as u8;
-
-                if is_read {
-                    cmd_buf[3] = ReadMode::Configurable as u8;
-                    cmd_buf[4] = opcodes::FAST_READ;
-                    cmd_buf[10] = if start >> 24 != 0 { 4 } else { 3 }; // address length
-                    cmd_buf[11] = 4; // dummy half-cycles (8 clocks / 2 for fast read)
-                    Ok(12)
-                } else {
-                    cmd_buf[3] = WriteMode::PagePgm as u8;
-                    cmd_buf[4] = 0;
-                    // Page size (256 bytes) as 32-bit LE
-                    cmd_buf[10] = 0x00;
-                    cmd_buf[11] = 0x01;
-                    cmd_buf[12] = 0x00;
-                    cmd_buf[13] = 0x00;
-                    Ok(14)
-                }
-            }
-            Protocol::Unknown => Err(DediprogError::Unsupported(
-                "Unknown protocol version".to_string(),
-            )),
+    async fn select_extended_address(&mut self, plan: AddressPlan, address: u32) -> Result<()> {
+        if let AddressPlan::Ear(features) = plan {
+            rflasher_core::protocol::set_extended_address(self, features, (address >> 24) as u8)
+                .await?;
         }
+        Ok(())
     }
 
     /// Bulk read from flash using CMD_READ + USB bulk IN transfers.
@@ -1021,7 +977,7 @@ impl Dediprog {
     /// Start and len MUST be 512-byte aligned. Uses a single large URB so the
     /// kernel handles all USB scheduling internally -- avoids per-packet
     /// userspace round-trips through nusb's epoll background thread.
-    async fn bulk_read_flash(&mut self, start: u32, buf: &mut [u8]) -> Result<()> {
+    async fn bulk_read_flash(&mut self, plan: &ReadPlan, start: u32, buf: &mut [u8]) -> Result<()> {
         let len = buf.len();
         if len == 0 {
             return Ok(());
@@ -1029,22 +985,10 @@ impl Dediprog {
 
         let count = (len / BULK_CHUNK_SIZE) as u16;
 
-        // Set I/O mode for reads (single for now, can add multi-IO later)
-        self.set_io_mode(DpIoMode::Single).await?;
-
-        // Build and send the CMD_READ command packet
-        let mut cmd_buf = [0u8; MAX_CMD_SIZE];
-        let mut value: u16 = 0;
-        let mut idx: u16 = 0;
-        let cmd_len = self.prepare_rw_cmd(
-            &mut cmd_buf,
-            &mut value,
-            &mut idx,
-            true,
-            ReadMode::Std as u8,
-            start,
-            count,
-        )?;
+        let (cmd_buf, cmd_len, value, idx) = read_packet(self.protocol, plan, start, count)?;
+        self.select_extended_address(plan.address, start).await?;
+        let dp_mode = DpIoMode::from(plan.op.io_mode);
+        self.set_io_mode(dp_mode).await?;
 
         self.control_write_raw(Command::Read as u8, value, idx, &cmd_buf[..cmd_len])
             .await?;
@@ -1085,31 +1029,20 @@ impl Dediprog {
     /// USB buffer with each 256-byte page padded to 512 bytes (0xFF fill),
     /// then submits it as one large URB. The firmware reads 512 bytes at a
     /// time and handles WREN, page program, and WIP polling internally.
-    async fn bulk_write_flash(&mut self, start: u32, data: &[u8]) -> Result<()> {
+    async fn bulk_write_flash(&mut self, plan: &WritePlan, start: u32, data: &[u8]) -> Result<()> {
         const PAGE_SIZE: usize = 256;
         let len = data.len();
         if len == 0 {
             return Ok(());
         }
 
+        self.select_extended_address(plan.address, start).await?;
         let count = (len / PAGE_SIZE) as u16;
 
         // Writes always use single I/O
         self.set_io_mode(DpIoMode::Single).await?;
 
-        // Build and send the CMD_WRITE command packet
-        let mut cmd_buf = [0u8; MAX_CMD_SIZE];
-        let mut value: u16 = 0;
-        let mut idx: u16 = 0;
-        let cmd_len = self.prepare_rw_cmd(
-            &mut cmd_buf,
-            &mut value,
-            &mut idx,
-            false,
-            WriteMode::PagePgm as u8,
-            start,
-            count,
-        )?;
+        let (cmd_buf, cmd_len, value, idx) = write_packet(self.protocol, plan, start, count)?;
 
         self.control_write_raw(Command::Write as u8, value, idx, &cmd_buf[..cmd_len])
             .await?;
@@ -1125,11 +1058,7 @@ impl Dediprog {
         let total_usb_len = count * BULK_CHUNK_SIZE;
         let mut out_buf = out_ep.allocate(total_usb_len);
 
-        for i in 0..count {
-            let src_start = i * PAGE_SIZE;
-            out_buf.extend_from_slice(&data[src_start..src_start + PAGE_SIZE]);
-            out_buf.extend_from_slice(&[0xFF; BULK_CHUNK_SIZE - PAGE_SIZE]);
-        }
+        fill_write_buffer(data, &mut out_buf);
 
         out_ep.submit(out_buf);
 
@@ -1142,67 +1071,21 @@ impl Dediprog {
         result
             .status
             .map_err(|e| DediprogError::TransferFailed(e.to_string()))?;
-
-        Ok(())
-    }
-
-    /// Slow read via SPI transceive (for unaligned head/tail residuals).
-    /// Reads up to 16 bytes per USB control transfer using standard READ (0x03).
-    async fn slow_read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
-        let mut offset = 0usize;
-        while offset < buf.len() {
-            let chunk_len = (buf.len() - offset).min(16);
-            let a = addr + offset as u32;
-            let cmd = [opcodes::READ, (a >> 16) as u8, (a >> 8) as u8, a as u8];
-            let result = self.spi_transceive(&cmd, chunk_len).await?;
-            buf[offset..offset + chunk_len].copy_from_slice(&result[..chunk_len]);
-            offset += chunk_len;
+        if result.actual_len != total_usb_len {
+            return Err(DediprogError::TransferFailed("Short bulk write".into()));
         }
         Ok(())
     }
 
-    /// Slow write via SPI transceive (for unaligned head/tail residuals).
-    /// Sends individual WREN + PP + RDSR poll sequences, max 11 bytes data per transfer.
-    async fn slow_write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
-        let max_write = 16 - 5; // 11 bytes per transceive (16 - 1 opcode - 3 addr - 1 margin)
-        let mut offset = 0usize;
-
-        while offset < data.len() {
-            let a = addr + offset as u32;
-            // Respect page boundaries (256 bytes)
-            let page_offset = a as usize % 256;
-            let to_page_end = 256 - page_offset;
-            let remaining = data.len() - offset;
-            let chunk_len = remaining.min(max_write).min(to_page_end);
-
-            // WREN
-            self.spi_transceive(&[opcodes::WREN], 0).await?;
-
-            // Page Program: [PP, addr_hi, addr_mid, addr_lo, data...]
-            let mut cmd = Vec::with_capacity(4 + chunk_len);
-            cmd.push(opcodes::PP);
-            cmd.push((a >> 16) as u8);
-            cmd.push((a >> 8) as u8);
-            cmd.push(a as u8);
-            cmd.extend_from_slice(&data[offset..offset + chunk_len]);
-            self.spi_transceive(&cmd, 0).await?;
-
-            // Poll RDSR until WIP clears (bit 0)
-            // Use a simple retry counter instead of Instant (not available on WASM)
-            let max_polls = 1000;
-            for poll in 0..max_polls {
-                let status = self.spi_transceive(&[opcodes::RDSR], 1).await?;
-                if status[0] & 0x01 == 0 {
-                    break;
-                }
-                if poll == max_polls - 1 {
-                    return Err(DediprogError::Timeout);
-                }
-                platform_sleep!(Duration::from_micros(100));
-            }
-
-            offset += chunk_len;
-        }
+    /// Residuals use the plan's single-I/O operation, never guessed addressing.
+    async fn slow_read(&mut self, plan: &ReadPlan, addr: u32, buf: &mut [u8]) -> Result<()> {
+        let mut residual = *plan;
+        residual.op = plan.single_read.ok_or(CoreError::ChipNotSupported)?;
+        io::read_spi(self, &residual, addr, buf).await?;
+        Ok(())
+    }
+    async fn slow_write(&mut self, plan: &WritePlan, addr: u32, data: &[u8]) -> Result<()> {
+        io::write_spi(self, plan, addr, data).await?;
         Ok(())
     }
 }
@@ -1216,120 +1099,70 @@ impl OpaqueMaster for Dediprog {
         self.flash_size.unwrap_or(0) as usize
     }
 
-    async fn read(&mut self, addr: u32, buf: &mut [u8]) -> CoreResult<()> {
-        let len = buf.len();
-        if len == 0 {
-            return Ok(());
+    fn supports_read_plan(&self, plan: &ReadPlan) -> bool {
+        read_plan_supported(self.protocol, plan)
+            && check_io_mode_supported(plan.op.io_mode, self.features()).is_ok()
+    }
+    fn supports_write_plan(&self, plan: &WritePlan) -> bool {
+        write_plan_supported(self.protocol, plan)
+    }
+    // This programmer is not genuinely opaque: chip metadata is mandatory.
+    async fn read(&mut self, _addr: u32, _buf: &mut [u8]) -> CoreResult<()> {
+        Err(CoreError::ChipNotSupported)
+    }
+    async fn write(&mut self, _addr: u32, _data: &[u8]) -> CoreResult<()> {
+        Err(CoreError::ChipNotSupported)
+    }
+
+    async fn read_planned(&mut self, plan: &ReadPlan, addr: u32, buf: &mut [u8]) -> CoreResult<()> {
+        if !self.supports_read_plan(plan) {
+            return Err(CoreError::ChipNotSupported);
         }
-
-        // Split into: head residue + aligned bulk + tail residue
-        let chunk_size = BULK_CHUNK_SIZE;
-        let head_residue = if !(addr as usize).is_multiple_of(chunk_size) {
-            len.min(chunk_size - (addr as usize % chunk_size))
-        } else {
-            0
-        };
-
-        // Head: slow read for unaligned start
-        if head_residue > 0 {
-            self.slow_read(addr, &mut buf[..head_residue])
-                .await
-                .map_err(|_| CoreError::ReadError { addr })?;
-        }
-
-        // Aligned bulk portion
-        let bulk_start = addr + head_residue as u32;
-        let remaining = len - head_residue;
-        let bulk_len = (remaining / chunk_size) * chunk_size;
-
-        if bulk_len > 0 {
-            // Split into chunks that fit in a single USB buffer.
-            let max_blocks = (MAX_BLOCK_COUNT as usize).min(MAX_READ_BLOCKS);
-            let mut bulk_offset = 0usize;
-            while bulk_offset < bulk_len {
-                let this_len = (bulk_len - bulk_offset).min(max_blocks * chunk_size);
-                let this_len = (this_len / chunk_size) * chunk_size;
-                if this_len == 0 {
-                    break;
-                }
-                let buf_start = head_residue + bulk_offset;
-                let read_addr = bulk_start + bulk_offset as u32;
-                self.bulk_read_flash(read_addr, &mut buf[buf_start..buf_start + this_len])
-                    .await
-                    .map_err(|_| CoreError::ReadError { addr: read_addr })?;
-                bulk_offset += this_len;
+        plan.address.validate_range(addr, buf.len())?;
+        let mut offset = 0;
+        while offset < buf.len() {
+            let address = addr + offset as u32;
+            let (count, bulk) = transfer_chunk(
+                address,
+                buf.len() - offset,
+                BULK_CHUNK_SIZE,
+                (MAX_BLOCK_COUNT as usize).min(MAX_READ_BLOCKS) * BULK_CHUNK_SIZE,
+            );
+            let chunk = &mut buf[offset..offset + count];
+            if bulk {
+                self.bulk_read_flash(plan, address, chunk).await
+            } else {
+                self.slow_read(plan, address, chunk).await
             }
+            .map_err(|_| CoreError::ReadError { addr: address })?;
+            offset += count;
         }
-
-        // Tail: slow read for remaining bytes
-        let tail_start = head_residue + bulk_len;
-        if tail_start < len {
-            let tail_addr = addr + tail_start as u32;
-            self.slow_read(tail_addr, &mut buf[tail_start..])
-                .await
-                .map_err(|_| CoreError::ReadError { addr: tail_addr })?;
-        }
-
         Ok(())
     }
 
-    async fn write(&mut self, addr: u32, data: &[u8]) -> CoreResult<()> {
-        const PAGE_SIZE: usize = 256;
-        let len = data.len();
-        if len == 0 {
-            return Ok(());
+    async fn write_planned(&mut self, plan: &WritePlan, addr: u32, data: &[u8]) -> CoreResult<()> {
+        if !self.supports_write_plan(plan) {
+            return Err(CoreError::ChipNotSupported);
         }
-
-        // Split into: head residue + aligned bulk + tail residue
-        // Bulk writes require 256-byte (page) alignment
-        let head_residue = if !(addr as usize).is_multiple_of(PAGE_SIZE) {
-            len.min(PAGE_SIZE - (addr as usize % PAGE_SIZE))
-        } else {
-            0
-        };
-
-        // Head: slow write for unaligned start
-        if head_residue > 0 {
-            self.slow_write(addr, &data[..head_residue])
-                .await
-                .map_err(|_| CoreError::WriteError { addr })?;
-        }
-
-        // Aligned bulk portion
-        let bulk_start = addr + head_residue as u32;
-        let remaining = len - head_residue;
-        let bulk_len = (remaining / PAGE_SIZE) * PAGE_SIZE;
-
-        if bulk_len > 0 {
-            // Split into chunks that fit in a single USB buffer.
-            // Each page is 512 bytes on the wire (256 data + 256 padding), so
-            // MAX_WRITE_PAGES pages = MAX_WRITE_PAGES * 512 bytes USB buffer.
-            let max_pages = (MAX_BLOCK_COUNT as usize).min(MAX_WRITE_PAGES);
-            let mut bulk_offset = 0usize;
-            while bulk_offset < bulk_len {
-                let this_len = (bulk_len - bulk_offset).min(max_pages * PAGE_SIZE);
-                let this_len = (this_len / PAGE_SIZE) * PAGE_SIZE;
-                if this_len == 0 {
-                    break;
-                }
-                let data_start = head_residue + bulk_offset;
-                let write_addr = bulk_start + bulk_offset as u32;
-                self.bulk_write_flash(write_addr, &data[data_start..data_start + this_len])
-                    .await
-                    .map_err(|_| CoreError::WriteError { addr: write_addr })?;
-                bulk_offset += this_len;
+        plan.address.validate_range(addr, data.len())?;
+        let mut offset = 0;
+        while offset < data.len() {
+            let address = addr + offset as u32;
+            let (count, bulk) = transfer_chunk(
+                address,
+                data.len() - offset,
+                256,
+                (MAX_BLOCK_COUNT as usize).min(MAX_WRITE_PAGES) * 256,
+            );
+            let chunk = &data[offset..offset + count];
+            if bulk {
+                self.bulk_write_flash(plan, address, chunk).await
+            } else {
+                self.slow_write(plan, address, chunk).await
             }
+            .map_err(|_| CoreError::WriteError { addr: address })?;
+            offset += count;
         }
-
-        // Tail: slow write for remaining bytes
-        let tail_start = head_residue + bulk_len;
-        if tail_start < len {
-            let tail_addr = addr + tail_start as u32;
-            self.slow_write(tail_addr, &data[tail_start..])
-                .await
-                .map_err(|_| CoreError::WriteError { addr: tail_addr })?;
-        }
-
         Ok(())
     }
 
@@ -1354,36 +1187,51 @@ impl SpiMaster for Dediprog {
             features |= SpiFeatures::FOUR_BYTE_ADDR;
         }
 
-        // Multi-I/O support for SF600 class with protocol V2+
+        // Multi-I/O support for SF600 class with protocol V2+.
+        // Cap by `max_io_mode` (from IoModePolicy::Auto, which mirrors
+        // flashprog: single everywhere except dual on SF600Plus-G2 — or
+        // IoModePolicy::Force(X) which caps at X).
         if self.device_type.is_sf600_class() && self.protocol >= Protocol::V2 {
-            match self.max_io_mode {
-                DpIoMode::DualOut | DpIoMode::DualIo => {
-                    features |= SpiFeatures::DUAL_IN;
-                    // V2 has issues with DUAL_IO, V3 works
-                    if self.protocol >= Protocol::V3 {
-                        features |= SpiFeatures::DUAL_IO;
-                    }
-                }
-                DpIoMode::QuadOut | DpIoMode::QuadIo | DpIoMode::Qpi => {
-                    features |= SpiFeatures::DUAL_IN | SpiFeatures::QUAD_IN;
-                    if self.protocol >= Protocol::V3 {
-                        features |= SpiFeatures::DUAL_IO | SpiFeatures::QUAD_IO;
-                    }
-                }
-                _ => {}
+            // Dual output (1-1-2, 0x3B) works on V2+: the V2 read packet
+            // passes the opcode through under ReadMode::Fast with
+            // firmware-side timing.
+            if self.max_io_mode >= DpIoMode::DualOut && self.protocol >= Protocol::V2 {
+                features |= SpiFeatures::DUAL_IN;
+            }
+            // Dual I/O (1-2-2, 0xBB) is V3+ only: the V2 fixed-op form uses
+            // the wrong number of dummy cycles (flashprog
+            // dediprog_init: "The v2, fixed-op JEDEC_FAST_READ_DUAL_DIO
+            // command seems to use the wrong number of dummy cycles").
+            if self.max_io_mode >= DpIoMode::DualIo && self.protocol >= Protocol::V3 {
+                features |= SpiFeatures::DUAL_IO;
+            }
+            // Quad output (1-1-4) is V3+ only (same V2 dummy-cycle limitation).
+            if self.max_io_mode >= DpIoMode::QuadOut && self.protocol >= Protocol::V3 {
+                features |= SpiFeatures::QUAD_IN;
+            }
+            // Quad I/O (1-4-4) is V3+ only
+            if self.max_io_mode >= DpIoMode::QuadIo && self.protocol >= Protocol::V3 {
+                features |= SpiFeatures::QUAD_IO;
+            }
+            // QPI (4-4-4) requires V3+ and explicit Qpi configuration
+            if self.max_io_mode >= DpIoMode::Qpi && self.protocol >= Protocol::V3 {
+                features |= SpiFeatures::QPI;
             }
         }
 
         // Some protocol versions have restrictions on 4BA modes
-        if self.protocol == Protocol::V1
-            && (self.device_type == DeviceType::SF100 || self.device_type.is_sf600_class())
-        {
-            // V1 on SF100 or SF600 class doesn't have 4BA mode restrictions
-        } else if self.protocol < Protocol::V2 {
+        let supports_4ba_modes = (self.device_type == DeviceType::SF100
+            && self.protocol == Protocol::V1)
+            || (self.device_type.is_sf600_class() && self.protocol == Protocol::V3);
+        if !supports_4ba_modes {
             features |= SpiFeatures::NO_4BA_MODES;
         }
 
         features
+    }
+
+    fn supports_read_dummy_cycles(&self, _mode: CoreIoMode, cycles: u8) -> bool {
+        read_dummy_supported(self.protocol, cycles)
     }
 
     fn max_read_len(&self) -> usize {
@@ -1397,9 +1245,26 @@ impl SpiMaster for Dediprog {
     }
 
     async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
-        // Check I/O mode support
+        // Check I/O mode support against advertised master features first.
         check_io_mode_supported(cmd.io_mode, self.features())?;
 
+        // The dediprog's generic `spi_transceive` command is single-IO only
+        // regardless of what `features()` advertises (multi-IO is reachable
+        // only via `OpaqueMaster::read` / `CMD_READ`). Reject multi-IO here
+        // loudly rather than silently downgrading and producing wrong data.
+        if cmd.io_mode != CoreIoMode::Single {
+            log::error!(
+                "Dediprog::execute called with io_mode={:?}; only Single is \
+                 supported via the generic SPI transceive path. Multi-IO \
+                 reads must go through OpaqueMaster::read.",
+                cmd.io_mode,
+            );
+            return Err(CoreError::ProgrammerError);
+        }
+
+        if !rflasher_core::spi::dummy_cycles_representable(cmd.io_mode, cmd.dummy_cycles) {
+            return Err(CoreError::ProgrammerError);
+        }
         // For simple commands, use transceive
         let header_len = cmd.header_len();
         let mut write_data = vec![0u8; header_len + cmd.write_data.len()];
@@ -1412,13 +1277,430 @@ impl SpiMaster for Dediprog {
             .await
             .map_err(|_e| CoreError::ProgrammerError)?;
 
-        cmd.read_buf
-            .copy_from_slice(&result[..read_len.min(result.len())]);
+        if result.len() != read_len {
+            return Err(CoreError::SpiTransferFailed);
+        }
+        cmd.read_buf.copy_from_slice(&result);
 
         Ok(())
     }
 
     async fn delay_us(&mut self, us: u32) {
         platform_sleep!(Duration::from_micros(us as u64));
+    }
+}
+
+// The same split is used by the actual bulk IN/OUT paths and packet tests.
+fn transfer_chunk(addr: u32, remaining: usize, alignment: usize, max_bulk: usize) -> (usize, bool) {
+    let available = remaining.min(0x0100_0000 - (addr as usize & 0xffffff));
+    let misalignment = addr as usize % alignment;
+    if misalignment != 0 {
+        (available.min(alignment - misalignment), false)
+    } else if available < alignment {
+        (available, false)
+    } else {
+        (available.min(max_bulk) / alignment * alignment, true)
+    }
+}
+fn fill_write_buffer(data: &[u8], buffer: &mut Buffer) {
+    for page in data.chunks_exact(256) {
+        buffer.extend_from_slice(page);
+        buffer.extend_from_slice(&[0xff; BULK_CHUNK_SIZE - 256]);
+    }
+}
+
+fn read_plan_supported(protocol: Protocol, plan: &ReadPlan) -> bool {
+    let op = plan.op;
+    if op.address_width != plan.address.width()
+        || op.native_4ba != (plan.address == AddressPlan::NativeFourByte)
+        || !read_dummy_supported(protocol, op.dummy_cycles)
+    {
+        return false;
+    }
+    let Some(single) = plan.single_read else {
+        return false;
+    };
+    if single.io_mode != CoreIoMode::Single
+        || single.address_width != plan.address.width()
+        || single.native_4ba != op.native_4ba
+        || !single.dummy_cycles.is_multiple_of(8)
+    {
+        return false;
+    }
+    match protocol {
+        Protocol::V1 => {
+            op.opcode == opcodes::READ
+                && op.io_mode == CoreIoMode::Single
+                && op.dummy_cycles == 0
+                && op.address_width.bytes() == 3
+        }
+        // V2 cannot express compatibility-four-byte framing. Its implicit 0x13
+        // -> 0x0c substitution is not safe unless chip metadata authorizes 0x0c;
+        // selection instead supplies an explicit native fast-read plan.
+        Protocol::V2 => {
+            !matches!(plan.address, AddressPlan::EnterFourByte(_))
+                && matches!(
+                    (op.opcode, op.io_mode, op.dummy_cycles),
+                    (0x03, CoreIoMode::Single, 0)
+                        | (0x0b | 0x0c, CoreIoMode::Single, 8)
+                        | (0x3b | 0x3c, CoreIoMode::DualOut, 8)
+                )
+        }
+        Protocol::V3 => op.io_mode != CoreIoMode::Qpi,
+        Protocol::Unknown => false,
+    }
+}
+fn write_plan_supported(protocol: Protocol, plan: &WritePlan) -> bool {
+    use rflasher_core::chip::WriteGranularity;
+    if plan.page_size != 256
+        || plan.granularity != WriteGranularity::Page
+        || plan.opcode
+            != if plan.address == AddressPlan::NativeFourByte {
+                opcodes::PP_4B
+            } else {
+                opcodes::PP
+            }
+    {
+        return false;
+    }
+    match protocol {
+        Protocol::V1 => plan.address.width().bytes() == 3,
+        Protocol::V2 => !matches!(plan.address, AddressPlan::EnterFourByte(_)),
+        Protocol::V3 => true,
+        Protocol::Unknown => false,
+    }
+}
+
+fn packet_header(
+    protocol: Protocol,
+    start: u32,
+    count: u16,
+    mode: u8,
+) -> ([u8; MAX_CMD_SIZE], u16, u16) {
+    let mut packet = [0; MAX_CMD_SIZE];
+    packet[..2].copy_from_slice(&count.to_le_bytes());
+    packet[3] = mode;
+    if protocol == Protocol::V1 {
+        (packet, start as u16, ((start >> 16) & 0xff) as u16)
+    } else {
+        packet[6..10].copy_from_slice(&start.to_le_bytes());
+        (packet, 0, 0)
+    }
+}
+fn read_packet(
+    protocol: Protocol,
+    plan: &ReadPlan,
+    start: u32,
+    count: u16,
+) -> Result<([u8; MAX_CMD_SIZE], usize, u16, u16)> {
+    if !read_plan_supported(protocol, plan) {
+        return Err(DediprogError::Unsupported(
+            "Unrepresentable read plan".into(),
+        ));
+    }
+    let (mut packet, value, index) = packet_header(protocol, start, count, ReadMode::Std as u8);
+    encode_read_op(protocol, plan.op, &mut packet)?;
+    let len = match protocol {
+        Protocol::V1 => 5,
+        Protocol::V2 => 10,
+        _ => 12,
+    };
+    Ok((packet, len, value, index))
+}
+fn write_packet(
+    protocol: Protocol,
+    plan: &WritePlan,
+    start: u32,
+    count: u16,
+) -> Result<([u8; MAX_CMD_SIZE], usize, u16, u16)> {
+    if !write_plan_supported(protocol, plan) {
+        return Err(DediprogError::Unsupported(
+            "Unrepresentable write plan".into(),
+        ));
+    }
+    let (mut packet, value, index) =
+        packet_header(protocol, start, count, WriteMode::PagePgm as u8);
+    if protocol != Protocol::V1 {
+        packet[4] = plan.opcode;
+        if plan.address.width().bytes() == 4 {
+            packet[3] = if protocol == Protocol::V2 {
+                WriteMode::FourByteAddr256BPagePgm0x12 as u8
+            } else {
+                WriteMode::FourByteAddr256BPagePgm as u8
+            };
+        }
+    }
+    if protocol == Protocol::V3 {
+        packet[10..14].copy_from_slice(&(plan.page_size as u32).to_le_bytes());
+    }
+    let len = match protocol {
+        Protocol::V1 => 5,
+        Protocol::V2 => 10,
+        _ => 14,
+    };
+    Ok((packet, len, value, index))
+}
+
+// V2 firmware has fixed fast-read latency. V3 expresses pairs of clocks.
+fn read_dummy_supported(protocol: Protocol, cycles: u8) -> bool {
+    match protocol {
+        Protocol::V3 => cycles.is_multiple_of(2),
+        _ => cycles == 0 || cycles == 8,
+    }
+}
+
+fn encode_read_op(
+    protocol: Protocol,
+    op: SpiReadOp,
+    packet: &mut [u8; MAX_CMD_SIZE],
+) -> Result<()> {
+    if !read_dummy_supported(protocol, op.dummy_cycles) {
+        return Err(DediprogError::Unsupported(
+            "Unrepresentable read dummy clocks".into(),
+        ));
+    }
+    if protocol == Protocol::V2 {
+        packet[3] = if op.native_4ba {
+            ReadMode::FourByteAddrFast0x0C as u8
+        } else if op.opcode != opcodes::READ {
+            ReadMode::Fast as u8
+        } else {
+            ReadMode::Std as u8
+        };
+        packet[4] = op.opcode;
+    } else if protocol == Protocol::V3 {
+        packet[3] = ReadMode::Configurable as u8;
+        packet[4] = op.opcode;
+        packet[10] = op.address_width.bytes();
+        packet[11] = op.dummy_cycles / 2;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod framing_tests {
+    use super::*;
+    use rflasher_core::spi::AddressWidth;
+
+    use rflasher_core::chip::{Features, WriteGranularity};
+    use rflasher_core::flash::FlashContext;
+    struct PlanningMaster;
+    impl SpiMaster for PlanningMaster {
+        fn features(&self) -> SpiFeatures {
+            SpiFeatures::FOUR_BYTE_ADDR
+                | SpiFeatures::DUAL_IN
+                | SpiFeatures::DUAL_IO
+                | SpiFeatures::QUAD_IO
+        }
+        fn max_read_len(&self) -> usize {
+            16
+        }
+        fn max_write_len(&self) -> usize {
+            11
+        }
+        async fn execute(&mut self, _: &mut SpiCommand<'_>) -> CoreResult<()> {
+            panic!("selection did I/O")
+        }
+        async fn delay_us(&mut self, _: u32) {}
+    }
+    fn context(features: Features, size: u32) -> FlashContext {
+        use rflasher_core::sfdp::*;
+        let info = SfdpInfo {
+            header: SfdpHeader::parse(&[0x53, 0x46, 0x44, 0x50, 6, 1, 0, 0xff]),
+            basic_params: BasicFlashParams {
+                density_bytes: size.into(),
+                page_size: 256,
+                ..Default::default()
+            },
+            num_param_headers: 1,
+            four_byte_addr_table: None,
+        };
+        let mut chip = to_flash_chip(&info, 0, 0);
+        chip.features = features;
+        chip.write_granularity = WriteGranularity::Page;
+        FlashContext::new(chip)
+    }
+    #[test]
+    fn read_plans_cover_v1_v2_v3_bulk_packets_and_exact_residuals() {
+        let features = Features::FAST_READ
+            | Features::FAST_READ_DOUT
+            | Features::FOUR_BYTE_DUAL_OUT_READ
+            | Features::FOUR_BYTE_READ
+            | Features::FOUR_BYTE_ENTER;
+        for (protocol, size, opcode, mode) in [
+            (Protocol::V1, 1 << 20, 0x03, ReadMode::Std),
+            (Protocol::V2, 1 << 20, 0x3b, ReadMode::Fast),
+            (Protocol::V2, 32 << 20, 0x3c, ReadMode::FourByteAddrFast0x0C),
+            (Protocol::V3, 32 << 20, 0x3c, ReadMode::Configurable),
+        ] {
+            let ctx = context(features, size);
+            let plan = io::select_read_plan(&PlanningMaster, &ctx, false, |p| {
+                read_plan_supported(protocol, p)
+            })
+            .unwrap();
+            let (packet, len, value, index) = read_packet(protocol, &plan, 0x123400, 8).unwrap();
+            assert_eq!(plan.op.opcode, opcode);
+            assert_eq!(packet[3], mode as u8);
+            assert_eq!(&packet[..2], &[8, 0]);
+            assert_eq!(
+                plan.single_read.unwrap().opcode,
+                if size > 16 << 20 { 0x13 } else { 0x03 }
+            );
+            if protocol == Protocol::V1 {
+                assert_eq!((len, value, index), (5, 0x3400, 0x12));
+            } else {
+                assert_eq!(packet[4], opcode);
+                assert_eq!(&packet[6..10], &0x123400u32.to_le_bytes());
+            }
+        }
+        // Native READ alone must never authorize firmware's implicit FAST_READ.
+        let ctx = context(Features::FOUR_BYTE_READ, 32 << 20);
+        assert!(
+            io::select_read_plan(&PlanningMaster, &ctx, false, |p| read_plan_supported(
+                Protocol::V2,
+                p
+            ))
+            .is_err()
+        );
+        let spi = io::select_read_plan(&PlanningMaster, &ctx, true, |_| true).unwrap();
+        assert_eq!(spi.op.opcode, 0x13); // safe pre-I/O generic read fallback
+    }
+    #[test]
+    fn program_addressing_is_independent_and_v2_chooses_native_or_ear_not_en4b() {
+        for protocol in [Protocol::V1, Protocol::V2, Protocol::V3] {
+            let ctx = context(
+                Features::FOUR_BYTE_PROGRAM
+                    | Features::FOUR_BYTE_ENTER
+                    | Features::EXT_ADDR_REG_C5C8,
+                32 << 20,
+            );
+            let plan =
+                io::select_write_plan(&PlanningMaster, &ctx, |p| write_plan_supported(protocol, p))
+                    .unwrap();
+            assert_eq!(
+                plan.opcode,
+                if protocol == Protocol::V1 { 0x02 } else { 0x12 }
+            );
+            let (packet, _, _, _) = write_packet(protocol, &plan, 0x0100_0000, 2).unwrap();
+            assert_eq!(&packet[..2], &[2, 0]);
+            if protocol == Protocol::V2 {
+                assert_eq!(packet[3], WriteMode::FourByteAddr256BPagePgm0x12 as u8);
+            }
+            if protocol == Protocol::V3 {
+                assert_eq!(packet[3], WriteMode::FourByteAddr256BPagePgm as u8);
+                assert_eq!(&packet[10..14], &256u32.to_le_bytes());
+            }
+        }
+        let ctx = context(Features::FOUR_BYTE_ENTER, 32 << 20);
+        assert!(
+            io::select_write_plan(&PlanningMaster, &ctx, |p| write_plan_supported(
+                Protocol::V2,
+                p
+            ))
+            .is_err()
+        );
+        let plan = io::select_write_plan(&PlanningMaster, &ctx, |p| {
+            write_plan_supported(Protocol::V3, p)
+        })
+        .unwrap();
+        assert!(matches!(plan.address, AddressPlan::EnterFourByte(_)));
+        assert_eq!(
+            &write_packet(Protocol::V3, &plan, 0x0100_0000, 1).unwrap().0[3..5],
+            &[WriteMode::FourByteAddr256BPagePgm as u8, 0x02]
+        );
+        let ctx = context(
+            Features::FOUR_BYTE_ENTER | Features::EXT_ADDR_REG_C5C8,
+            32 << 20,
+        );
+        let plan = io::select_write_plan(&PlanningMaster, &ctx, |p| {
+            write_plan_supported(Protocol::V2, p)
+        })
+        .unwrap();
+        assert!(matches!(plan.address, AddressPlan::Ear(_)));
+    }
+    #[test]
+    fn aligned_writes_route_to_padded_bulk_out_and_splits_keep_every_byte_at_bank_edges() {
+        for alignment in [256, 512] {
+            let start = 0x00ff_fc03u32;
+            let len = 4000;
+            let mut offset = 0;
+            let mut bulk_count = 0;
+            let mut residual_count = 0;
+            while offset < len {
+                let address = start + offset as u32;
+                let (count, bulk) = transfer_chunk(address, len - offset, alignment, 1024);
+                assert!(count > 0);
+                assert!((address & 0xffffff) as usize + count <= 0x0100_0000);
+                if bulk {
+                    bulk_count += 1;
+                    assert!(count.is_multiple_of(alignment));
+                    assert!((address as usize).is_multiple_of(alignment));
+                } else {
+                    residual_count += 1;
+                }
+                offset += count;
+            }
+            assert_eq!(offset, len);
+            assert!(bulk_count >= 3);
+            assert_eq!(residual_count, 2);
+        }
+        let (count, bulk) = transfer_chunk(0x0100_0000, 512, 256, MAX_WRITE_PAGES * 256);
+        assert_eq!((count, bulk), (512, true));
+        let mut buffer = Buffer::new(1024);
+        fill_write_buffer(&[0xa5; 512], &mut buffer);
+        assert_eq!(buffer.len(), 1024);
+        for page in buffer.chunks_exact(512) {
+            assert_eq!(&page[..256], &[0xa5; 256]);
+            assert_eq!(&page[256..], &[0xff; 256]);
+        }
+    }
+
+    #[test]
+    fn v2_native_address_mode_is_independent_of_opcode() {
+        for (opcode, native, mode, wire_opcode) in [
+            (0x3c, true, ReadMode::FourByteAddrFast0x0C, 0x3c),
+            (0x3b, false, ReadMode::Fast, 0x3b),
+        ] {
+            let mut packet = [0; MAX_CMD_SIZE];
+            let op = SpiReadOp {
+                opcode,
+                io_mode: CoreIoMode::DualOut,
+                dummy_cycles: 8,
+                address_width: if native {
+                    AddressWidth::FourByte
+                } else {
+                    AddressWidth::ThreeByte
+                },
+                native_4ba: native,
+            };
+            encode_read_op(Protocol::V2, op, &mut packet).unwrap();
+            assert_eq!(&packet[3..5], &[mode as u8, wire_opcode]);
+        }
+    }
+
+    #[test]
+    fn v3_dummy_pairs_are_exact_and_invalid_packet_is_untouched() {
+        for (mode, clocks, valid) in [
+            (CoreIoMode::DualIo, 5, false),
+            (CoreIoMode::QuadIo, 7, false),
+            (CoreIoMode::DualIo, 4, true),
+            (CoreIoMode::QuadIo, 6, true),
+        ] {
+            let mut packet = [0; MAX_CMD_SIZE];
+            let op = SpiReadOp {
+                opcode: 0xeb,
+                io_mode: mode,
+                dummy_cycles: clocks,
+                address_width: AddressWidth::FourByte,
+                native_4ba: false,
+            };
+            assert_eq!(encode_read_op(Protocol::V3, op, &mut packet).is_ok(), valid);
+            if valid {
+                assert_eq!(packet[10], 4);
+                assert_eq!(packet[11], clocks / 2);
+            } else {
+                assert_eq!(packet, [0; MAX_CMD_SIZE]);
+            }
+        }
     }
 }

--- a/crates/rflasher-programmers/src/backends/dediprog/protocol.rs
+++ b/crates/rflasher-programmers/src/backends/dediprog/protocol.rs
@@ -265,7 +265,7 @@ pub enum StandaloneMode {
 
 /// Dediprog I/O mode for multi-I/O commands
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DpIoMode {
     Single = 0,
     DualOut = 1,

--- a/crates/rflasher-programmers/src/backends/ft4222/device.rs
+++ b/crates/rflasher-programmers/src/backends/ft4222/device.rs
@@ -12,7 +12,7 @@ use nusb::transfer::{Buffer, Bulk, ControlIn, ControlOut, ControlType, In, Out, 
 use nusb::{Endpoint, Interface};
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
 use rflasher_core::programmer::{SpiFeatures, SpiMaster};
-use rflasher_core::spi::SpiCommand;
+use rflasher_core::spi::{IoMode as CoreIoMode, SpiCommand};
 
 use super::error::{Ft4222Error, Result};
 use super::protocol::*;
@@ -75,6 +75,8 @@ pub struct Ft4222 {
     in_endpoint: Option<Endpoint<Bulk, In>>,
     /// Cached `max_packet_size` for the bulk IN endpoint.
     in_max_packet_size: usize,
+    /// Silicon revision (1 = A, 4 = D, ...; -1 = unrecognized/pre-D).
+    silicon_rev: i32,
 }
 
 // ---------------------------------------------------------------------------
@@ -272,6 +274,7 @@ impl Ft4222 {
             out_endpoint: None,
             in_endpoint: None,
             in_max_packet_size: 0,
+            silicon_rev: -1,
         };
 
         let out_endpoint = ft4222
@@ -299,6 +302,19 @@ impl Ft4222 {
             version2,
             version3
         );
+
+        self.silicon_rev = ft4222_silicon_rev(chip_version);
+        // TN_161 errata §3.3.3: revisions A-C hang on the single-write +
+        // multi-read shape our multi-IO header emits for 1-1-2 and 1-1-4.
+        // Cap pre-D (and unrecognized) silicon at dual I/O (1-2-2), which
+        // carries the address in a multi-write phase.
+        if self.silicon_rev < 4 && self.config.io_mode != IoMode::Single {
+            log::warn!(
+                "FT4222H silicon revision {} is pre-D; disabling 1-1-2/1-1-4 reads and \
+                 QPI (TN_161 errata 3.3.3). Dual I/O (1-2-2) remains available.",
+                self.silicon_rev
+            );
+        }
 
         let channels = self.get_num_channels().await?;
         log::debug!("FT4222H channels: {}", channels);
@@ -694,6 +710,27 @@ impl Ft4222 {
         }
     }
 
+    /// Execute a command using dual, quad, or QPI framing.
+    async fn execute_multi_io(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
+        let MultiIoCommand {
+            single,
+            multi,
+            read_total,
+            high_z_bytes,
+            io_width,
+        } = build_multi_io_command(cmd)?;
+        let data = self
+            .spi_transfer_multi(&single, &multi, read_total, io_width as u8)
+            .await
+            .map_err(|_| CoreError::ProgrammerError)?;
+        if data.len() < read_total {
+            return Err(CoreError::ProgrammerError);
+        }
+        cmd.read_buf
+            .copy_from_slice(&data[high_z_bytes..high_z_bytes + cmd.read_buf.len()]);
+        Ok(())
+    }
+
     /// Perform a multi-I/O SPI transfer (half duplex).
     #[allow(dead_code)]
     async fn spi_transfer_multi(
@@ -726,12 +763,7 @@ impl Ft4222 {
 
         self.set_io_lines(io_lines).await?;
 
-        let mut header = [0u8; MULTI_IO_HEADER_SIZE];
-        header[0] = MULTI_IO_MAGIC | (single_data.len() as u8 & 0x0F);
-        header[1] = (multi_write_data.len() & 0xFF) as u8;
-        header[2] = ((multi_write_data.len() >> 8) & 0xFF) as u8;
-        header[3] = (multi_read_len & 0xFF) as u8;
-        header[4] = ((multi_read_len >> 8) & 0xFF) as u8;
+        let header = multi_io_header(single_data.len(), multi_write_data.len(), multi_read_len);
 
         let mut out_buf =
             Vec::with_capacity(MULTI_IO_HEADER_SIZE + single_data.len() + multi_write_data.len());
@@ -740,7 +772,12 @@ impl Ft4222 {
         out_buf.extend_from_slice(multi_write_data);
 
         self.bulk_write(&out_buf).await?;
-        self.bulk_write(&[]).await?;
+        // NOTE: no empty-packet write here. In flashprog's single-I/O path
+        // an empty packet deasserts CS *after* the read clocks, but
+        // `ft4222_spi_send_multi_io` sends write-then-read with no empty
+        // packet — the multi-IO header already defines the whole
+        // transaction, and an intervening empty packet could deassert CS
+        // between the address/mode phase and the data phase.
 
         if multi_read_len > 0 {
             self.bulk_read(multi_read_len).await
@@ -760,20 +797,183 @@ impl Ft4222 {
     }
 }
 
+fn multi_io_header(
+    single_len: usize,
+    write_len: usize,
+    read_len: usize,
+) -> [u8; MULTI_IO_HEADER_SIZE] {
+    let mut header = [0u8; MULTI_IO_HEADER_SIZE];
+    header[0] = MULTI_IO_MAGIC | (single_len as u8 & 0x0F);
+    header[1] = ((write_len >> 8) & 0xFF) as u8;
+    header[2] = (write_len & 0xFF) as u8;
+    header[3] = ((read_len >> 8) & 0xFF) as u8;
+    header[4] = (read_len & 0xFF) as u8;
+    header
+}
+
+const FT4222_MAX_READ: usize = MULTI_IO_MAX_DATA - (u8::MAX as usize * 4 / 8);
+
+fn ft4222_features(silicon_rev: i32, io_mode: IoMode) -> SpiFeatures {
+    let mut features = SpiFeatures::FOUR_BYTE_ADDR;
+    // TN_161 errata §3.3.3: pre-D (and unrecognized) silicon hangs on
+    // 1-1-2 and 1-1-4 reads, whose header is a single-write + multi-read
+    // transfer with no multi-write phase. Only dual I/O (1-2-2) and
+    // single I/O are safe there.
+    let pre_d = silicon_rev < 4;
+    match io_mode {
+        IoMode::Single => {}
+        IoMode::Dual => {
+            features |= SpiFeatures::DUAL_IO;
+            if !pre_d {
+                features |= SpiFeatures::DUAL_IN;
+            }
+        }
+        IoMode::Quad => {
+            if pre_d {
+                features |= SpiFeatures::DUAL_IO;
+            } else {
+                features |= SpiFeatures::DUAL_IN
+                    | SpiFeatures::DUAL_IO
+                    | SpiFeatures::QUAD_IN
+                    | SpiFeatures::QUAD_IO
+                    | SpiFeatures::QPI;
+            }
+        }
+    }
+    features
+}
+
+fn ft4222_dummy_bytes(mode: CoreIoMode, cycles: u8) -> CoreResult<usize> {
+    // The high-Z phase clocks on the data lanes, including output-only reads.
+    let width = match mode {
+        CoreIoMode::Single => 1,
+        CoreIoMode::DualOut | CoreIoMode::DualIo => 2,
+        CoreIoMode::QuadOut | CoreIoMode::QuadIo | CoreIoMode::Qpi => 4,
+    };
+    let bits = cycles as usize * width;
+    if !bits.is_multiple_of(8) {
+        return Err(CoreError::ProgrammerError);
+    }
+    Ok(bits / 8)
+}
+
+fn validate_command(cmd: &SpiCommand<'_>, features: SpiFeatures) -> CoreResult<()> {
+    rflasher_core::spi::check_io_mode_supported(cmd.io_mode, features)?;
+    ft4222_dummy_bytes(cmd.io_mode, cmd.dummy_cycles)?;
+    Ok(())
+}
+
+struct MultiIoCommand {
+    single: Vec<u8>,
+    multi: Vec<u8>,
+    read_total: usize,
+    high_z_bytes: usize,
+    io_width: usize,
+}
+
+fn build_multi_io_command(cmd: &SpiCommand<'_>) -> CoreResult<MultiIoCommand> {
+    let io_width = match cmd.io_mode {
+        CoreIoMode::Single => 1,
+        CoreIoMode::DualOut | CoreIoMode::DualIo => 2,
+        CoreIoMode::QuadOut | CoreIoMode::QuadIo | CoreIoMode::Qpi => 4,
+    };
+
+    let opcode = [cmd.opcode];
+    let addr_width = cmd.address_width.bytes() as usize;
+    let mut addr_bytes = [0u8; 4];
+    if let Some(addr) = cmd.address {
+        cmd.address_width.encode(addr, &mut addr_bytes);
+    }
+    let addr = &addr_bytes[..addr_width];
+    let dummy_bytes = ft4222_dummy_bytes(cmd.io_mode, cmd.dummy_cycles)?;
+    let uses_mode_byte = matches!(
+        cmd.io_mode,
+        CoreIoMode::DualIo | CoreIoMode::QuadIo | CoreIoMode::Qpi
+    );
+    let mode_byte_len = usize::from(uses_mode_byte && dummy_bytes > 0);
+    let high_z_bytes = dummy_bytes.saturating_sub(mode_byte_len);
+
+    let (single, multi) = match cmd.io_mode {
+        CoreIoMode::Single => (opcode.to_vec(), Vec::new()),
+        CoreIoMode::DualOut | CoreIoMode::QuadOut => {
+            let mut single = Vec::with_capacity(1 + addr_width + cmd.write_data.len());
+            single.extend_from_slice(&opcode);
+            single.extend_from_slice(addr);
+            single.extend_from_slice(cmd.write_data);
+            (single, Vec::new())
+        }
+        CoreIoMode::DualIo | CoreIoMode::QuadIo => {
+            let mut multi = Vec::with_capacity(addr_width + mode_byte_len + cmd.write_data.len());
+            multi.extend_from_slice(addr);
+            if mode_byte_len != 0 {
+                multi.push(0xff);
+            }
+            multi.extend_from_slice(cmd.write_data);
+            (opcode.to_vec(), multi)
+        }
+        CoreIoMode::Qpi => {
+            let mut multi =
+                Vec::with_capacity(1 + addr_width + mode_byte_len + cmd.write_data.len());
+            multi.extend_from_slice(&opcode);
+            multi.extend_from_slice(addr);
+            if mode_byte_len != 0 {
+                multi.push(0xff);
+            }
+            multi.extend_from_slice(cmd.write_data);
+            (Vec::new(), multi)
+        }
+    };
+
+    let read_total = high_z_bytes + cmd.read_buf.len();
+    if read_total > MULTI_IO_MAX_DATA {
+        return Err(CoreError::ProgrammerError);
+    }
+    Ok(MultiIoCommand {
+        single,
+        multi,
+        read_total,
+        high_z_bytes,
+        io_width,
+    })
+}
+
+/// Decode the silicon revision from `FT4222_GetVersion`'s `chip_version`.
+///
+/// Mirrors flashprog's `ft4222_silicon_rev`: 1..=26 for revisions A..Z and
+/// `-1` for an unrecognized value, which callers must treat as pre-D.
+fn ft4222_silicon_rev(chip_version: u32) -> i32 {
+    if (chip_version & 0xffff_00ff) != 0x4222_0000 {
+        return -1;
+    }
+    ((chip_version >> 8) & 0xff) as i32
+}
+
 impl SpiMaster for Ft4222 {
     fn features(&self) -> SpiFeatures {
-        SpiFeatures::FOUR_BYTE_ADDR
+        ft4222_features(self.silicon_rev, self.config.io_mode)
+    }
+
+    fn supports_read_dummy_cycles(&self, mode: CoreIoMode, cycles: u8) -> bool {
+        ft4222_dummy_bytes(mode, cycles).is_ok()
     }
 
     fn max_read_len(&self) -> usize {
-        65535
+        // A u8 dummy count can consume up to 127 quad bytes (output-only
+        // reads put all dummy clocks in high-Z). Reserve that worst case.
+        FT4222_MAX_READ
     }
 
     fn max_write_len(&self) -> usize {
-        65535
+        // Reserve space for protocol framing, matching flashprog.
+        65530
     }
 
     async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
+        validate_command(cmd, self.features())?;
+        if cmd.io_mode != CoreIoMode::Single {
+            return self.execute_multi_io(cmd).await;
+        }
+
         let header_len = cmd.header_len();
         let mut write_data = vec![0u8; header_len + cmd.write_data.len()];
         cmd.encode_header(&mut write_data);
@@ -895,4 +1095,150 @@ pub fn parse_options(options: &[(&str, &str)]) -> Result<SpiConfig> {
     }
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multi_io_framing_is_exact_and_big_endian() {
+        let mut buf = [0; 0x1234];
+        let mut cmd = SpiCommand::read_3b(0xeb, 0x123456, &mut buf);
+        cmd.io_mode = CoreIoMode::QuadIo;
+        cmd.dummy_cycles = 6;
+        let frame = build_multi_io_command(&cmd).unwrap();
+        assert_eq!(frame.single, [0xeb]);
+        assert_eq!(frame.multi, [0x12, 0x34, 0x56, 0xff]);
+        assert_eq!(frame.high_z_bytes, 2);
+        assert_eq!(
+            multi_io_header(frame.single.len(), frame.multi.len(), frame.read_total),
+            [MULTI_IO_MAGIC | 1, 0, 4, 0x12, 0x36]
+        );
+        for (mode, clocks) in [(CoreIoMode::DualIo, 5), (CoreIoMode::QuadIo, 7)] {
+            cmd.io_mode = mode;
+            cmd.dummy_cycles = clocks;
+            assert!(build_multi_io_command(&cmd).is_err());
+        }
+        cmd.io_mode = CoreIoMode::DualIo;
+        cmd.dummy_cycles = 0;
+        let zero = build_multi_io_command(&cmd).unwrap();
+        assert_eq!(zero.multi, [0x12, 0x34, 0x56]);
+        assert_eq!(zero.high_z_bytes, 0);
+        assert_eq!(zero.read_total, 0x1234);
+        cmd.dummy_cycles = 4;
+        let default = build_multi_io_command(&cmd).unwrap();
+        assert_eq!(default.multi, [0x12, 0x34, 0x56, 0xff]);
+        assert_eq!(default.high_z_bytes, 0);
+    }
+
+    #[test]
+    fn execution_guard_rejects_pre_d_output_and_configured_caps() {
+        let mut buf = [0; 1];
+        let mut cmd = SpiCommand::read_3b(0x3b, 0, &mut buf);
+        cmd.dummy_cycles = 8;
+        for revision in [-1, 1, 3] {
+            for mode in [CoreIoMode::DualOut, CoreIoMode::QuadOut] {
+                cmd.io_mode = mode;
+                assert!(validate_command(&cmd, ft4222_features(revision, IoMode::Quad)).is_err());
+            }
+        }
+        cmd.io_mode = CoreIoMode::QuadIo;
+        assert!(validate_command(&cmd, ft4222_features(4, IoMode::Dual)).is_err());
+        cmd.io_mode = CoreIoMode::DualIo;
+        assert!(validate_command(&cmd, ft4222_features(4, IoMode::Single)).is_err());
+        assert!(validate_command(&cmd, ft4222_features(1, IoMode::Dual)).is_ok());
+    }
+
+    // Exercises the same validation/builders as execute(), without a USB device.
+    #[derive(Default)]
+    struct FramingMaster {
+        lengths: Vec<usize>,
+    }
+    impl SpiMaster for FramingMaster {
+        fn features(&self) -> SpiFeatures {
+            ft4222_features(4, IoMode::Quad)
+        }
+        fn max_read_len(&self) -> usize {
+            FT4222_MAX_READ
+        }
+        fn max_write_len(&self) -> usize {
+            FT4222_MAX_READ
+        }
+        fn supports_read_dummy_cycles(&self, mode: CoreIoMode, cycles: u8) -> bool {
+            ft4222_dummy_bytes(mode, cycles).is_ok()
+        }
+        async fn delay_us(&mut self, _: u32) {}
+        async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
+            validate_command(cmd, self.features())?;
+            if cmd.io_mode != CoreIoMode::Single {
+                let frame = build_multi_io_command(cmd)?;
+                self.lengths.push(frame.read_total);
+            }
+            cmd.read_buf.fill(if cmd.opcode == 0x05 { 0 } else { 0xff });
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn sfdp_selection_falls_back_and_fourteen_clock_reads_chunk_safely() {
+        use rflasher_core::{
+            flash::{FlashContext, FlashDevice, SpiFlashDevice},
+            sfdp::*,
+        };
+        futures_lite::future::block_on(async {
+            for (dio, qio, expected) in [
+                (5, 7, CoreIoMode::Single),
+                (4, 7, CoreIoMode::DualIo),
+                (4, 6, CoreIoMode::QuadIo),
+                (4, 14, CoreIoMode::QuadIo),
+            ] {
+                let info = SfdpInfo {
+                    header: SfdpHeader::parse(&[0x53, 0x46, 0x44, 0x50, 6, 1, 0, 0xff]),
+                    basic_params: BasicFlashParams {
+                        density_bytes: 1024 * 1024,
+                        page_size: 256,
+                        fast_read_122: true,
+                        fast_read_144: true,
+                        fast_read_122_params: FastReadParams::new(0xbb, 4, dio - 4),
+                        fast_read_144_params: FastReadParams::new(0xeb, 2, qio - 2),
+                        quad_enable: QuadEnableRequirement::None,
+                        ..Default::default()
+                    },
+                    num_param_headers: 1,
+                    four_byte_addr_table: None,
+                };
+                let mut dev = SpiFlashDevice::new(
+                    FramingMaster::default(),
+                    FlashContext::new(to_flash_chip(&info, 0, 0)),
+                );
+                let plan = rflasher_core::flash::io::select_read_plan(
+                    &FramingMaster::default(),
+                    dev.context(),
+                    false,
+                    |_| true,
+                )
+                .unwrap();
+                assert_eq!(plan.op.io_mode, expected);
+                let mut buf = vec![0; FT4222_MAX_READ + 10];
+                dev.read(0, &mut buf).await.unwrap();
+                if qio == 14 {
+                    assert_eq!(dev.master().lengths, [FT4222_MAX_READ + 6, 16]);
+                    assert!(dev.master().lengths.iter().all(|&n| n <= MULTI_IO_MAX_DATA));
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn silicon_rev_matches_flashprog_encoding() {
+        assert_eq!(ft4222_silicon_rev(0x4222_0100), 1); // revision A
+        assert_eq!(ft4222_silicon_rev(0x4222_0400), 4); // revision D
+    }
+
+    #[test]
+    fn unrecognized_chip_version_is_treated_as_pre_d() {
+        assert_eq!(ft4222_silicon_rev(0x0000_0000), -1);
+        assert_eq!(ft4222_silicon_rev(0x4223_0100), -1);
+    }
 }

--- a/crates/rflasher-programmers/src/backends/sunxi_fel/device.rs
+++ b/crates/rflasher-programmers/src/backends/sunxi_fel/device.rs
@@ -23,9 +23,8 @@
 //! - WP/status regs   → SpiMaster (generic SPI commands)
 
 use nusb::transfer::{Bulk, In, Out};
-use rflasher_core::chip::EraseBlock;
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
-use rflasher_core::flash::select_erase_block;
+use rflasher_core::flash::io::{AddressPlan, ErasePlan, ReadPlan, WritePlan};
 use rflasher_core::programmer::{OpaqueMaster, SpiFeatures, SpiMaster};
 use rflasher_core::spi::SpiCommand;
 
@@ -40,13 +39,6 @@ pub struct SunxiFel {
     chip: ChipFamily,
     spi_info: SpiPayloadInfo,
     _interface: nusb::Interface,
-    /// Whether to use 4-byte addressing for OpaqueMaster read/write.
-    /// Set after probing via `set_use_4byte_addr()` when the flash is >16MB.
-    use_4byte_addr: bool,
-    /// Chip erase block table, set after probing via `set_erase_blocks()`.
-    /// Used by `OpaqueMaster::erase()` to select the correct opcode and
-    /// block size from the chip's actual capabilities (from RON database or SFDP).
-    erase_blocks: Vec<EraseBlock>,
 }
 
 impl SunxiFel {
@@ -140,27 +132,7 @@ impl SunxiFel {
             chip,
             spi_info,
             _interface: interface,
-            use_4byte_addr: false,
-            erase_blocks: Vec::new(),
         })
-    }
-
-    /// Set the chip's erase block table for `OpaqueMaster::erase()`.
-    ///
-    /// Call this after probing with the chip's erase blocks from the RON
-    /// database or SFDP. Without this, `OpaqueMaster::erase()` will return
-    /// an error and the hybrid adapter falls back to SPI-based erase.
-    pub fn set_erase_blocks(&mut self, blocks: Vec<EraseBlock>) {
-        self.erase_blocks = blocks;
-    }
-
-    /// Set whether to use 4-byte addressing for bulk read/write operations.
-    ///
-    /// Call this after probing if the flash chip requires 4-byte addressing
-    /// (i.e., capacity >16 MiB). This affects `OpaqueMaster::read()` and
-    /// `OpaqueMaster::write()`.
-    pub fn set_use_4byte_addr(&mut self, use_4byte: bool) {
-        self.use_4byte_addr = use_4byte;
     }
 
     /// Get the detected SoC name
@@ -287,37 +259,7 @@ impl SunxiFel {
     /// `spinor_sector_erase_*` functions. The SoC firmware handles busy-wait
     /// locally, so there are no USB round-trips for status polling.
     fn erase_block_bytecode(&mut self, opcode: u8, addr: u32, use_4byte: bool) -> Result<()> {
-        let fast_len: u8 = if use_4byte { 5 } else { 4 }; // opcode + addr bytes
-
-        let mut cbuf = Vec::with_capacity(32);
-
-        // WREN
-        cbuf.push(spi_cmd::SELECT);
-        cbuf.push(spi_cmd::FAST);
-        cbuf.push(1);
-        cbuf.push(0x06); // WREN opcode
-        cbuf.push(spi_cmd::DESELECT);
-
-        // Erase command (opcode + address)
-        cbuf.push(spi_cmd::SELECT);
-        cbuf.push(spi_cmd::FAST);
-        cbuf.push(fast_len);
-        cbuf.push(opcode);
-        if use_4byte {
-            cbuf.push((addr >> 24) as u8);
-        }
-        cbuf.push((addr >> 16) as u8);
-        cbuf.push((addr >> 8) as u8);
-        cbuf.push(addr as u8);
-        cbuf.push(spi_cmd::DESELECT);
-
-        // Wait for erase to complete (on-SoC RDSR polling)
-        cbuf.push(spi_cmd::SELECT);
-        cbuf.push(spi_cmd::SPINOR_WAIT);
-        cbuf.push(spi_cmd::DESELECT);
-
-        cbuf.push(spi_cmd::END);
-
+        let cbuf = erase_bytecode(opcode, addr, use_4byte);
         chips::spi_run(&mut self.transport, &self.spi_info, &cbuf)
     }
 
@@ -337,10 +279,10 @@ impl SunxiFel {
         addr: u32,
         data: &[u8],
         page_size: usize,
+        pp_opcode: u8,
         use_4byte: bool,
     ) -> Result<()> {
         let addr_len: usize = if use_4byte { 4 } else { 3 };
-        let pp_opcode: u8 = 0x02; // Page Program
         let wren_opcode: u8 = 0x06;
 
         // Per-page overhead:
@@ -426,10 +368,15 @@ impl SunxiFel {
     /// the command buffer via SPI_CMD_FAST, then receives data via RXBUF.
     /// This eliminates the separate FEL write for TX data that `spi_xfer`
     /// would do, saving ~9 USB transfers per chunk.
-    fn fast_read(&mut self, addr: u32, buf: &mut [u8], use_4byte: bool) -> Result<()> {
+    fn fast_read(
+        &mut self,
+        addr: u32,
+        buf: &mut [u8],
+        read_opcode: u8,
+        use_4byte: bool,
+    ) -> Result<()> {
         let swapbuf = self.spi_info.swapbuf;
         let swaplen = self.spi_info.swaplen as usize;
-        let read_opcode: u8 = 0x03; // READ
         let addr_len: usize = if use_4byte { 4 } else { 3 };
 
         let mut offset = 0usize;
@@ -490,6 +437,10 @@ impl SpiMaster for SunxiFel {
     }
 
     async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
+        rflasher_core::spi::check_io_mode_supported(cmd.io_mode, self.features())?;
+        if !rflasher_core::spi::dummy_cycles_representable(cmd.io_mode, cmd.dummy_cycles) {
+            return Err(CoreError::ProgrammerError);
+        }
         let header_len = cmd.header_len();
         let mut write_data = vec![0u8; header_len + cmd.write_data.len()];
         cmd.encode_header(&mut write_data);
@@ -515,46 +466,188 @@ impl OpaqueMaster for SunxiFel {
         0
     }
 
-    async fn read(&mut self, addr: u32, buf: &mut [u8]) -> CoreResult<()> {
-        self.fast_read(addr, buf, self.use_4byte_addr)
-            .map_err(|_| CoreError::ReadError { addr })
+    fn supports_read_plan(&self, plan: &ReadPlan) -> bool {
+        plan.op.io_mode == rflasher_core::spi::IoMode::Single
+            && plan.op.dummy_cycles == 0
+            && plan.op.address_width == plan.address.width()
+            && plan.op.opcode
+                == if plan.address == AddressPlan::NativeFourByte {
+                    0x13
+                } else {
+                    0x03
+                }
+            && self.spi_info.swaplen > 0
+    }
+    fn supports_write_plan(&self, plan: &WritePlan) -> bool {
+        plan.page_size > 0
+            && plan.page_size + 5 <= self.spi_info.swaplen as usize
+            && self.spi_info.cmdlen > 20
+            && plan.granularity == rflasher_core::chip::WriteGranularity::Page
+            && plan.opcode
+                == if plan.address == AddressPlan::NativeFourByte {
+                    0x12
+                } else {
+                    0x02
+                }
+    }
+    fn supports_erase_plan(&self, plan: &ErasePlan) -> bool {
+        plan.block.max_block_size() > 0
+    }
+    // SPI metadata is mandatory for this hybrid programmer too.
+    async fn read(&mut self, _addr: u32, _buf: &mut [u8]) -> CoreResult<()> {
+        Err(CoreError::ChipNotSupported)
+    }
+    async fn write(&mut self, _addr: u32, _data: &[u8]) -> CoreResult<()> {
+        Err(CoreError::ChipNotSupported)
+    }
+    async fn erase(&mut self, _addr: u32, _len: u32) -> CoreResult<()> {
+        Err(CoreError::ChipNotSupported)
     }
 
-    async fn write(&mut self, addr: u32, data: &[u8]) -> CoreResult<()> {
-        // Batched page program with on-SoC busy-wait.
-        // Page size is always 256 for standard SPI NOR.
-        self.batched_write(addr, data, 256, self.use_4byte_addr)
-            .map_err(|_| CoreError::WriteError { addr })
-    }
-
-    async fn erase(&mut self, addr: u32, len: u32) -> CoreResult<()> {
-        // Use the chip's actual erase block table (from RON/SFDP) to select
-        // the right opcode and block size. If no erase blocks are configured,
-        // return Err so the hybrid adapter falls back to SPI-based erase.
-        if self.erase_blocks.is_empty() {
-            return Err(CoreError::ProgrammerError);
+    async fn read_planned(&mut self, plan: &ReadPlan, addr: u32, buf: &mut [u8]) -> CoreResult<()> {
+        if !self.supports_read_plan(plan) {
+            return Err(CoreError::ChipNotSupported);
         }
-
-        let erase_block =
-            select_erase_block(&self.erase_blocks, addr, len).ok_or(CoreError::ProgrammerError)?;
-
-        let use_4byte = self.use_4byte_addr;
-        let max_block_size = erase_block.max_block_size();
-        let mut current = addr;
-        let end = addr + len;
-
-        while current < end {
-            let offset_in_layout = current - addr;
-            let block_size = erase_block
-                .block_size_at_offset(offset_in_layout)
-                .unwrap_or(max_block_size);
-
-            self.erase_block_bytecode(erase_block.opcode, current, use_4byte)
-                .map_err(|_| CoreError::ProgrammerError)?;
-
-            current += block_size;
+        plan.address.validate_range(addr, buf.len())?;
+        let mut offset = 0;
+        while offset < buf.len() {
+            let address = addr + offset as u32;
+            let count = (buf.len() - offset).min(0x0100_0000 - (address as usize & 0xffffff));
+            if let AddressPlan::Ear(f) = plan.address {
+                rflasher_core::protocol::set_extended_address(self, f, (address >> 24) as u8)
+                    .await?;
+            }
+            self.fast_read(
+                address,
+                &mut buf[offset..offset + count],
+                plan.op.opcode,
+                plan.address.width().bytes() == 4,
+            )
+            .map_err(|_| CoreError::ReadError { addr: address })?;
+            offset += count;
         }
-
         Ok(())
+    }
+    async fn write_planned(&mut self, plan: &WritePlan, addr: u32, data: &[u8]) -> CoreResult<()> {
+        if !self.supports_write_plan(plan) {
+            return Err(CoreError::ChipNotSupported);
+        }
+        plan.address.validate_range(addr, data.len())?;
+        let mut offset = 0;
+        while offset < data.len() {
+            let address = addr + offset as u32;
+            let count = (data.len() - offset).min(0x0100_0000 - (address as usize & 0xffffff));
+            if let AddressPlan::Ear(f) = plan.address {
+                rflasher_core::protocol::set_extended_address(self, f, (address >> 24) as u8)
+                    .await?;
+            }
+            self.batched_write(
+                address,
+                &data[offset..offset + count],
+                plan.page_size,
+                plan.opcode,
+                plan.address.width().bytes() == 4,
+            )
+            .map_err(|_| CoreError::WriteError { addr: address })?;
+            offset += count;
+        }
+        Ok(())
+    }
+    async fn erase_planned(&mut self, plan: &ErasePlan, addr: u32, len: u32) -> CoreResult<()> {
+        if !self.supports_erase_plan(plan) {
+            return Err(CoreError::ChipNotSupported);
+        }
+        plan.address.validate_range(addr, len as usize)?;
+        let mut offset = 0;
+        while offset < len {
+            let address = addr + offset;
+            if let AddressPlan::Ear(f) = plan.address {
+                rflasher_core::protocol::set_extended_address(self, f, (address >> 24) as u8)
+                    .await?;
+            }
+            self.erase_block_bytecode(plan.opcode, address, plan.address.width().bytes() == 4)
+                .map_err(|_| CoreError::ProgrammerError)?;
+            offset += plan
+                .block
+                .block_size_at_offset(offset)
+                .unwrap_or(plan.block.max_block_size());
+        }
+        Ok(())
+    }
+}
+
+fn erase_bytecode(opcode: u8, addr: u32, use_4byte: bool) -> Vec<u8> {
+    let fast_len: u8 = if use_4byte { 5 } else { 4 }; // opcode + addr bytes
+
+    let mut cbuf = Vec::with_capacity(32);
+
+    // WREN
+    cbuf.push(spi_cmd::SELECT);
+    cbuf.push(spi_cmd::FAST);
+    cbuf.push(1);
+    cbuf.push(0x06); // WREN opcode
+    cbuf.push(spi_cmd::DESELECT);
+
+    // Erase command (opcode + address)
+    cbuf.push(spi_cmd::SELECT);
+    cbuf.push(spi_cmd::FAST);
+    cbuf.push(fast_len);
+    cbuf.push(opcode);
+    if use_4byte {
+        cbuf.push((addr >> 24) as u8);
+    }
+    cbuf.push((addr >> 16) as u8);
+    cbuf.push((addr >> 8) as u8);
+    cbuf.push(addr as u8);
+    cbuf.push(spi_cmd::DESELECT);
+
+    // Wait for erase to complete (on-SoC RDSR polling)
+    cbuf.push(spi_cmd::SELECT);
+    cbuf.push(spi_cmd::SPINOR_WAIT);
+    cbuf.push(spi_cmd::DESELECT);
+
+    cbuf.push(spi_cmd::END);
+
+    cbuf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn firmware_erase_bytecode_preserves_native_and_compatibility_addressing_and_wait() {
+        for (opcode, address, four) in [
+            (0x21, 0x0123_4000u32, true),
+            (0x20, 0x0123_4000, true),
+            (0x20, 0x0023_4000, false),
+        ] {
+            let code = erase_bytecode(opcode, address, four);
+            assert_eq!(
+                &code[..5],
+                &[spi_cmd::SELECT, spi_cmd::FAST, 1, 0x06, spi_cmd::DESELECT]
+            );
+            assert_eq!(
+                &code[5..9],
+                &[
+                    spi_cmd::SELECT,
+                    spi_cmd::FAST,
+                    if four { 5 } else { 4 },
+                    opcode
+                ]
+            );
+            let bytes = address.to_be_bytes();
+            let addr_bytes = if four { &bytes[..] } else { &bytes[1..] };
+            assert_eq!(&code[9..9 + addr_bytes.len()], addr_bytes);
+            assert_eq!(
+                &code[9 + addr_bytes.len()..],
+                &[
+                    spi_cmd::DESELECT,
+                    spi_cmd::SELECT,
+                    spi_cmd::SPINOR_WAIT,
+                    spi_cmd::DESELECT,
+                    spi_cmd::END
+                ]
+            );
+        }
     }
 }

--- a/crates/rflasher-programmers/src/erased.rs
+++ b/crates/rflasher-programmers/src/erased.rs
@@ -193,6 +193,7 @@ trait DynSpiMaster {
     fn max_read_len(&self) -> usize;
     fn max_write_len(&self) -> usize;
     fn probe_opcode(&self, opcode: u8) -> bool;
+    fn supports_read_dummy_cycles(&self, mode: rflasher_core::spi::IoMode, cycles: u8) -> bool;
     fn execute<'a>(&'a mut self, cmd: &'a mut SpiCommand<'_>) -> BoxFuture<'a, Result<()>>;
     fn delay_us(&mut self, us: u32) -> BoxFuture<'_, ()>;
 }
@@ -209,6 +210,9 @@ impl<M: SpiMaster> DynSpiMaster for M {
     }
     fn probe_opcode(&self, opcode: u8) -> bool {
         SpiMaster::probe_opcode(self, opcode)
+    }
+    fn supports_read_dummy_cycles(&self, mode: rflasher_core::spi::IoMode, cycles: u8) -> bool {
+        SpiMaster::supports_read_dummy_cycles(self, mode, cycles)
     }
     fn execute<'a>(&'a mut self, cmd: &'a mut SpiCommand<'_>) -> BoxFuture<'a, Result<()>> {
         Box::pin(SpiMaster::execute(self, cmd))
@@ -248,10 +252,55 @@ impl SpiMaster for ErasedSpiMaster {
     fn probe_opcode(&self, opcode: u8) -> bool {
         self.inner.probe_opcode(opcode)
     }
+    fn supports_read_dummy_cycles(&self, mode: rflasher_core::spi::IoMode, cycles: u8) -> bool {
+        self.inner.supports_read_dummy_cycles(mode, cycles)
+    }
     async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> Result<()> {
         self.inner.execute(cmd).await
     }
     async fn delay_us(&mut self, us: u32) {
         self.inner.delay_us(us).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn erased_spi_forwards_exact_dummy_clock_capability() {
+        struct Exact;
+        impl SpiMaster for Exact {
+            fn features(&self) -> SpiFeatures {
+                SpiFeatures::DUAL_IO
+            }
+            fn max_read_len(&self) -> usize {
+                16
+            }
+            fn max_write_len(&self) -> usize {
+                16
+            }
+            fn supports_read_dummy_cycles(
+                &self,
+                _: rflasher_core::spi::IoMode,
+                cycles: u8,
+            ) -> bool {
+                cycles == 5
+            }
+            async fn execute(&mut self, _: &mut SpiCommand<'_>) -> Result<()> {
+                panic!("pure capability query performed I/O")
+            }
+            async fn delay_us(&mut self, _: u32) {}
+        }
+        let erased = ErasedSpiMaster::new(Exact);
+        assert!(SpiMaster::supports_read_dummy_cycles(
+            &erased,
+            rflasher_core::spi::IoMode::DualIo,
+            5
+        ));
+        assert!(!SpiMaster::supports_read_dummy_cycles(
+            &erased,
+            rflasher_core::spi::IoMode::DualIo,
+            4
+        ));
     }
 }

--- a/crates/rflasher-programmers/src/registry.rs
+++ b/crates/rflasher-programmers/src/registry.rs
@@ -1065,10 +1065,6 @@ async fn open_sunxi_fel(
     let chip_info = ChipInfo::from(result);
     let ctx = rflasher_core::flash::FlashContext::new(chip_info.chip.clone());
 
-    // Configure OpaqueMaster with chip info discovered during probe
-    master.set_use_4byte_addr(ctx.total_size() > 16 * 1024 * 1024);
-    master.set_erase_blocks(ctx.chip.erase_blocks().to_vec());
-
     // Use HybridFlashDevice: OpaqueMaster for fast bulk read/write/erase
     // (batched SPI commands with on-SoC busy-wait), SpiMaster for WP and
     // status register access
@@ -1121,7 +1117,7 @@ pub fn available_programmers() -> Vec<ProgrammerInfo> {
         name: "dediprog",
         aliases: &["dediprog_spi"],
         description:
-            "Dediprog SF100/SF200/SF600/SF700 USB SPI (voltage=<V>,spispeed=<speed>,target=<1|2>)",
+            "Dediprog SF100/SF200/SF600/SF700 USB SPI (voltage=<V>,spispeed=<speed>,target=<1|2>,iomode=<auto|single|dual|quad>)",
     });
 
     #[cfg(feature = "serprog-native")]

--- a/crates/rflasher-wasm/Cargo.toml
+++ b/crates/rflasher-wasm/Cargo.toml
@@ -16,9 +16,9 @@ default = []
 [dependencies]
 # Internal crates
 # We override the workspace dependency to ensure async mode for WASM
-rflasher-core = { version = "0.1.0", path = "../rflasher-core", default-features = false, features = ["std", "alloc"] }
-rflasher-chips = { version = "0.1.0", path = "../rflasher-chips", features = ["static-chips"] }
-rflasher-programmers = { version = "0.1.0", path = "../rflasher-programmers", default-features = false, features = [
+rflasher-core = { version = "0.2.0", path = "../rflasher-core", default-features = false, features = ["std", "alloc"] }
+rflasher-chips = { version = "0.2.0", path = "../rflasher-chips", features = ["static-chips"] }
+rflasher-programmers = { version = "0.2.0", path = "../rflasher-programmers", default-features = false, features = [
     "wasm",
     "serprog",
     "ch341a",

--- a/crates/rflasher-wasm/src/app.rs
+++ b/crates/rflasher-wasm/src/app.rs
@@ -176,58 +176,66 @@ macro_rules! with_programmer {
 ///
 /// The body receives `$device` as `&mut impl FlashDevice`. The macro handles
 /// extracting the master back via `into_parts()` and putting the Programmer
-/// wrapper back into shared state.
+/// wrapper back into shared state only after confirmed cleanup. A failed device
+/// is discarded; reconnecting still requires actual hardware recovery and reprobe.
 macro_rules! with_flash_device {
     ($shared:expr, $programmer:expr, $ctx_flash:expr, $device:ident, $body:expr) => {
         match $programmer {
             Programmer::Serprog(master) => {
                 let mut $device = SpiFlashDevice::new(master, $ctx_flash);
                 let result = { $body };
+                let healthy = !$device.recovery_required();
                 let (master, _) = $device.into_parts();
-                $shared.borrow_mut().programmer = Some(Programmer::Serprog(master));
+                $shared.borrow_mut().programmer = healthy.then_some(Programmer::Serprog(master));
                 result
             }
             Programmer::Ch341a(master) => {
                 let mut $device = SpiFlashDevice::new(master, $ctx_flash);
                 let result = { $body };
+                let healthy = !$device.recovery_required();
                 let (master, _) = $device.into_parts();
-                $shared.borrow_mut().programmer = Some(Programmer::Ch341a(master));
+                $shared.borrow_mut().programmer = healthy.then_some(Programmer::Ch341a(master));
                 result
             }
             Programmer::Ch347(master) => {
                 let mut $device = SpiFlashDevice::new(master, $ctx_flash);
                 let result = { $body };
+                let healthy = !$device.recovery_required();
                 let (master, _) = $device.into_parts();
-                $shared.borrow_mut().programmer = Some(Programmer::Ch347(master));
+                $shared.borrow_mut().programmer = healthy.then_some(Programmer::Ch347(master));
                 result
             }
             Programmer::Ftdi(master) => {
                 let mut $device = SpiFlashDevice::new(master, $ctx_flash);
                 let result = { $body };
+                let healthy = !$device.recovery_required();
                 let (master, _) = $device.into_parts();
-                $shared.borrow_mut().programmer = Some(Programmer::Ftdi(master));
+                $shared.borrow_mut().programmer = healthy.then_some(Programmer::Ftdi(master));
                 result
             }
             Programmer::Ft4222(master) => {
                 let mut $device = SpiFlashDevice::new(master, $ctx_flash);
                 let result = { $body };
+                let healthy = !$device.recovery_required();
                 let (master, _) = $device.into_parts();
-                $shared.borrow_mut().programmer = Some(Programmer::Ft4222(master));
+                $shared.borrow_mut().programmer = healthy.then_some(Programmer::Ft4222(master));
                 result
             }
             Programmer::Dediprog(mut master) => {
                 master.set_flash_size($ctx_flash.total_size() as u32);
                 let mut $device = HybridFlashDevice::new(master, $ctx_flash);
                 let result = { $body };
+                let healthy = !$device.recovery_required();
                 let (master, _) = $device.into_parts();
-                $shared.borrow_mut().programmer = Some(Programmer::Dediprog(master));
+                $shared.borrow_mut().programmer = healthy.then_some(Programmer::Dediprog(master));
                 result
             }
             Programmer::Raiden(master) => {
                 let mut $device = SpiFlashDevice::new(master, $ctx_flash);
                 let result = { $body };
+                let healthy = !$device.recovery_required();
                 let (master, _) = $device.into_parts();
-                $shared.borrow_mut().programmer = Some(Programmer::Raiden(master));
+                $shared.borrow_mut().programmer = healthy.then_some(Programmer::Raiden(master));
                 result
             }
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,3 +46,76 @@ platform-specific access layer by implementing `rflasher_internal::HostAccess`:
 
 See [crates/rflasher-internal/README.md](../crates/rflasher-internal/README.md)
 for details.
+
+## Operation-scoped SPI I/O
+
+`flash/io.rs` selects small immutable `ReadPlan`, `WritePlan`, and `ErasePlan`
+values using chip capabilities and pure backend representability checks. Program
+addressing is independent of read addressing. Native four-byte opcodes,
+compatibility EN4B, and EAR are explicit alternatives; residual commands share
+the selected address strategy. Selection rejects unrepresentable dummy timing
+and unsupported/unknown QE sequences without speculative register writes. Per-chip
+`dummy_cycles_*` overrides and `DummyCycleOverrides` use `Option<u8>`: `None`
+selects the JEDEC default, while `Some(0)` means exactly zero clocks. RON may
+omit these fields or supply `Some(n)`; SFDP stores supported descriptor totals
+as `Some(mode + wait)`. Resolved command timing remains a plain `u8`. QPI
+entry remains disabled.
+
+`SpiFlashDevice` and `HybridFlashDevice` retain only a binary recovery-required
+latch. One shared async bracket owns temporary addressing and (reads only) QE
+around the **entire requested operation**, including every bulk chunk and
+unaligned head/tail. Undo obligations are recorded before mutation submission.
+Normal errors still reach cleanup: wait for idle, disable writes, restore owned
+QE, restore EAR or exit owned EN4B. Independent cleanup is attempted even when
+one restoration fails. Pre-existing QE and unrelated status bits are preserved.
+A cleanup failure takes precedence over the operation error (both are logged).
+Uncertain firmware failures bypass all ordinary SPI cleanup, including RDSR:
+without a firmware quiescence barrier, even an idle flash may receive further
+firmware commands. The latch stays armed and explicit recovery owns restoration.
+Persistent WP uses the same lifecycle but never enters a read-QE scope. Modern
+persistent status writes use WREN; mandatory legacy EWSR remains distinct from
+optional volatile writes.
+
+Hybrid paths use explicit `OpaqueMaster::*_planned` calls. Defaults report no
+support and fail before I/O, never silently discard a plan. Dediprog retains
+aligned firmware READ/bulk IN and WRITE/padded bulk OUT, with explicitly planned
+single-I/O residuals and bank-boundary splitting. V2 uses native four-byte packet
+framing, not an inferred address width; compatibility-four-byte program is V3
+only. V2 bulk `0x13` is not silently substituted with `0x0c`: selection must
+explicitly authorize a native fast-read command. When no bulk read plan is
+representable, Hybrid selects a separate single-I/O SPI plan before setup;
+failed bulk reads are never retried through SPI. Writes require backend plan
+support, including V2's native-PP/EAR restriction. Sunxi retains firmware bulk
+read, batched program, and erase with on-SoC busy polling. Firmware erase versus
+SPI fallback is chosen **before** hardware I/O; a firmware failure never triggers
+a SPI retry. Erase completes and cleans up before a fresh single-I/O verification
+scope. Raw opaque APIs remain available on genuinely opaque programmers; the
+SPI-backed Dediprog/Sunxi paths require chip plans instead of guessed metadata.
+
+### Baseline and cancellation
+
+Adapter construction and probing assume the caller has established an idle,
+ordinary-SPI, three-byte command baseline. JEDEC identification does **not**
+establish that baseline; there is no universally safe generic chip reset.
+EAR is read and restored for operations that use it. Callers must ensure bank
+zero for ordinary three-byte operations. Connection to a previously used flash
+must not be mistaken for a reset.
+
+The adapter's latch is armed before the first hardware await. Dropping a polled
+future performs no async cleanup and leaves the latch armed. Every adapter I/O
+and WP entry point rejects subsequent access until explicit **hardware recovery
+and reprobe**; there is no transparent latch-reset/reprepare method. Opaque
+firmware failures also require recovery because a status read alone cannot prove
+the firmware command engine has stopped. `master()` and `into_parts()` are
+low-level escapes whose callers inherit this responsibility. The low-level free
+SPI functions likewise leave cancellation recovery to their caller.
+
+The CLI and registry need no preparation or temporary-state teardown plumbing.
+The browser discards an adapter's master after failed cleanup rather than
+reconstructing a healthy adapter on uncertain hardware. Disconnect/reconnect
+alone is **not** a promise of chip recovery. Unrelated programmer resource
+shutdown remains backend-owned.
+
+Chip capabilities and QE metadata live in `rflasher-chip-types` and the vendor
+RON database, with conservative SFDP conversion. Erased SPI dispatch forwards
+exact dummy-clock representability as well as opcode and I/O-mode capabilities.


### PR DESCRIPTION
Adds dual and quad SPI reads to FT4222, Dediprog, and the existing linux-gpio multi-I/O path. Fine-grained chip capabilities and exact programmer limits select the read instruction, address width, and dummy clocks.

Temporary chip state belongs to a single operation, not a device-wide prepared session. A shared core implementation sets up and restores QE/addressing around the complete transfer. Immutable operation plans reach both firmware bulk transfers and their partial-transfer paths; persistent write-protection updates cannot capture temporary QE. Failed cleanup, uncertain firmware failure, or cancellation prevents reuse of the adapter until hardware recovery.

The implementation retains Dediprog bulk reads/writes and Sunxi firmware erase acceleration, rejects unsupported framing rather than rounding clocks, and treats unknown SFDP QE requirements conservatively. Chip definitions are migrated to explicit per-instruction flags and QE methods.

QPI entry remains disabled. Adapters require a known idle, ordinary-SPI addressing baseline; probing or reconnecting USB is not a hardware reset. Real-hardware validation of the new FT4222 and Dediprog multi-I/O paths remains outstanding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more precise support for SPI, dual, quad, and QPI read modes across supported flash chips.
  * Added automatic handling for quad-enable methods, read timing, and four-byte addressing.
  * Dediprog now supports automatic or forced I/O modes (`auto`, `single`, `dual`, `quad`).
  * FT4222 now supports multi-I/O transfers where supported.

* **Bug Fixes**
  * Improved address-range validation and prevented unsupported transfers from silently falling back.
  * Added clearer recovery handling when hardware cleanup fails or operations are interrupted.

* **Documentation**
  * Documented operation recovery requirements and updated chip capability guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->