### PR TITLE
feat(internal): add ATI/AMD Radeon GPU SPI flash programmer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,6 +2925,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rflasher-ati-spi"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "maybe-async",
+ "rflasher-core",
+ "rflasher-pci",
+ "tock-registers",
+]
+
+[[package]]
 name = "rflasher-ch341a"
 version = "0.1.0"
 dependencies = [
@@ -3032,6 +3043,7 @@ name = "rflasher-flash"
 version = "0.1.0"
 dependencies = [
  "log",
+ "rflasher-ati-spi",
  "rflasher-ch341a",
  "rflasher-ch347",
  "rflasher-core",
@@ -3692,6 +3704,12 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tock-registers"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2d250f87fb3fb6f225c907cf54381509f47b40b74b1d1f12d2dccbc915bdfe"
 
 [[package]]
 name = "toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/rflasher-ft4222",
     "crates/rflasher-internal",
     "crates/rflasher-pci",
+    "crates/rflasher-ati-spi",
     "crates/rflasher-linux-spi",
     "crates/rflasher-linux-mtd",
     "crates/rflasher-linux-gpio",
@@ -38,6 +39,7 @@ default-members = [
     "crates/rflasher-ft4222",
     "crates/rflasher-internal",
     "crates/rflasher-pci",
+    "crates/rflasher-ati-spi",
     "crates/rflasher-linux-spi",
     "crates/rflasher-linux-mtd",
     "crates/rflasher-linux-gpio",
@@ -60,6 +62,7 @@ rflasher-chip-types = { path = "crates/rflasher-chip-types", default-features = 
 rflasher-core = { path = "crates/rflasher-core", default-features = false }
 rflasher-chips = { path = "crates/rflasher-chips" }
 rflasher-pci = { path = "crates/rflasher-pci", default-features = false }
+rflasher-ati-spi = { path = "crates/rflasher-ati-spi", default-features = false }
 
 # Core
 bitflags = "2"
@@ -87,6 +90,7 @@ prettyplease = "0.2"
 heapless = "0.8"
 once_cell = { version = "1.21", default-features = false }
 maybe-async = "0.2"
+tock-registers = { version = "0.10.1", default-features = false, features = ["register_types"] }
 
 [package]
 name = "rflasher"

--- a/crates/rflasher-ati-spi/Cargo.toml
+++ b/crates/rflasher-ati-spi/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rflasher-ati-spi"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "ATI/AMD Radeon GPU SPI flash programmer support for rflasher"
+
+[features]
+default = ["std"]
+std = ["rflasher-core/std", "rflasher-pci/std"]
+is_sync = ["rflasher-core/is_sync"]
+
+[dependencies]
+rflasher-core.workspace = true
+rflasher-pci.workspace = true
+log.workspace = true
+maybe-async.workspace = true
+tock-registers.workspace = true

--- a/crates/rflasher-ati-spi/src/ati_pci.rs
+++ b/crates/rflasher-ati-spi/src/ati_pci.rs
@@ -1,0 +1,394 @@
+//! ATI/AMD Radeon GPU PCI device ID table
+//!
+//! Maps GPU PCI device IDs to their SPI interface type.
+//! Ported from flashrom `ati_spi.c` (Luc Verhaegen, Jiajie Chen).
+
+/// Hardware test status for an ATI GPU entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestStatus {
+    Ok,
+    Untested,
+}
+
+/// ATI/AMD GPU SPI interface type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtiSpiType {
+    /// R600 family (HD 2xxx/3xxx/4xxx) — BAR2, direct MMIO
+    R600,
+    /// RV730/RV740 — BAR2, slightly different clock divider
+    Rv730,
+    /// Evergreen (HD 5xxx: Cypress, Juniper, Redwood, Cedar) — BAR2
+    Evergreen,
+    /// Northern Island (HD 6xxx: Cayman, Barts, Turks, Caicos) — BAR2
+    NorthernIsland,
+    /// Southern Island (HD 7xxx: Lombok, Verde, Pitcairn) — BAR2
+    SouthernIsland,
+    /// Bonaire (GCN 1.1, first Sea Island) — BAR5, SMC indirect
+    Bonaire,
+    /// Hawaii (GCN 1.1) — BAR5, SMC indirect
+    Hawaii,
+    /// Iceland/Tonga/Fiji/Polaris (GCN 1.2+) — BAR5, SMC indirect
+    Iceland,
+}
+
+impl AtiSpiType {
+    /// Which PCI BAR contains the MMIO registers
+    pub fn io_bar(self) -> u8 {
+        match self {
+            Self::R600
+            | Self::Rv730
+            | Self::Evergreen
+            | Self::NorthernIsland
+            | Self::SouthernIsland => 0x18, // PCI_BASE_ADDRESS_2
+            Self::Bonaire | Self::Hawaii | Self::Iceland => 0x24, // PCI_BASE_ADDRESS_5
+        }
+    }
+
+    /// Whether this type uses the CI (Sea Island+) register interface
+    pub fn is_ci(self) -> bool {
+        matches!(self, Self::Bonaire | Self::Hawaii | Self::Iceland)
+    }
+
+    /// Human-readable family name
+    pub fn family_name(self) -> &'static str {
+        match self {
+            Self::R600 => "R600",
+            Self::Rv730 => "RV730",
+            Self::Evergreen => "Evergreen",
+            Self::NorthernIsland => "Northern Island",
+            Self::SouthernIsland => "Southern Island",
+            Self::Bonaire => "Bonaire",
+            Self::Hawaii => "Hawaii",
+            Self::Iceland => "Iceland+",
+        }
+    }
+}
+
+/// ATI SPI PCI device entry
+#[derive(Debug, Clone)]
+pub struct AtiSpiDevice {
+    pub vendor_id: u16,
+    pub device_id: u16,
+    pub spi_type: AtiSpiType,
+    pub status: TestStatus,
+    pub vendor_name: &'static str,
+    pub device_name: &'static str,
+}
+
+/// ATI vendor ID
+pub const ATI_VID: u16 = 0x1002;
+
+/// Find an ATI SPI device by PCI vendor/device ID
+pub fn find_ati_spi_device(vendor_id: u16, device_id: u16) -> Option<&'static AtiSpiDevice> {
+    ATI_SPI_DEVICES
+        .iter()
+        .find(|d| d.vendor_id == vendor_id && d.device_id == device_id)
+}
+
+// Macro to reduce boilerplate in the device table
+macro_rules! ati_dev {
+    ($did:expr, $typ:expr, $status:expr, $name:expr) => {
+        AtiSpiDevice {
+            vendor_id: ATI_VID,
+            device_id: $did,
+            spi_type: $typ,
+            status: $status,
+            vendor_name: "AMD",
+            device_name: $name,
+        }
+    };
+}
+
+use AtiSpiType::*;
+use TestStatus::{Ok as TOk, Untested as NT};
+
+/// Complete PCI device ID table for ATI/AMD GPU SPI flash access.
+///
+/// Covers R600 through Polaris (HD 2xxx → RX 5xx).
+pub static ATI_SPI_DEVICES: &[AtiSpiDevice] = &[
+    // === Bonaire (GCN 1.1 / Sea Islands) ===
+    ati_dev!(0x6640, Bonaire, NT, "Saturn XT [FirePro M6100]"),
+    ati_dev!(0x6641, Bonaire, NT, "Saturn PRO [Radeon HD 8930M]"),
+    ati_dev!(0x6646, Bonaire, NT, "Bonaire XT [Radeon R9 M280X]"),
+    ati_dev!(0x6647, Bonaire, NT, "Saturn PRO/XT [Radeon R9 M270X/M280X]"),
+    ati_dev!(0x6649, Bonaire, NT, "Bonaire [FirePro W5100]"),
+    ati_dev!(0x6650, Bonaire, NT, "Bonaire"),
+    ati_dev!(0x6651, Bonaire, NT, "Bonaire"),
+    ati_dev!(0x6658, Bonaire, NT, "Bonaire XTX [Radeon R7 260X/360]"),
+    ati_dev!(0x665C, Bonaire, NT, "Bonaire XT [Radeon HD 7790/8770]"),
+    ati_dev!(0x665D, Bonaire, NT, "Bonaire [Radeon R7 200 Series]"),
+    ati_dev!(0x665F, Bonaire, TOk, "Tobago PRO [Radeon R7 360]"),
+    // === Northern Island (HD 6xxx) ===
+    ati_dev!(0x6704, NorthernIsland, NT, "Cayman PRO GL [FirePro V7900]"),
+    ati_dev!(0x6707, NorthernIsland, NT, "Cayman LE GL [FirePro V5900]"),
+    ati_dev!(0x6718, NorthernIsland, NT, "Cayman XT [Radeon HD 6970]"),
+    ati_dev!(0x6719, NorthernIsland, NT, "Cayman PRO [Radeon HD 6950]"),
+    ati_dev!(0x671C, NorthernIsland, NT, "Antilles [Radeon HD 6990]"),
+    ati_dev!(0x671D, NorthernIsland, NT, "Antilles [Radeon HD 6990]"),
+    ati_dev!(0x671F, NorthernIsland, NT, "Cayman CE [Radeon HD 6930]"),
+    ati_dev!(
+        0x6720,
+        NorthernIsland,
+        NT,
+        "Blackcomb [Radeon HD 6970M/6990M]"
+    ),
+    ati_dev!(0x6738, NorthernIsland, NT, "Barts XT [Radeon HD 6870]"),
+    ati_dev!(0x6739, NorthernIsland, NT, "Barts PRO [Radeon HD 6850]"),
+    ati_dev!(0x673E, NorthernIsland, NT, "Barts LE [Radeon HD 6790]"),
+    ati_dev!(
+        0x6740,
+        NorthernIsland,
+        NT,
+        "Whistler [Radeon HD 6730M/6770M]"
+    ),
+    ati_dev!(
+        0x6741,
+        NorthernIsland,
+        NT,
+        "Whistler [Radeon HD 6630M/6650M]"
+    ),
+    ati_dev!(0x6742, NorthernIsland, NT, "Whistler LE [Radeon HD 6610M]"),
+    ati_dev!(0x6743, NorthernIsland, NT, "Whistler [Radeon E6760]"),
+    ati_dev!(0x6749, NorthernIsland, NT, "Turks GL [FirePro V4900]"),
+    ati_dev!(0x674A, NorthernIsland, NT, "Turks GL [FirePro V3900]"),
+    ati_dev!(0x6750, NorthernIsland, NT, "Onega [Radeon HD 6650A/7650A]"),
+    ati_dev!(0x6751, NorthernIsland, NT, "Turks [Radeon HD 7650A/7670A]"),
+    ati_dev!(0x6758, NorthernIsland, NT, "Turks XT [Radeon HD 6670/7670]"),
+    ati_dev!(
+        0x6759,
+        NorthernIsland,
+        NT,
+        "Turks PRO [Radeon HD 6570/7570]"
+    ),
+    ati_dev!(0x675b, NorthernIsland, NT, "Turks [Radeon HD 7600 Series]"),
+    ati_dev!(0x675d, NorthernIsland, NT, "Turks PRO [Radeon HD 7570]"),
+    ati_dev!(0x675f, NorthernIsland, NT, "Turks LE [Radeon HD 5570/6510]"),
+    ati_dev!(0x6760, NorthernIsland, NT, "Seymour [Radeon HD 6400M]"),
+    ati_dev!(0x6761, NorthernIsland, NT, "Seymour LP [Radeon HD 6430M]"),
+    ati_dev!(0x6763, NorthernIsland, NT, "Seymour [Radeon E6460]"),
+    ati_dev!(0x6764, NorthernIsland, NT, "Seymour [Radeon HD 6400M]"),
+    ati_dev!(0x6765, NorthernIsland, NT, "Seymour [Radeon HD 6400M]"),
+    ati_dev!(0x6766, NorthernIsland, NT, "Caicos"),
+    ati_dev!(0x6767, NorthernIsland, NT, "Caicos"),
+    ati_dev!(0x6768, NorthernIsland, NT, "Caicos"),
+    ati_dev!(0x6770, NorthernIsland, NT, "Caicos [Radeon HD 6450A/7450A]"),
+    ati_dev!(0x6771, NorthernIsland, NT, "Caicos XTX [Radeon HD 8490]"),
+    ati_dev!(0x6772, NorthernIsland, NT, "Caicos [Radeon HD 7450A]"),
+    ati_dev!(
+        0x6778,
+        NorthernIsland,
+        NT,
+        "Caicos XT [Radeon HD 7470/8470]"
+    ),
+    ati_dev!(
+        0x6779,
+        NorthernIsland,
+        NT,
+        "Caicos [Radeon HD 6450/7450/8450]"
+    ),
+    ati_dev!(0x677B, NorthernIsland, NT, "Caicos PRO [Radeon HD 7450]"),
+    // === Hawaii (GCN 1.1) ===
+    ati_dev!(0x67A0, Hawaii, NT, "Hawaii XT GL [FirePro W9100]"),
+    ati_dev!(0x67A1, Hawaii, NT, "Hawaii PRO GL [FirePro W8100]"),
+    ati_dev!(0x67A2, Hawaii, NT, "Hawaii GL"),
+    ati_dev!(0x67A8, Hawaii, NT, "Hawaii"),
+    ati_dev!(0x67A9, Hawaii, NT, "Hawaii"),
+    ati_dev!(0x67AA, Hawaii, NT, "Hawaii"),
+    ati_dev!(0x67B0, Hawaii, NT, "Hawaii XT [Radeon R9 290X/390X]"),
+    ati_dev!(0x67B1, Hawaii, NT, "Hawaii PRO [Radeon R9 290/390]"),
+    ati_dev!(0x67B9, Hawaii, NT, "Vesuvius [Radeon R9 295X2]"),
+    ati_dev!(0x67BE, Hawaii, NT, "Hawaii LE"),
+    // === Iceland/Tonga/Fiji/Polaris (GCN 1.2+) ===
+    ati_dev!(0x67C0, Iceland, NT, "Ellesmere [Radeon Pro WX 7100 Mobile]"),
+    ati_dev!(0x67C2, Iceland, NT, "Ellesmere [Radeon Pro V7300X]"),
+    ati_dev!(0x67C4, Iceland, NT, "Ellesmere [Radeon Pro WX 7100]"),
+    ati_dev!(0x67C7, Iceland, NT, "Ellesmere [Radeon Pro WX 5100]"),
+    ati_dev!(0x67CA, Iceland, NT, "Ellesmere [Polaris10]"),
+    ati_dev!(0x67CC, Iceland, NT, "Ellesmere [Polaris10]"),
+    ati_dev!(0x67CF, Iceland, NT, "Ellesmere [Polaris10]"),
+    ati_dev!(0x67D0, Iceland, NT, "Ellesmere [Radeon Pro V7300X]"),
+    ati_dev!(0x67DF, Iceland, NT, "Ellesmere [Radeon RX 470/480/570/580]"),
+    ati_dev!(0x67E0, Iceland, NT, "Baffin [Radeon Pro WX 4170]"),
+    ati_dev!(0x67E1, Iceland, NT, "Baffin [Polaris11]"),
+    ati_dev!(0x67E3, Iceland, NT, "Baffin [Radeon Pro WX 4100]"),
+    ati_dev!(0x67E8, Iceland, NT, "Baffin [Radeon Pro WX 4130/4150]"),
+    ati_dev!(0x67E9, Iceland, NT, "Baffin [Polaris11]"),
+    ati_dev!(0x67EB, Iceland, NT, "Baffin [Radeon Pro V5300X]"),
+    ati_dev!(0x67EF, Iceland, NT, "Baffin [Radeon RX 460/560D]"),
+    ati_dev!(0x67FF, Iceland, NT, "Baffin [Radeon RX 550/560X]"),
+    // === Southern Island (HD 7xxx) — Lombok ===
+    ati_dev!(0x6840, SouthernIsland, NT, "Thames [Radeon HD 7500M/7600M]"),
+    ati_dev!(0x6841, SouthernIsland, NT, "Thames [Radeon HD 7550M/7570M]"),
+    ati_dev!(0x6842, SouthernIsland, NT, "Thames LE [Radeon HD 7000M]"),
+    ati_dev!(0x6843, SouthernIsland, NT, "Thames [Radeon HD 7670M]"),
+    // === Evergreen (HD 5xxx) ===
+    ati_dev!(0x6880, Evergreen, NT, "Lexington [Radeon HD 6550M]"),
+    ati_dev!(0x6888, Evergreen, NT, "Cypress XT [FirePro V8800]"),
+    ati_dev!(0x6889, Evergreen, NT, "Cypress PRO [FirePro V7800]"),
+    ati_dev!(0x688A, Evergreen, NT, "Cypress XT [FirePro V9800]"),
+    ati_dev!(0x688C, Evergreen, NT, "Cypress XT GL [FireStream 9370]"),
+    ati_dev!(0x688D, Evergreen, NT, "Cypress PRO GL [FireStream 9350]"),
+    ati_dev!(0x6898, Evergreen, NT, "Cypress XT [Radeon HD 5870]"),
+    ati_dev!(0x6899, Evergreen, NT, "Cypress PRO [Radeon HD 5850]"),
+    ati_dev!(0x689B, Evergreen, NT, "Cypress PRO [Radeon HD 6800]"),
+    ati_dev!(0x689C, Evergreen, NT, "Hemlock [Radeon HD 5970]"),
+    ati_dev!(0x689D, Evergreen, NT, "Hemlock [Radeon HD 5970]"),
+    ati_dev!(0x689E, Evergreen, NT, "Cypress LE [Radeon HD 5830]"),
+    ati_dev!(0x68A0, Evergreen, NT, "Broadway XT [Mobility HD 5870]"),
+    ati_dev!(0x68A1, Evergreen, NT, "Broadway PRO [Mobility HD 5850]"),
+    ati_dev!(0x68A8, Evergreen, NT, "Granville [Radeon HD 6850M/6870M]"),
+    ati_dev!(0x68A9, Evergreen, NT, "Juniper XT [FirePro V5800]"),
+    ati_dev!(0x68B8, Evergreen, NT, "Juniper XT [Radeon HD 5770]"),
+    ati_dev!(0x68B9, Evergreen, NT, "Juniper LE [Radeon HD 5670]"),
+    ati_dev!(0x68BA, Evergreen, NT, "Juniper XT [Radeon HD 6770]"),
+    ati_dev!(0x68BE, Evergreen, NT, "Juniper PRO [Radeon HD 5750]"),
+    ati_dev!(0x68BF, Evergreen, NT, "Juniper PRO [Radeon HD 6750]"),
+    ati_dev!(0x68C0, Evergreen, NT, "Madison [Mobility HD 5730/6570M]"),
+    ati_dev!(0x68C1, Evergreen, NT, "Madison [Mobility HD 5650/5750]"),
+    ati_dev!(0x68C7, Evergreen, NT, "Pinewood [Mobility HD 5570/6550A]"),
+    ati_dev!(0x68C8, Evergreen, NT, "Redwood XT GL [FirePro V4800]"),
+    ati_dev!(0x68C9, Evergreen, NT, "Redwood PRO GL [FirePro V3800]"),
+    ati_dev!(0x68D8, Evergreen, NT, "Redwood XT [Radeon HD 5670/5690]"),
+    ati_dev!(0x68D9, Evergreen, NT, "Redwood PRO [Radeon HD 5550/5570]"),
+    ati_dev!(0x68DA, Evergreen, NT, "Redwood LE [Radeon HD 5550/5570]"),
+    ati_dev!(0x68DE, Evergreen, NT, "Redwood"),
+    ati_dev!(0x68E0, Evergreen, NT, "Park [Mobility HD 5430/5450/5470]"),
+    ati_dev!(0x68E1, Evergreen, NT, "Park [Mobility HD 5430]"),
+    ati_dev!(0x68E4, Evergreen, NT, "Robson CE [Radeon HD 6370M/7370M]"),
+    ati_dev!(0x68E5, Evergreen, NT, "Robson LE [Radeon HD 6330M]"),
+    ati_dev!(0x68E8, Evergreen, NT, "Cedar"),
+    ati_dev!(0x68E9, Evergreen, NT, "Cedar [FirePro Graphics Adapter]"),
+    ati_dev!(0x68F1, Evergreen, NT, "Cedar GL [FirePro 2460]"),
+    ati_dev!(0x68F2, Evergreen, NT, "Cedar GL [FirePro 2270]"),
+    ati_dev!(0x68F8, Evergreen, NT, "Cedar [Radeon HD 7300 Series]"),
+    ati_dev!(0x68F9, Evergreen, NT, "Cedar [Radeon HD 5000/6000/7350]"),
+    ati_dev!(0x68FA, Evergreen, NT, "Cedar [Radeon HD 7350/8350]"),
+    ati_dev!(0x68FE, Evergreen, NT, "Cedar LE"),
+    // === Iceland/Tonga (GCN 1.2) ===
+    ati_dev!(0x6900, Iceland, NT, "Topaz XT [Radeon R7 M260/M265]"),
+    ati_dev!(0x6901, Iceland, NT, "Topaz PRO [Radeon R5 M255]"),
+    ati_dev!(0x6907, Iceland, NT, "Meso XT [Radeon R5 M315]"),
+    ati_dev!(0x6921, Iceland, NT, "Amethyst XT [Radeon R9 M295X]"),
+    ati_dev!(0x6929, Iceland, NT, "Tonga XT GL [FirePro S7150]"),
+    ati_dev!(0x692B, Iceland, NT, "Tonga PRO GL [FirePro W7100]"),
+    ati_dev!(0x692F, Iceland, NT, "Tonga XTV GL [FirePro S7150V]"),
+    ati_dev!(0x6938, Iceland, NT, "Tonga XT [Radeon R9 380X]"),
+    ati_dev!(0x6939, Iceland, NT, "Tonga PRO [Radeon R9 285/380]"),
+    ati_dev!(0x694C, Iceland, NT, "Polaris 22 XT [RX Vega M GH]"),
+    ati_dev!(0x694E, Iceland, NT, "Polaris 22 XL [RX Vega M GL]"),
+    ati_dev!(0x6980, Iceland, NT, "Polaris12"),
+    ati_dev!(0x6981, Iceland, NT, "Lexa XT [Radeon PRO WX 3200]"),
+    ati_dev!(0x6985, Iceland, NT, "Lexa XT [Radeon PRO WX 3100]"),
+    ati_dev!(0x6986, Iceland, NT, "Polaris12"),
+    ati_dev!(0x6987, Iceland, NT, "Lexa [Radeon 540X/550X/630]"),
+    ati_dev!(0x6995, Iceland, NT, "Lexa XT [Radeon PRO WX 2100]"),
+    ati_dev!(0x699F, Iceland, NT, "Lexa PRO [Radeon 540/540X/550/550X]"),
+    ati_dev!(0x7300, Iceland, NT, "Fiji [Radeon R9 FURY / NANO]"),
+    // === R600 (HD 2xxx) ===
+    ati_dev!(0x9400, R600, NT, "R600 [Radeon HD 2900 PRO/XT]"),
+    ati_dev!(0x9401, R600, NT, "R600 [Radeon HD 2900 XT]"),
+    ati_dev!(0x9402, R600, NT, "R600"),
+    ati_dev!(0x9403, R600, NT, "R600 [Radeon HD 2900 PRO]"),
+    ati_dev!(0x9405, R600, NT, "R600 [Radeon HD 2900 GT]"),
+    ati_dev!(0x940A, R600, NT, "R600 GL [FireGL V8650]"),
+    ati_dev!(0x940B, R600, NT, "R600 GL [FireGL V8600]"),
+    ati_dev!(0x940F, R600, NT, "R600 GL [FireGL V7600]"),
+    // === RV770 (HD 4xxx) ===
+    ati_dev!(0x9440, R600, NT, "RV770 [Radeon HD 4870]"),
+    ati_dev!(0x9441, R600, NT, "R700 [Radeon HD 4870 X2]"),
+    ati_dev!(0x9442, R600, NT, "RV770 [Radeon HD 4850]"),
+    ati_dev!(0x9443, R600, NT, "R700 [Radeon HD 4850 X2]"),
+    ati_dev!(0x9444, R600, NT, "RV770 GL [FirePro V8750]"),
+    ati_dev!(0x9446, R600, NT, "RV770 GL [FirePro V7760]"),
+    ati_dev!(0x944A, R600, NT, "RV770 [Mobility HD 4850]"),
+    ati_dev!(0x944B, R600, NT, "RV770 [Mobility HD 4850 X2]"),
+    ati_dev!(0x944C, R600, NT, "RV770 LE [Radeon HD 4830]"),
+    ati_dev!(0x944e, R600, NT, "RV770 CE [Radeon HD 4710]"),
+    ati_dev!(0x9450, R600, NT, "RV770 GL [FireStream 9270]"),
+    ati_dev!(0x9452, R600, NT, "RV770 GL [FireStream 9250]"),
+    ati_dev!(0x9456, R600, NT, "RV770 GL [FirePro V8700]"),
+    ati_dev!(0x945A, R600, NT, "RV770 [Mobility HD 4870]"),
+    ati_dev!(0x9460, R600, NT, "RV790 [Radeon HD 4890]"),
+    ati_dev!(0x9462, R600, NT, "RV790 [Radeon HD 4860]"),
+    ati_dev!(0x946A, R600, NT, "RV770 GL [FirePro M7750]"),
+    // === RV730/RV740 ===
+    ati_dev!(0x9480, Rv730, NT, "RV730 [Mobility HD 4650/5165]"),
+    ati_dev!(0x9488, Rv730, NT, "RV730 [Mobility HD 4670]"),
+    ati_dev!(0x9489, Rv730, NT, "RV730 GL [Mobility FireGL V5725]"),
+    ati_dev!(0x9490, Rv730, NT, "RV730 XT [Radeon HD 4670]"),
+    ati_dev!(0x9491, Rv730, NT, "RV730 [Radeon E4690]"),
+    ati_dev!(0x9495, Rv730, NT, "RV730 [Radeon HD 4600 AGP]"),
+    ati_dev!(0x9498, Rv730, NT, "RV730 PRO [Radeon HD 4650]"),
+    ati_dev!(0x949C, Rv730, NT, "RV730 GL [FirePro V7750]"),
+    ati_dev!(0x949E, Rv730, NT, "RV730 GL [FirePro V5700]"),
+    ati_dev!(0x949F, Rv730, NT, "RV730 GL [FirePro V3750]"),
+    ati_dev!(0x94A0, Rv730, NT, "RV740 [Mobility HD 4830]"),
+    ati_dev!(0x94A1, Rv730, NT, "RV740 [Mobility HD 4860]"),
+    ati_dev!(0x94A3, Rv730, NT, "RV740 GL [FirePro M7740]"),
+    ati_dev!(0x94B3, Rv730, NT, "RV740 PRO [Radeon HD 4770]"),
+    ati_dev!(0x94B4, Rv730, NT, "RV740 PRO [Radeon HD 4750]"),
+    // === RV610 (HD 2400) ===
+    ati_dev!(0x94C1, R600, NT, "RV610 [Radeon HD 2400 PRO/XT]"),
+    ati_dev!(0x94C3, R600, TOk, "RV610 [Radeon HD 2400 PRO]"),
+    ati_dev!(0x94C4, R600, NT, "RV610 LE [Radeon HD 2400 PRO AGP]"),
+    ati_dev!(0x94C5, R600, NT, "RV610 [Radeon HD 2400 LE]"),
+    ati_dev!(0x94C6, R600, NT, "R600"),
+    ati_dev!(0x94C7, R600, NT, "RV610 [Radeon HD 2350]"),
+    ati_dev!(0x94C8, R600, NT, "RV610 [Mobility HD 2400 XT]"),
+    ati_dev!(0x94C9, R600, NT, "RV610 [Mobility HD 2400]"),
+    ati_dev!(0x94CB, R600, NT, "RV610 [Radeon E2400]"),
+    ati_dev!(0x94CC, R600, NT, "RV610 LE [Radeon HD 2400 PRO PCI]"),
+    // === RV670 (HD 3xxx) ===
+    ati_dev!(0x9500, R600, NT, "RV670 [Radeon HD 3850 X2]"),
+    ati_dev!(0x9501, R600, NT, "RV670 [Radeon HD 3870]"),
+    ati_dev!(0x9504, R600, NT, "RV670 [Mobility HD 3850]"),
+    ati_dev!(0x9505, R600, NT, "RV670 [Radeon HD 3690/3850]"),
+    ati_dev!(0x9506, R600, NT, "RV670 [Mobility HD 3850 X2]"),
+    ati_dev!(0x9507, R600, NT, "RV670 [Radeon HD 3830]"),
+    ati_dev!(0x9508, R600, NT, "RV670 [Mobility HD 3870]"),
+    ati_dev!(0x9509, R600, NT, "RV670 [Mobility HD 3870 X2]"),
+    ati_dev!(0x950F, R600, NT, "R680 [Radeon HD 3870 X2]"),
+    ati_dev!(0x9511, R600, TOk, "RV670 GL [FireGL V7700]"),
+    ati_dev!(0x9513, R600, NT, "RV670 [Radeon HD 3850 X2]"),
+    ati_dev!(0x9515, R600, NT, "RV670 PRO [Radeon HD 3850 AGP]"),
+    ati_dev!(0x9519, R600, NT, "RV670 GL [FireStream 9170]"),
+    // === RV710 ===
+    ati_dev!(0x9540, R600, NT, "RV710 [Radeon HD 4550]"),
+    ati_dev!(0x954F, R600, NT, "RV710 [Radeon HD 4350/4550]"),
+    ati_dev!(0x9552, R600, NT, "RV710 [Mobility HD 4330/4350]"),
+    ati_dev!(0x9553, R600, NT, "RV710 [Mobility HD 4530/4570]"),
+    ati_dev!(0x9555, R600, NT, "RV711 [Mobility HD 4350/4550]"),
+    ati_dev!(0x9557, R600, NT, "RV711 GL [FirePro RG220]"),
+    ati_dev!(0x955F, R600, NT, "RV710 [Mobility HD 4330]"),
+    // === RV630 (HD 2600) ===
+    ati_dev!(0x9580, R600, NT, "RV630 [Radeon HD 2600 PRO]"),
+    ati_dev!(0x9581, R600, NT, "RV630 [Mobility HD 2600]"),
+    ati_dev!(0x9583, R600, NT, "RV630 [Mobility HD 2600 XT/2700]"),
+    ati_dev!(0x9586, R600, NT, "RV630 XT [Radeon HD 2600 XT AGP]"),
+    ati_dev!(0x9587, R600, NT, "RV630 PRO [Radeon HD 2600 PRO AGP]"),
+    ati_dev!(0x9588, R600, NT, "RV630 XT [Radeon HD 2600 XT]"),
+    ati_dev!(0x9589, R600, TOk, "RV630 PRO [Radeon HD 2600 PRO]"),
+    ati_dev!(0x958A, R600, NT, "RV630 [Radeon HD 2600 X2]"),
+    ati_dev!(0x958B, R600, NT, "RV630 [Mobility HD 2600 XT]"),
+    ati_dev!(0x958C, R600, NT, "RV630 GL [FireGL V5600]"),
+    ati_dev!(0x958D, R600, TOk, "RV630 GL [FireGL V3600]"),
+    ati_dev!(0x958E, R600, NT, "R600"),
+    // === RV635 (HD 3600) ===
+    ati_dev!(0x9591, R600, NT, "RV635 [Mobility HD 3650]"),
+    ati_dev!(0x9593, R600, NT, "RV635 [Mobility HD 3670]"),
+    ati_dev!(0x9595, R600, NT, "RV635 GL [Mobility FireGL V5700]"),
+    ati_dev!(0x9596, R600, NT, "RV635 PRO [Radeon HD 3650 AGP]"),
+    ati_dev!(0x9597, R600, NT, "RV635 PRO [Radeon HD 3650 AGP]"),
+    ati_dev!(0x9598, R600, NT, "RV635 [Radeon HD 3650/3750/4570]"),
+    ati_dev!(0x9599, R600, NT, "RV635 PRO [Radeon HD 3650 AGP]"),
+    // === RV620 (HD 3400) ===
+    ati_dev!(0x95C0, R600, NT, "RV620 PRO [Radeon HD 3470]"),
+    ati_dev!(0x95C2, R600, NT, "RV620 [Mobility HD 3410/3430]"),
+    ati_dev!(0x95C4, R600, NT, "RV620 [Mobility HD 3450/3470]"),
+    ati_dev!(0x95C5, R600, NT, "RV620 LE [Radeon HD 3450]"),
+    ati_dev!(0x95C6, R600, NT, "RV620 LE [Radeon HD 3450 AGP]"),
+    ati_dev!(0x95C9, R600, NT, "RV620 LE [Radeon HD 3450 PCI]"),
+    ati_dev!(0x95CC, R600, NT, "RV620 GL [FirePro V3700]"),
+    ati_dev!(0x95CD, R600, NT, "RV620 GL [FirePro 2450]"),
+    ati_dev!(0x95CF, R600, NT, "RV620 GL [FirePro 2260]"),
+];

--- a/crates/rflasher-ati-spi/src/ati_spi.rs
+++ b/crates/rflasher-ati-spi/src/ati_spi.rs
@@ -1,0 +1,760 @@
+//! ATI/AMD Radeon GPU SPI flash programmer
+//!
+//! Accesses the SPI flash chip on discrete AMD/ATI GPUs via the GPU's
+//! built-in ROM controller, accessed through PCI MMIO registers.
+//! This allows reading/writing the VBIOS flash.
+//!
+//! Ported from flashrom `ati_spi.c` by Luc Verhaegen and Jiajie Chen.
+//!
+//! # Supported GPU families
+//!
+//! - **R600** (HD 2xxx–4xxx): Direct MMIO via BAR2, ROM_SW_* registers
+//! - **Evergreen** (HD 5xxx): Same engine, different GPIO init
+//! - **Northern Island** (HD 6xxx): Same engine, extra GPIO setup
+//! - **Southern Island** (HD 7xxx): Same engine
+//! - **Sea Islands+** (GCN 1.1+: Bonaire, Hawaii, Iceland, Tonga, Fiji, Polaris):
+//!   BAR5, SMC indirect register access for ROM_SW_* registers
+
+use crate::ati_pci::{AtiSpiType, find_ati_spi_device};
+use crate::error::AtiSpiError;
+use maybe_async::maybe_async;
+use rflasher_core::error::{Error as CoreError, Result as CoreResult};
+use rflasher_core::programmer::{SpiFeatures, SpiMaster};
+use rflasher_core::spi::{AddressWidth, SpiCommand};
+
+use core::marker::PhantomData;
+use tock_registers::fields::FieldValue;
+use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
+use tock_registers::registers::{ReadOnly, ReadWrite};
+use tock_registers::{LocalRegisterCopy, RegisterLongName, register_bitfields, register_structs};
+
+register_bitfields![u32,
+ GeneralPower [ OPEN_DRAIN OFFSET(11) NUMBITS(1) [] ],
+ Gpio10 [ PIN OFFSET(10) NUMBITS(1) [] ],
+ RomControl [ CLOCK_GATE OFFSET(1) NUMBITS(1) [], DIVIDER OFFSET(24) NUMBITS(8) [], PRESCALE OFFSET(28) NUMBITS(4) [] ],
+ PageMirror [ MODE OFFSET(26) NUMBITS(2) [] ],
+ SoftwareControl [ DATA_BYTES OFFSET(0) NUMBITS(16) [], COMMAND_BYTES OFFSET(16) NUMBITS(2) [], READ OFFSET(18) NUMBITS(1) [] ],
+ SoftwareStatus [ COMPLETE OFFSET(0) NUMBITS(32) [] ],
+ GpioPad [ SPI OFFSET(7) NUMBITS(3) [], LEGACY OFFSET(19) NUMBITS(1) [], EXTRA OFFSET(30) NUMBITS(1) [] ],
+ NiGpio [ ENABLE OFFSET(8) NUMBITS(1) [] ],
+ DrmStraps [ VALUE OFFSET(28) NUMBITS(4) [] ]
+];
+
+register_structs! {
+ R600Registers {
+  (0x0000 => _r0), (0x0618 => general_power: ReadWrite<u32, GeneralPower::Register>),
+  (0x061c => _r1), (0x0710 => lower_gpio_enable: ReadWrite<u32, Gpio10::Register>),
+  (0x0714 => _r2), (0x0718 => ctx_gpio: ReadWrite<u32, Gpio10::Register>),
+  (0x071c => high_gpio: ReadWrite<u32, Gpio10::Register>), (0x0720 => medium_gpio: ReadWrite<u32, Gpio10::Register>),
+  (0x0724 => low_gpio: ReadWrite<u32, Gpio10::Register>), (0x0728 => _r3),
+  (0x1600 => rom_control: ReadWrite<u32, RomControl::Register>), (0x1604 => page_mirror: ReadWrite<u32, PageMirror::Register>),
+  (0x1608 => _r4), (0x1618 => sw_control: ReadWrite<u32, SoftwareControl::Register>),
+  (0x161c => sw_status: ReadWrite<u32, SoftwareStatus::Register>), (0x1620 => sw_command: ReadWrite<u32>),
+  (0x1624 => sw_data: [ReadWrite<u32>; 64]), (0x1724 => _r5),
+  (0x1798 => gpio_mask: ReadWrite<u32, GpioPad::Register>), (0x179c => gpio_value: ReadWrite<u32, GpioPad::Register>),
+  (0x17a0 => gpio_enable: ReadWrite<u32, GpioPad::Register>), (0x17a4 => _r6),
+  (0x64a0 => ni_gpio0: ReadWrite<u32, NiGpio::Register>), (0x64a4 => ni_gpio1: ReadWrite<u32, NiGpio::Register>),
+  (0x64a8 => ni_gpio2: ReadWrite<u32, NiGpio::Register>), (0x64ac => @END),
+ },
+ CiRegisters {
+  (0x0000 => _r0), (0x0208 => smc_index: ReadWrite<u32>), (0x020c => smc_data: ReadWrite<u32>),
+  (0x0210 => _r1), (0x0608 => gpio_mask: ReadWrite<u32, GpioPad::Register>),
+  (0x060c => gpio_value: ReadWrite<u32, GpioPad::Register>), (0x0610 => gpio_enable: ReadWrite<u32, GpioPad::Register>),
+  (0x0614 => _r2), (0x5564 => drm_straps: ReadOnly<u32, DrmStraps::Register>), (0x5568 => @END),
+ }
+}
+
+const STATUS_LOOP_COUNT: usize = 1000;
+const SPI_TRANSFER_SIZE: usize = 0x100;
+#[derive(Clone, Copy)]
+struct SmcRegister<R: RegisterLongName> {
+    address: u32,
+    marker: PhantomData<R>,
+}
+impl<R: RegisterLongName> SmcRegister<R> {
+    const fn new(address: u32) -> Self {
+        Self {
+            address,
+            marker: PhantomData,
+        }
+    }
+}
+const SMC_GENERAL_POWER: SmcRegister<GeneralPower::Register> = SmcRegister::new(0xC0200000);
+const SMC_ROM_CONTROL: SmcRegister<RomControl::Register> = SmcRegister::new(0xC0600000);
+const SMC_PAGE_MIRROR: SmcRegister<PageMirror::Register> = SmcRegister::new(0xC0600004);
+const SMC_SW_CONTROL: SmcRegister<SoftwareControl::Register> = SmcRegister::new(0xC060001C);
+const SMC_SW_STATUS: SmcRegister<SoftwareStatus::Register> = SmcRegister::new(0xC0600020);
+const SMC_SW_COMMAND: SmcRegister<()> = SmcRegister::new(0xC0600024);
+const SMC_SW_DATA_BASE: u32 = 0xC0600028;
+
+// ============================================================================
+// Saved register state for restore on shutdown
+// ============================================================================
+
+/// R600-family saved register state
+struct R600SavedState {
+    general_pwrmgt: u32,
+    lower_gpio_enable: u32,
+    ctxsw_vid_lower_gpio_cntl: u32,
+    high_vid_lower_gpio_cntl: u32,
+    medium_vid_lower_gpio_cntl: u32,
+    low_vid_lower_gpio_cntl: u32,
+    rom_cntl: u32,
+    page_mirror_cntl: u32,
+    gpiopad_mask: u32,
+    gpiopad_a: u32,
+    gpiopad_en: u32,
+}
+
+/// CI-family saved register state
+struct CiSavedState {
+    gpiopad_mask: u32,
+    gpiopad_a: u32,
+    gpiopad_en: u32,
+    general_pwrmgt: u32,
+    rom_cntl: u32,
+    page_mirror_cntl: u32,
+}
+
+enum SavedState {
+    R600(R600SavedState),
+    Ci(CiSavedState),
+}
+
+// ============================================================================
+// ATI SPI Controller
+// ============================================================================
+
+/// ATI/AMD Radeon GPU SPI flash controller
+///
+/// Accesses the SPI flash on a discrete AMD GPU through MMIO.
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub struct AtiSpiController {
+    bar: rflasher_pci::MappedBar,
+    spi_type: AtiSpiType,
+    saved: Option<SavedState>,
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+impl AtiSpiController {
+    /// Create and initialize a new ATI SPI controller.
+    ///
+    /// Scans the PCI bus for a supported AMD GPU, maps its MMIO BAR,
+    /// saves the current register state, and enables SPI access.
+    pub fn new(
+        vendor_id: u16,
+        device_id: u16,
+        address: rflasher_pci::PciAddress,
+        bar_index: u8,
+    ) -> Result<Self, AtiSpiError> {
+        let dev =
+            find_ati_spi_device(vendor_id, device_id).ok_or(AtiSpiError::UnsupportedDevice {
+                vendor_id,
+                device_id,
+                name: "Unknown ATI/AMD GPU",
+            })?;
+
+        log::info!(
+            "ATI SPI: detected {} {} (family: {})",
+            dev.vendor_name,
+            dev.device_name,
+            dev.spi_type.family_name()
+        );
+
+        let bar = rflasher_pci::SysfsPci::system().map_bar(address, bar_index, 0x7000)?;
+
+        let mut ctrl = Self {
+            bar,
+            spi_type: dev.spi_type,
+            saved: None,
+        };
+
+        ctrl.save()?;
+        ctrl.enable()?;
+
+        Ok(ctrl)
+    }
+
+    fn r600(&self) -> &R600Registers {
+        // SAFETY: R600Registers describes the BAR layout for non-CI GPUs.
+        unsafe { self.bar.registers() }
+    }
+
+    fn ci(&self) -> &CiRegisters {
+        // SAFETY: CiRegisters describes the BAR layout for CI-family GPUs.
+        unsafe { self.bar.registers() }
+    }
+
+    fn smc_read<R: RegisterLongName>(&self, register: SmcRegister<R>) -> LocalRegisterCopy<u32, R> {
+        self.ci().smc_index.set(register.address);
+        LocalRegisterCopy::new(self.ci().smc_data.get())
+    }
+
+    fn smc_write<R: RegisterLongName>(&self, register: SmcRegister<R>, value: u32) {
+        self.ci().smc_index.set(register.address);
+        self.ci().smc_data.set(value);
+    }
+
+    fn smc_modify<R: RegisterLongName>(
+        &self,
+        register: SmcRegister<R>,
+        fields: FieldValue<u32, R>,
+    ) {
+        let address = register.address;
+        let mut value = self.smc_read(register);
+        value.modify(fields);
+        self.smc_write(SmcRegister::<R>::new(address), value.get());
+    }
+
+    fn smc_data_register(offset: u32) -> SmcRegister<()> {
+        SmcRegister::new(SMC_SW_DATA_BASE + offset)
+    }
+
+    // ---- Save/Restore ----
+
+    fn save(&mut self) -> Result<(), AtiSpiError> {
+        log::debug!("ATI SPI: saving register state");
+        if self.spi_type.is_ci() {
+            let r = self.ci();
+            self.saved = Some(SavedState::Ci(CiSavedState {
+                general_pwrmgt: self.smc_read(SMC_GENERAL_POWER).get(),
+                rom_cntl: self.smc_read(SMC_ROM_CONTROL).get(),
+                page_mirror_cntl: self.smc_read(SMC_PAGE_MIRROR).get(),
+                gpiopad_mask: r.gpio_mask.get(),
+                gpiopad_a: r.gpio_value.get(),
+                gpiopad_en: r.gpio_enable.get(),
+            }));
+        } else {
+            let r = self.r600();
+            self.saved = Some(SavedState::R600(R600SavedState {
+                general_pwrmgt: r.general_power.get(),
+                lower_gpio_enable: r.lower_gpio_enable.get(),
+                ctxsw_vid_lower_gpio_cntl: r.ctx_gpio.get(),
+                high_vid_lower_gpio_cntl: r.high_gpio.get(),
+                medium_vid_lower_gpio_cntl: r.medium_gpio.get(),
+                low_vid_lower_gpio_cntl: r.low_gpio.get(),
+                rom_cntl: r.rom_control.get(),
+                page_mirror_cntl: r.page_mirror.get(),
+                gpiopad_mask: r.gpio_mask.get(),
+                gpiopad_a: r.gpio_value.get(),
+                gpiopad_en: r.gpio_enable.get(),
+            }));
+        }
+        Ok(())
+    }
+
+    fn restore(&self) {
+        log::debug!("ATI SPI: restoring register state");
+        match &self.saved {
+            Some(SavedState::R600(s)) => {
+                let r = self.r600();
+                r.rom_control.set(s.rom_cntl);
+                r.gpio_value.set(s.gpiopad_a);
+                r.gpio_enable.set(s.gpiopad_en);
+                r.gpio_mask.set(s.gpiopad_mask);
+                r.general_power.set(s.general_pwrmgt);
+                r.ctx_gpio.set(s.ctxsw_vid_lower_gpio_cntl);
+                r.high_gpio.set(s.high_vid_lower_gpio_cntl);
+                r.medium_gpio.set(s.medium_vid_lower_gpio_cntl);
+                r.low_gpio.set(s.low_vid_lower_gpio_cntl);
+                r.lower_gpio_enable.set(s.lower_gpio_enable);
+                r.page_mirror.set(s.page_mirror_cntl);
+            }
+            Some(SavedState::Ci(s)) => {
+                let r = self.ci();
+                self.smc_write(SMC_ROM_CONTROL, s.rom_cntl);
+                r.gpio_value.set(s.gpiopad_a);
+                r.gpio_enable.set(s.gpiopad_en);
+                r.gpio_mask.set(s.gpiopad_mask);
+                self.smc_write(SMC_GENERAL_POWER, s.general_pwrmgt);
+                self.smc_write(SMC_PAGE_MIRROR, s.page_mirror_cntl);
+            }
+            None => {}
+        }
+    }
+
+    fn enable(&self) -> Result<(), AtiSpiError> {
+        log::debug!(
+            "ATI SPI: enabling SPI access (family: {})",
+            self.spi_type.family_name()
+        );
+
+        if self.spi_type.is_ci() {
+            self.ci_enable()
+        } else {
+            self.r600_enable()
+        }
+    }
+
+    fn r600_enable(&self) -> Result<(), AtiSpiError> {
+        let r = self.r600();
+        if self.spi_type == AtiSpiType::Rv730 {
+            r.rom_control
+                .modify(RomControl::DIVIDER.val(0x19) + RomControl::CLOCK_GATE::SET);
+        } else {
+            r.rom_control
+                .modify(RomControl::PRESCALE.val(1) + RomControl::CLOCK_GATE::SET);
+        }
+        if self.spi_type == AtiSpiType::NorthernIsland {
+            r.ni_gpio0.modify(NiGpio::ENABLE::SET);
+            r.ni_gpio1.modify(NiGpio::ENABLE::SET);
+            r.ni_gpio2.modify(NiGpio::ENABLE::SET);
+        }
+        r.gpio_value.modify(GpioPad::SPI.val(0));
+        r.gpio_enable.modify(GpioPad::SPI.val(6));
+        r.gpio_mask.modify(GpioPad::SPI.val(7));
+        r.general_power.modify(GeneralPower::OPEN_DRAIN::CLEAR);
+        if matches!(
+            self.spi_type,
+            AtiSpiType::R600
+                | AtiSpiType::Rv730
+                | AtiSpiType::Evergreen
+                | AtiSpiType::NorthernIsland
+        ) {
+            r.ctx_gpio.modify(Gpio10::PIN::CLEAR);
+            r.high_gpio.modify(Gpio10::PIN::CLEAR);
+            r.medium_gpio.modify(Gpio10::PIN::CLEAR);
+            r.low_gpio.modify(Gpio10::PIN::CLEAR);
+        }
+        if matches!(self.spi_type, AtiSpiType::R600 | AtiSpiType::Rv730) {
+            r.lower_gpio_enable.modify(Gpio10::PIN::SET);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        r.gpio_mask.modify(GpioPad::SPI::CLEAR);
+        r.gpio_enable.modify(GpioPad::SPI::CLEAR);
+        r.gpio_value.modify(GpioPad::LEGACY::CLEAR);
+        r.page_mirror.modify(PageMirror::MODE.val(1));
+        if r.sw_status.get() != 0 {
+            for i in 0..STATUS_LOOP_COUNT {
+                r.sw_status.set(0);
+                std::thread::sleep(std::time::Duration::from_millis(1));
+                if r.sw_status.get() == 0 {
+                    break;
+                }
+                if i == STATUS_LOOP_COUNT - 1 {
+                    return Err(AtiSpiError::SpiInit("failed to clear R600 ROM_SW_STATUS"));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn ci_enable(&self) -> Result<(), AtiSpiError> {
+        let r = self.ci();
+        self.smc_modify(SMC_ROM_CONTROL, RomControl::PRESCALE.val(1));
+        let gate =
+            if self.spi_type == AtiSpiType::Bonaire && r.drm_straps.read(DrmStraps::VALUE) != 0 {
+                RomControl::CLOCK_GATE::CLEAR
+            } else {
+                RomControl::CLOCK_GATE::SET
+            };
+        self.smc_modify(SMC_ROM_CONTROL, gate);
+        r.gpio_value.modify(GpioPad::SPI.val(0));
+        r.gpio_enable.modify(GpioPad::SPI.val(6));
+        r.gpio_mask.modify(GpioPad::SPI.val(7));
+        if self.spi_type != AtiSpiType::Bonaire {
+            r.gpio_mask.modify(GpioPad::EXTRA::SET);
+            r.gpio_enable.modify(GpioPad::EXTRA::SET);
+            r.gpio_value.modify(GpioPad::EXTRA::SET);
+        }
+        if !matches!(self.spi_type, AtiSpiType::Bonaire | AtiSpiType::Hawaii) {
+            self.smc_modify(SMC_GENERAL_POWER, GeneralPower::OPEN_DRAIN::CLEAR);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        r.gpio_mask
+            .modify(GpioPad::SPI::CLEAR + GpioPad::LEGACY::CLEAR);
+        r.gpio_enable
+            .modify(GpioPad::SPI::CLEAR + GpioPad::LEGACY::CLEAR);
+        r.gpio_value
+            .modify(GpioPad::SPI::CLEAR + GpioPad::LEGACY::CLEAR);
+        self.smc_modify(SMC_PAGE_MIRROR, PageMirror::MODE.val(1));
+        if self.smc_read(SMC_SW_STATUS).get() != 0 {
+            for i in 0..STATUS_LOOP_COUNT {
+                self.smc_write(SMC_SW_STATUS, 0);
+                std::thread::sleep(std::time::Duration::from_millis(1));
+                if self.smc_read(SMC_SW_STATUS).get() == 0 {
+                    break;
+                }
+                if i == STATUS_LOOP_COUNT - 1 {
+                    return Err(AtiSpiError::SpiInit("failed to clear CI ROM_SW_STATUS"));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn r600_spi_command(&self, writearr: &[u8], readarr: &mut [u8]) -> Result<(), AtiSpiError> {
+        let writecnt = writearr.len();
+        let readcnt = readarr.len();
+
+        // Build the 4-byte command register: opcode | addr[2] | addr[1] | addr[0]
+        let mut command: u32 = writearr[0] as u32;
+        if writecnt > 1 {
+            command |= (writearr[1] as u32) << 24;
+        }
+        if writecnt > 2 {
+            command |= (writearr[2] as u32) << 16;
+        }
+        if writecnt > 3 {
+            command |= (writearr[3] as u32) << 8;
+        }
+
+        let command_size = writecnt.min(4);
+
+        let r = self.r600();
+        r.sw_command.set(command);
+
+        // Write remaining data bytes (after the 4-byte command) to FIFO.
+        // ATI HW does 32-bit register writes; writing 8 bits zeroes upper bytes.
+        // Also endianness is swapped between read and write paths.
+        let mut i = 4;
+        while i < writecnt {
+            let mut value: u32 = 0;
+            let remainder = (writecnt - i).min(4);
+
+            if remainder > 0 {
+                value |= (writearr[i] as u32) << 24;
+            }
+            if remainder > 1 {
+                value |= (writearr[i + 1] as u32) << 16;
+            }
+            if remainder > 2 {
+                value |= (writearr[i + 2] as u32) << 8;
+            }
+            if remainder > 3 {
+                value |= writearr[i + 3] as u32;
+            }
+
+            r.sw_data[(i - 4) / 4].set(value);
+            i += 4;
+        }
+
+        // Build the typed control register and trigger the transfer.
+        let data_bytes = if readcnt > 0 {
+            readcnt
+        } else {
+            writecnt.saturating_sub(4)
+        };
+        let mut fields = SoftwareControl::COMMAND_BYTES.val((command_size - 1) as u32)
+            + SoftwareControl::DATA_BYTES.val(data_bytes as u32);
+        if readcnt > 0 {
+            fields += SoftwareControl::READ::SET;
+        }
+        r.sw_control.write(fields);
+
+        // Poll for completion
+        for j in 0..STATUS_LOOP_COUNT {
+            if r.sw_status.get() != 0 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            if j == STATUS_LOOP_COUNT - 1 {
+                log::error!("ATI SPI: R600 SPI command timed out");
+                return Err(AtiSpiError::Io("R600 SPI command timed out"));
+            }
+        }
+        r.sw_status.set(0);
+
+        // Read response data byte-by-byte
+        for (j, byte) in readarr[..readcnt].iter_mut().enumerate() {
+            *byte = ((r.sw_data[j / 4].get() >> ((j % 4) * 8)) & 0xff) as u8;
+        }
+
+        Ok(())
+    }
+
+    /// Execute a raw SPI command (CI family — SMC indirect).
+    fn ci_spi_command(&self, writearr: &[u8], readarr: &mut [u8]) -> Result<(), AtiSpiError> {
+        let writecnt = writearr.len();
+        let readcnt = readarr.len();
+
+        // Build the 4-byte command register
+        let mut command: u32 = writearr[0] as u32;
+        if writecnt > 1 {
+            command |= (writearr[1] as u32) << 24;
+        }
+        if writecnt > 2 {
+            command |= (writearr[2] as u32) << 16;
+        }
+        if writecnt > 3 {
+            command |= (writearr[3] as u32) << 8;
+        }
+
+        let command_size = writecnt.min(4);
+
+        self.smc_write(SMC_SW_COMMAND, command);
+
+        // Write remaining data
+        let mut i = 4u32;
+        while (i as usize) < writecnt {
+            let mut value: u32 = 0;
+            let remainder = (writecnt - i as usize).min(4);
+
+            if remainder > 0 {
+                value |= (writearr[i as usize] as u32) << 24;
+            }
+            if remainder > 1 {
+                value |= (writearr[i as usize + 1] as u32) << 16;
+            }
+            if remainder > 2 {
+                value |= (writearr[i as usize + 2] as u32) << 8;
+            }
+            if remainder > 3 {
+                value |= writearr[i as usize + 3] as u32;
+            }
+
+            // Bonaire has a gap between 0xD8 and 0xE8
+            if self.spi_type == AtiSpiType::Bonaire && i >= 0xdc {
+                self.smc_write(Self::smc_data_register(i + 0x0C), value);
+            } else {
+                self.smc_write(Self::smc_data_register(i - 4), value);
+            }
+            i += 4;
+        }
+
+        // Build the typed control register and trigger the transfer.
+        let data_bytes = if readcnt > 0 {
+            readcnt
+        } else {
+            writecnt.saturating_sub(4)
+        };
+        let mut control = LocalRegisterCopy::<u32, SoftwareControl::Register>::new(0);
+        let mut fields = SoftwareControl::COMMAND_BYTES.val((command_size - 1) as u32)
+            + SoftwareControl::DATA_BYTES.val(data_bytes as u32);
+        if readcnt > 0 {
+            fields += SoftwareControl::READ::SET;
+        }
+        control.write(fields);
+        self.smc_write(SMC_SW_CONTROL, control.get());
+
+        // Poll for completion
+        for j in 0..STATUS_LOOP_COUNT {
+            if self.smc_read(SMC_SW_STATUS).get() != 0 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            if j == STATUS_LOOP_COUNT - 1 {
+                log::error!("ATI SPI: CI SPI command timed out");
+                return Err(AtiSpiError::Io("CI SPI command timed out"));
+            }
+        }
+        self.smc_write(SMC_SW_STATUS, 0);
+
+        // Read response data (32-bit words, unpacked)
+        let mut i = 0u32;
+        while (i as usize) < readcnt {
+            let value = if self.spi_type == AtiSpiType::Bonaire && i >= 0xd8 {
+                self.smc_read(Self::smc_data_register(i + 0x10)).get()
+            } else {
+                self.smc_read(Self::smc_data_register(i)).get()
+            };
+
+            let remainder = readcnt - i as usize;
+            if remainder > 0 {
+                readarr[i as usize] = value as u8;
+            }
+            if remainder > 1 {
+                readarr[i as usize + 1] = (value >> 8) as u8;
+            }
+            if remainder > 2 {
+                readarr[i as usize + 2] = (value >> 16) as u8;
+            }
+            if remainder > 3 {
+                readarr[i as usize + 3] = (value >> 24) as u8;
+            }
+            i += 4;
+        }
+
+        Ok(())
+    }
+
+    /// Execute a raw SPI command, dispatching to the correct family.
+    pub fn send_command(&self, writearr: &[u8], readarr: &mut [u8]) -> Result<(), AtiSpiError> {
+        if writearr.is_empty() {
+            return Err(AtiSpiError::Io("SPI command must have at least 1 byte"));
+        }
+        if writearr.len().saturating_sub(4) > SPI_TRANSFER_SIZE {
+            return Err(AtiSpiError::Io("SPI write exceeds the hardware FIFO"));
+        }
+        if readarr.len() > SPI_TRANSFER_SIZE {
+            return Err(AtiSpiError::Io("SPI read exceeds the hardware FIFO"));
+        }
+
+        log::trace!(
+            "ATI SPI: cmd 0x{:02x}, write {} bytes, read {} bytes",
+            writearr[0],
+            writearr.len(),
+            readarr.len()
+        );
+
+        if self.spi_type.is_ci() {
+            self.ci_spi_command(writearr, readarr)
+        } else {
+            self.r600_spi_command(writearr, readarr)
+        }
+    }
+
+    /// Maximum SPI transfer size for this controller
+    pub fn max_transfer_size(&self) -> usize {
+        if self.spi_type.is_ci() {
+            SPI_TRANSFER_SIZE
+        } else {
+            SPI_TRANSFER_SIZE
+        }
+    }
+
+    /// Get the SPI type / GPU family
+    pub fn spi_type(&self) -> AtiSpiType {
+        self.spi_type
+    }
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+impl Drop for AtiSpiController {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
+// ============================================================================
+// SpiMaster trait implementation
+// ============================================================================
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+#[maybe_async(AFIT)]
+impl SpiMaster for AtiSpiController {
+    fn features(&self) -> SpiFeatures {
+        SpiFeatures::empty()
+    }
+
+    fn max_read_len(&self) -> usize {
+        self.max_transfer_size()
+    }
+
+    fn max_write_len(&self) -> usize {
+        self.max_transfer_size()
+    }
+
+    async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
+        if cmd.write_data.len() > self.max_write_len() || cmd.read_buf.len() > self.max_read_len() {
+            return Err(CoreError::SpiTransferFailed);
+        }
+
+        // Build the write array: opcode + address + write data
+        let max = self.max_transfer_size() + 4; // opcode + 3-byte address + data
+        let mut writearr = alloc::vec![0u8; max];
+        let mut write_len = 1;
+
+        writearr[0] = cmd.opcode;
+
+        match cmd.address_width {
+            AddressWidth::None => {}
+            AddressWidth::ThreeByte => {
+                let addr = cmd.address.unwrap_or(0);
+                writearr[1] = (addr >> 16) as u8;
+                writearr[2] = (addr >> 8) as u8;
+                writearr[3] = addr as u8;
+                write_len += 3;
+            }
+            AddressWidth::FourByte => {
+                let addr = cmd.address.unwrap_or(0);
+                writearr[1] = (addr >> 24) as u8;
+                writearr[2] = (addr >> 16) as u8;
+                writearr[3] = (addr >> 8) as u8;
+                writearr[4] = addr as u8;
+                write_len += 4;
+            }
+        }
+
+        let write_data = cmd.write_data;
+        if write_data.len() > max - write_len {
+            return Err(CoreError::SpiTransferFailed);
+        }
+        if !write_data.is_empty() {
+            writearr[write_len..write_len + write_data.len()].copy_from_slice(write_data);
+            write_len += write_data.len();
+        }
+
+        self.send_command(&writearr[..write_len], cmd.read_buf)
+            .map_err(map_ati_error)
+    }
+
+    fn probe_opcode(&self, _opcode: u8) -> bool {
+        true // ATI SPI doesn't restrict opcodes
+    }
+
+    async fn delay_us(&mut self, us: u32) {
+        std::thread::sleep(std::time::Duration::from_micros(us as u64));
+    }
+}
+
+fn map_ati_error(e: AtiSpiError) -> CoreError {
+    match e {
+        AtiSpiError::Io(_) => CoreError::IoError,
+        AtiSpiError::SpiInit(_) => CoreError::ProgrammerError,
+        _ => CoreError::ProgrammerError,
+    }
+}
+
+// ============================================================================
+// Non-Linux stub
+// ============================================================================
+
+#[cfg(not(all(feature = "std", target_os = "linux")))]
+pub struct AtiSpiController {
+    _private: (),
+}
+
+#[cfg(not(all(feature = "std", target_os = "linux")))]
+impl AtiSpiController {
+    pub fn new(
+        _vendor_id: u16,
+        _device_id: u16,
+        _address: rflasher_pci::PciAddress,
+        _bar_index: u8,
+    ) -> Result<Self, AtiSpiError> {
+        Err(AtiSpiError::NotSupported(
+            "ATI SPI programmer only supported on Linux",
+        ))
+    }
+
+    pub fn send_command(&self, _writearr: &[u8], _readarr: &mut [u8]) -> Result<(), AtiSpiError> {
+        Err(AtiSpiError::NotSupported(
+            "ATI SPI programmer only supported on Linux",
+        ))
+    }
+
+    pub fn max_transfer_size(&self) -> usize {
+        0
+    }
+
+    pub fn spi_type(&self) -> crate::ati_pci::AtiSpiType {
+        crate::ati_pci::AtiSpiType::R600
+    }
+}
+
+#[cfg(not(all(feature = "std", target_os = "linux")))]
+#[maybe_async(AFIT)]
+impl SpiMaster for AtiSpiController {
+    fn features(&self) -> SpiFeatures {
+        SpiFeatures::empty()
+    }
+
+    fn max_read_len(&self) -> usize {
+        self.max_transfer_size()
+    }
+
+    fn max_write_len(&self) -> usize {
+        self.max_transfer_size()
+    }
+
+    async fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
+        self.send_command(&[], cmd.read_buf).map_err(map_ati_error)
+    }
+
+    fn probe_opcode(&self, _opcode: u8) -> bool {
+        false
+    }
+
+    async fn delay_us(&mut self, _us: u32) {}
+}

--- a/crates/rflasher-ati-spi/src/error.rs
+++ b/crates/rflasher-ati-spi/src/error.rs
@@ -1,0 +1,42 @@
+use core::fmt;
+
+#[derive(Debug)]
+pub enum AtiSpiError {
+    UnsupportedDevice {
+        vendor_id: u16,
+        device_id: u16,
+        name: &'static str,
+    },
+    Pci(rflasher_pci::PciError),
+    SpiInit(&'static str),
+    NotSupported(&'static str),
+    Io(&'static str),
+}
+
+impl From<rflasher_pci::PciError> for AtiSpiError {
+    fn from(error: rflasher_pci::PciError) -> Self {
+        Self::Pci(error)
+    }
+}
+
+impl fmt::Display for AtiSpiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedDevice {
+                vendor_id,
+                device_id,
+                name,
+            } => write!(
+                f,
+                "GPU {vendor_id:04x}:{device_id:04x} ({name}) is not supported"
+            ),
+            Self::Pci(error) => write!(f, "PCI access error: {error}"),
+            Self::SpiInit(message) => write!(f, "SPI controller init failed: {message}"),
+            Self::NotSupported(message) => write!(f, "not supported: {message}"),
+            Self::Io(message) => write!(f, "I/O error: {message}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AtiSpiError {}

--- a/crates/rflasher-ati-spi/src/lib.rs
+++ b/crates/rflasher-ati-spi/src/lib.rs
@@ -1,0 +1,76 @@
+//! ATI/AMD Radeon GPU SPI flash programmer.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
+mod ati_pci;
+mod ati_spi;
+mod error;
+
+pub use ati_pci::{
+    ATI_SPI_DEVICES, ATI_VID, AtiSpiDevice, AtiSpiType, TestStatus, find_ati_spi_device,
+};
+pub use ati_spi::AtiSpiController;
+pub use error::AtiSpiError;
+
+#[derive(Debug, Clone)]
+pub struct DetectedAtiGpu {
+    pub device: &'static AtiSpiDevice,
+    pub address: rflasher_pci::PciAddress,
+    pub bar: u8,
+}
+
+impl DetectedAtiGpu {
+    pub fn name(&self) -> &'static str {
+        self.device.device_name
+    }
+    pub fn family(&self) -> &'static str {
+        self.device.spi_type.family_name()
+    }
+    pub fn create_controller(&self) -> Result<AtiSpiController, AtiSpiError> {
+        AtiSpiController::new(
+            self.device.vendor_id,
+            self.device.device_id,
+            self.address,
+            self.bar,
+        )
+    }
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn scan_for_ati_gpus() -> Result<alloc::vec::Vec<DetectedAtiGpu>, AtiSpiError> {
+    use rflasher_pci::SysfsPci;
+    let pci = SysfsPci::system();
+    let mut found = alloc::vec::Vec::new();
+    for pci_dev in pci.enumerate()? {
+        let Some(device) = find_ati_spi_device(pci_dev.vendor_id, pci_dev.device_id) else {
+            continue;
+        };
+        let bar = (device.spi_type.io_bar() - 0x10) / 4;
+        found.push(DetectedAtiGpu {
+            device,
+            address: pci_dev.address,
+            bar,
+        });
+    }
+    Ok(found)
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn find_ati_gpu() -> Result<Option<DetectedAtiGpu>, AtiSpiError> {
+    Ok(scan_for_ati_gpus()?.into_iter().next())
+}
+
+#[cfg(not(all(feature = "std", target_os = "linux")))]
+pub fn scan_for_ati_gpus() -> Result<alloc::vec::Vec<DetectedAtiGpu>, AtiSpiError> {
+    Err(AtiSpiError::NotSupported(
+        "PCI scanning only supported on Linux",
+    ))
+}
+
+#[cfg(not(all(feature = "std", target_os = "linux")))]
+pub fn find_ati_gpu() -> Result<Option<DetectedAtiGpu>, AtiSpiError> {
+    Err(AtiSpiError::NotSupported(
+        "PCI scanning only supported on Linux",
+    ))
+}

--- a/crates/rflasher-flash/Cargo.toml
+++ b/crates/rflasher-flash/Cargo.toml
@@ -19,15 +19,24 @@ rflasher-linux-spi = { path = "../rflasher-linux-spi", optional = true }
 rflasher-linux-mtd = { path = "../rflasher-linux-mtd", optional = true }
 rflasher-linux-gpio = { path = "../rflasher-linux-gpio", optional = true }
 rflasher-internal = { path = "../rflasher-internal", optional = true }
+rflasher-ati-spi = { path = "../rflasher-ati-spi", optional = true }
 rflasher-raiden = { path = "../rflasher-raiden", optional = true }
 rflasher-sunxi-fel = { path = "../rflasher-sunxi-fel", optional = true }
+
 
 [features]
 default = ["std", "is_sync"]
 std = ["rflasher-core/std"]
 alloc = ["rflasher-core/alloc"]
 # Sync mode - when enabled, all programmer code is synchronous
-is_sync = ["rflasher-core/is_sync", "rflasher-serprog?/is_sync", "rflasher-ch341a?/is_sync", "rflasher-ch347?/is_sync", "rflasher-ftdi?/is_sync"]
+is_sync = [
+  "rflasher-core/is_sync",
+  "rflasher-serprog?/is_sync",
+  "rflasher-ch341a?/is_sync",
+  "rflasher-ch347?/is_sync",
+  "rflasher-ftdi?/is_sync",
+  "rflasher-ati-spi?/is_sync",
+]
 
 # Programmer features
 dummy = ["dep:rflasher-dummy"]
@@ -43,6 +52,7 @@ linux-spi = ["dep:rflasher-linux-spi"]
 linux-mtd = ["dep:rflasher-linux-mtd"]
 linux-gpio = ["dep:rflasher-linux-gpio"]
 internal = ["dep:rflasher-internal"]
+ati-spi = ["dep:rflasher-ati-spi"]
 raiden = ["dep:rflasher-raiden"]
 sunxi-fel = ["dep:rflasher-sunxi-fel"]
 

--- a/crates/rflasher-flash/src/registry.rs
+++ b/crates/rflasher-flash/src/registry.rs
@@ -380,6 +380,22 @@ pub fn open_spi_programmer(programmer: &str) -> Result<BoxedSpiMaster, Box<dyn s
         }
 
         // Internal and MTD are opaque-only or not SPI-based
+        #[cfg(feature = "ati-spi")]
+        "ati_spi" | "ati-spi" | "ati" | "amdgpu" => {
+            log::info!("Opening ATI/AMD GPU SPI programmer for REPL...");
+            let gpu = rflasher_ati_spi::find_ati_gpu()
+                .map_err(|e| format!("Failed to scan for ATI GPUs: {}", e))?
+                .ok_or("No supported ATI/AMD GPU found on PCI bus")?;
+            let master = gpu.create_controller().map_err(|e| {
+                format!(
+                    "Failed to initialize ATI SPI controller: {}\n\
+                     Make sure you have root privileges and the GPU driver isn't blocking access.",
+                    e
+                )
+            })?;
+            Ok(Box::new(master))
+        }
+
         #[cfg(feature = "internal")]
         "internal" => {
             Err("The REPL is only supported for SPI-based programmers. \
@@ -463,6 +479,9 @@ pub fn open_flash(
 
         #[cfg(feature = "internal")]
         "internal" => open_internal(&params, db),
+
+        #[cfg(feature = "ati-spi")]
+        "ati_spi" | "ati-spi" | "ati" | "amdgpu" => open_ati_spi(&params, db),
 
         #[cfg(feature = "raiden")]
         "raiden_debug_spi" | "raiden" | "raiden_spi" => open_raiden(&params, db),
@@ -814,6 +833,40 @@ fn open_linux_gpio_spi(
     probe_and_create_handle(master, db)
 }
 
+#[cfg(feature = "ati-spi")]
+fn open_ati_spi(
+    _params: &ProgrammerParams,
+    db: &dyn ChipProvider,
+) -> Result<FlashHandle, Box<dyn std::error::Error>> {
+    log::info!("Opening ATI/AMD GPU SPI programmer...");
+
+    let gpu = rflasher_ati_spi::find_ati_gpu()
+        .map_err(|e| format!("Failed to scan for ATI GPUs: {}", e))?
+        .ok_or(
+            "No supported ATI/AMD GPU found on PCI bus.\n\
+                Supported: Radeon HD 2000 through RX 500 series (R600 → Polaris).",
+        )?;
+
+    log::info!(
+        "Using GPU: {} ({}) at {:02x}:{:02x}.{:x}",
+        gpu.name(),
+        gpu.family(),
+        gpu.address.bus(),
+        gpu.address.device(),
+        gpu.address.function()
+    );
+
+    let master = gpu.create_controller().map_err(|e| {
+        format!(
+            "Failed to initialize ATI SPI controller: {}\n\
+             Make sure you have root privileges and the GPU driver isn't blocking MMIO access.",
+            e
+        )
+    })?;
+
+    probe_and_create_handle(master, db)
+}
+
 #[cfg(feature = "internal")]
 fn open_internal(
     params: &ProgrammerParams,
@@ -1011,6 +1064,13 @@ pub fn available_programmers() -> Vec<ProgrammerInfo> {
         name: "internal",
         aliases: &[],
         description: "Intel PCH internal SPI/FWH controller (ich_spi_mode=<auto|swseq|hwseq>)",
+    });
+
+    #[cfg(feature = "ati-spi")]
+    programmers.push(ProgrammerInfo {
+        name: "ati_spi",
+        aliases: &["ati-spi", "ati", "amdgpu"],
+        description: "ATI/AMD Radeon GPU VBIOS SPI flash (R600 through Polaris)",
     });
 
     #[cfg(feature = "raiden")]

--- a/crates/rflasher-internal/src/error.rs
+++ b/crates/rflasher-internal/src/error.rs
@@ -94,6 +94,10 @@ impl From<rflasher_pci::PciError> for InternalError {
                     register: offset,
                 })
             }
+            rflasher_pci::PciError::InvalidBar { bar, .. }
+            | rflasher_pci::PciError::MapBar { bar, .. } => {
+                Self::PciAccess(PciAccessError::InvalidBar(bar))
+            }
         }
     }
 }

--- a/crates/rflasher-pci/src/lib.rs
+++ b/crates/rflasher-pci/src/lib.rs
@@ -64,6 +64,10 @@ pub enum PciError {
     ConfigWrite { address: PciAddress, offset: u16 },
     /// The address, register offset, or access width is invalid for the backend.
     InvalidAccess { address: PciAddress, offset: u16 },
+    /// The requested BAR index is invalid.
+    InvalidBar { address: PciAddress, bar: u8 },
+    /// A PCI BAR resource could not be mapped.
+    MapBar { address: PciAddress, bar: u8 },
 }
 
 impl core::fmt::Display for PciError {
@@ -79,6 +83,12 @@ impl core::fmt::Display for PciError {
             }
             Self::InvalidAccess { address, offset } => {
                 write!(f, "invalid PCI config access at {address} reg {offset:#x}")
+            }
+            Self::InvalidBar { address, bar } => {
+                write!(f, "invalid BAR{bar} for PCI device {address}")
+            }
+            Self::MapBar { address, bar } => {
+                write!(f, "failed to map BAR{bar} for PCI device {address}")
             }
         }
     }
@@ -219,7 +229,48 @@ mod linux {
     use super::{PciAddress, PciConfigAccess, PciDevice, PciError};
     use std::fs::{self, OpenOptions};
     use std::io::{Read, Seek, Write};
+    use std::os::fd::AsRawFd;
     use std::path::{Path, PathBuf};
+
+    /// Memory mapping of one PCI BAR resource.
+    pub struct MappedBar {
+        ptr: *mut u8,
+        size: usize,
+    }
+
+    impl MappedBar {
+        /// Views this BAR as a caller-defined register block.
+        ///
+        /// # Safety
+        ///
+        /// `T` must exactly describe the registers at the start of this BAR.
+        pub unsafe fn registers<T>(&self) -> &T {
+            assert!(
+                core::mem::size_of::<T>() <= self.size,
+                "register block exceeds BAR mapping"
+            );
+            assert!(
+                (self.ptr as usize).is_multiple_of(core::mem::align_of::<T>()),
+                "unaligned register block"
+            );
+            // SAFETY: guaranteed by the caller and checked for size/alignment above.
+            unsafe { &*self.ptr.cast::<T>() }
+        }
+
+        pub fn size(&self) -> usize {
+            self.size
+        }
+    }
+
+    impl Drop for MappedBar {
+        fn drop(&mut self) {
+            // SAFETY: this is the mapping created by `SysfsPci::map_bar`.
+            unsafe { libc::munmap(self.ptr.cast(), self.size) };
+        }
+    }
+
+    unsafe impl Send for MappedBar {}
+    unsafe impl Sync for MappedBar {}
 
     /// Linux sysfs PCI backend.
     #[derive(Clone, Debug)]
@@ -252,6 +303,41 @@ mod linux {
 
         fn config_path(&self, address: PciAddress) -> PathBuf {
             self.device_path(address).join("config")
+        }
+
+        /// Maps a PCI BAR through its Linux sysfs `resourceN` file.
+        pub fn map_bar(
+            &self,
+            address: PciAddress,
+            bar: u8,
+            size: usize,
+        ) -> Result<MappedBar, PciError> {
+            if bar > 5 || size == 0 {
+                return Err(PciError::InvalidBar { address, bar });
+            }
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(self.device_path(address).join(format!("resource{bar}")))
+                .map_err(|_| PciError::MapBar { address, bar })?;
+            // SAFETY: Linux PCI sysfs resource files are mmap-able BAR windows.
+            let ptr = unsafe {
+                libc::mmap(
+                    core::ptr::null_mut(),
+                    size,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_SHARED,
+                    file.as_raw_fd(),
+                    0,
+                )
+            };
+            if ptr == libc::MAP_FAILED {
+                return Err(PciError::MapBar { address, bar });
+            }
+            Ok(MappedBar {
+                ptr: ptr.cast(),
+                size,
+            })
         }
 
         /// Enumerates PCI functions exposed by Linux sysfs.
@@ -405,7 +491,7 @@ mod linux {
 }
 
 #[cfg(all(feature = "std", target_os = "linux"))]
-pub use linux::{SysfsPci, read32_direct};
+pub use linux::{MappedBar, SysfsPci, read32_direct};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Port the flashrom `ati_spi` programmer to Rust, enabling read/write access to the VBIOS SPI flash on discrete AMD/ATI GPUs via PCI MMIO.

## Origin

Based on the abandoned flashrom patch series ([topic: ati_spi_rebase](https://review.coreboot.org/q/project:flashrom+topic:ati_spi_rebase), 24 patches) by Luc Verhaegen and Jiajie Chen on review.coreboot.org.

## Supported GPU families

| Family | GPUs | BAR | SPI Engine |
|--------|------|-----|------------|
| R600 | HD 2xxx–4xxx | BAR2 | Direct MMIO |
| RV730 | RV730/RV740 | BAR2 | Direct MMIO (different clk div) |
| Evergreen | HD 5xxx | BAR2 | Direct MMIO |
| Northern Island | HD 6xxx | BAR2 | Direct MMIO + extra GPIO |
| Southern Island | HD 7xxx | BAR2 | Direct MMIO |
| Bonaire | GCN 1.1 | BAR5 | SMC indirect |
| Hawaii | GCN 1.1 | BAR5 | SMC indirect |
| Iceland+ | Tonga/Fiji/Polaris | BAR5 | SMC indirect |

~200 PCI device IDs covered.

## Changes

### `rflasher-internal`
- **`ati_pci.rs`** — PCI device ID table, `AtiSpiType` enum, lookup function
- **`ati_spi.rs`** — SPI controller driver with save/restore, enable sequences, `SpiMaster` trait impl
- **`pci.rs`** — `scan_for_ati_gpus()` / `find_ati_gpu()` with 64-bit BAR support, `DetectedAtiGpu::create_controller()`
- **`lib.rs`** — Module declarations and public re-exports

### `rflasher-flash`
- **`Cargo.toml`** — `ati-spi` feature flag (uses `rflasher-internal`)
- **`registry.rs`** — `open_ati_spi()` for flash operations, REPL support, `ProgrammerInfo` entry

### Top-level
- **`Cargo.toml`** — `ati-spi` feature (included in `default` and `all-programmers`)

## Usage

```bash
rflasher probe -p ati_spi
rflasher read -p ati_spi -o vbios.bin
rflasher write -p ati_spi -i vbios.bin
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ATI/AMD Radeon/FirePro GPU SPI flashing support on Linux via a new ATI SPI programmer backend.
  * Added automatic detection of supported ATI GPUs and GPU-family identification.
  * Added ATI SPI programmer options: `ati_spi`, `ati-spi`, `ati`, and `amdgpu`.
  * Added underlying PCI discovery and configuration access support.
* **Bug Fixes**
  * Improved diagnostics for unsupported devices and PCI BAR/access errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->