### PR TITLE
Add `no_std` / embedded-host support to `rflasher-internal`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,24 @@ jobs:
       - name: Build
         run: cargo build --workspace --exclude rflasher-wasm --all-features --release
 
+  no-std:
+    name: no_std embedded checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-none
+      - uses: Swatinem/rust-cache@v2
+      - name: Check rflasher-core without std
+        run: cargo check -p rflasher-core --no-default-features --target x86_64-unknown-none
+      - name: Check rflasher-core sync without std
+        run: cargo check -p rflasher-core --no-default-features --features is_sync --target x86_64-unknown-none
+      - name: Check rflasher-internal sync without std
+        run: cargo check -p rflasher-internal --no-default-features --features is_sync --target x86_64-unknown-none
+
   wasm:
     name: WASM Build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A modern Rust implementation for reading, writing, and erasing SPI flash chips. 
 - **Modern Rust Architecture**: Clean separation of concerns with workspace organization
 - **Dual-Mode Support**: Synchronous CLI and asynchronous WASM/browser support from a single codebase
 - **Web Interface**: Browser-based UI using egui and WebSerial API for programming flash chips directly in Chrome/Edge
-- **`no_std` Compatible Core**: Designed for potential embedded and async use cases. WIP
+- **`no_std` Compatible Core**: Core flash and selected internal-controller logic can be reused in firmware/embedded environments.
 - **RON-based Chip Database**: Human-readable chip definitions with build-time code generation
 - **Trait-based Programmer Abstraction**: Extensible design for adding new programmers
 - **Layout Support**: Intel Flash Descriptor (IFD) and FMAP parsing for region-based operations
@@ -219,7 +219,7 @@ rflasher probe -p dediprog:spispeed=12M
 # Raiden Debug SPI (Chrome OS debug hardware)
 rflasher probe -p raiden
 
-# Internal chipset programmer (Intel/AMD)
+# Internal chipset programmer (Intel/AMD; Linux userspace only)
 rflasher probe -p internal
 
 # FTDI with specific device type
@@ -246,6 +246,25 @@ rflasher probe -p linux_mtd:dev=0
 # Linux MTD - read from device 0
 rflasher read -p linux_mtd:dev=0 -o flash_backup.bin
 ```
+
+### Internal Programmer and Embedded Reuse
+
+The `internal` programmer uses chipset-integrated SPI controllers. The CLI path is available on Linux userspace and uses Linux PCI sysfs plus `/dev/mem`, so it usually requires root or equivalent hardware access permissions.
+
+The low-level Intel ICH/PCH and AMD SPI100 controller code is also structured for firmware reuse without duplicating controller logic. Embedded callers provide the platform-specific access layer by implementing `rflasher_internal::HostAccess`:
+
+- `PciConfigAccess` methods for PCI configuration reads/writes.
+- `map_mmio` for controller register and optional flash memory windows.
+- `delay_us` for short controller polling delays.
+
+For a synchronous `no_std` firmware integration, depend on the crates without default features:
+
+```toml
+rflasher-core = { version = "0.1", default-features = false, features = ["is_sync"] }
+rflasher-internal = { version = "0.1", default-features = false, features = ["is_sync"] }
+```
+
+Firmware code can pass its own PCI scan results to `find_intel_chipset_in_devices` / `find_amd_chipset_in_devices`, then construct controllers with `IchSpiController::new_with_host(...)` or `AmdSpi100Info::create_controller_with_host(...)`.
 
 ### Layout Operations
 

--- a/crates/rflasher-internal/Cargo.toml
+++ b/crates/rflasher-internal/Cargo.toml
@@ -7,12 +7,12 @@ description = "Intel chipset internal flash programmer support for rflasher"
 
 [features]
 default = ["std"]
-std = ["rflasher-core/std", "dep:thiserror"]
+std = ["alloc", "is_sync", "rflasher-core/std", "dep:thiserror", "dep:libc"]
+alloc = ["rflasher-core/alloc"]
+is_sync = ["rflasher-core/is_sync"]
 
 [dependencies]
 rflasher-core.workspace = true
 log.workspace = true
 thiserror = { workspace = true, optional = true }
-
-[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-libc = "0.2"
+libc = { version = "0.2", optional = true }

--- a/crates/rflasher-internal/src/amd_enable.rs
+++ b/crates/rflasher-internal/src/amd_enable.rs
@@ -6,7 +6,11 @@
 use crate::amd_pci::AmdChipsetEnable;
 use crate::amd_spi100::Spi100Controller;
 use crate::error::InternalError;
-use crate::pci::pci_read_config32;
+#[cfg(all(feature = "std", target_os = "linux"))]
+use crate::host::DefaultPciAccess;
+#[cfg(all(feature = "std", target_os = "linux"))]
+use crate::host::LinuxHost;
+use crate::host::{Bdf, HostAccess, PciConfigAccess};
 
 /// PCI register offset for SPI BAR in AMD FCH LPC device
 const AMD_SPI_BAR_OFFSET: u8 = 0xa0;
@@ -22,6 +26,8 @@ const AMD_LPC_FUNCTION: u8 = 3;
 pub struct AmdSpi100Info {
     /// The chipset enable entry
     pub enable: &'static AmdChipsetEnable,
+    /// PCI segment/domain
+    pub domain: u16,
     /// PCI bus number
     pub bus: u8,
     /// PCI device number
@@ -41,10 +47,122 @@ pub struct AmdSpi100Info {
 }
 
 impl AmdSpi100Info {
-    /// Create a new SPI100 controller instance from this info
-    pub fn create_controller(&self) -> Result<Spi100Controller, InternalError> {
+    /// Create a new SPI100 controller instance from this info using Linux host access.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    pub fn create_controller(&self) -> Result<Spi100Controller<LinuxHost>, InternalError> {
         Spi100Controller::new(self.spibar_addr, self.memory_addr, self.mapped_len)
     }
+
+    /// Create a new SPI100 controller instance from this info using caller-provided host access.
+    #[cfg(any(all(feature = "std", target_os = "linux"), not(feature = "std")))]
+    pub fn create_controller_with_host<H: HostAccess>(
+        &self,
+        host: H,
+    ) -> Result<Spi100Controller<H>, InternalError> {
+        Spi100Controller::new_with_host(host, self.spibar_addr, self.memory_addr, self.mapped_len)
+    }
+}
+
+/// Enables AMD SPI100 using host-provided PCI config access.
+///
+/// This helper contains the platform-independent BAR and ROM range discovery
+/// logic. Linux userspace and embedded firmware can use the same code with
+/// different [`PciConfigAccess`] implementations.
+pub fn enable_amd_spi100_with_host<H: PciConfigAccess>(
+    host: &H,
+    enable: &'static AmdChipsetEnable,
+    smbus_bdf: Bdf,
+    revision_id: u8,
+) -> Result<AmdSpi100Info, InternalError> {
+    log::info!(
+        "Enabling AMD {} SPI100 controller at {:02x}:{:02x}.0",
+        enable.device_name,
+        smbus_bdf.bus,
+        smbus_bdf.device
+    );
+
+    let lpc_bdf = Bdf::with_segment(
+        smbus_bdf.segment,
+        smbus_bdf.bus,
+        smbus_bdf.device,
+        AMD_LPC_FUNCTION,
+    );
+    let spibar = host.read32(lpc_bdf, AMD_SPI_BAR_OFFSET as u16)?;
+
+    if spibar == 0xffff_ffff {
+        return Err(InternalError::ChipsetEnable(
+            "SPI100 BAR reads all 0xff, aborting",
+        ));
+    }
+
+    log::debug!(
+        "SPI BAR config: AltSpiCSEnable={} SpiRomEnable={} AbortEnable={} \
+         RouteTpm2Spi={} PspSpiMmioSel={}",
+        spibar & 1,
+        (spibar >> 1) & 1,
+        (spibar >> 2) & 1,
+        (spibar >> 3) & 1,
+        (spibar >> 4) & 1,
+    );
+
+    let spirom_enabled = (spibar & (1 << 1)) != 0;
+    let phys_spibar = (spibar & !0xff) as u64;
+
+    if phys_spibar == 0 {
+        if spirom_enabled {
+            log::error!("SPI ROM is enabled but SPI BAR is unconfigured");
+            return Err(InternalError::ChipsetEnable(
+                "SPI BAR unconfigured but SPI ROM enabled",
+            ));
+        }
+
+        log::debug!("SPI100 not used");
+        return Err(InternalError::NotSupported("SPI100 not in use"));
+    }
+
+    log::debug!("SPI100 BAR at {:#010x}", phys_spibar);
+
+    let rom_range2 = host.read32(lpc_bdf, AMD_ROM_RANGE2_OFFSET as u16)?;
+    let rom_range_end = rom_range2 | 0xffff;
+    let rom_range_start = (rom_range2 & 0xffff) << 16;
+    let mapped_len = if rom_range_end > rom_range_start {
+        (rom_range_end - rom_range_start + 1) as usize
+    } else {
+        0
+    };
+
+    log::debug!(
+        "ROM Range 2: {:#010x}..{:#010x} ({} KB)",
+        rom_range_start,
+        rom_range_end,
+        mapped_len / 1024
+    );
+
+    let memory_addr = if spirom_enabled && mapped_len > 0 && rom_range_start != 0 {
+        Some(rom_range_start as u64)
+    } else {
+        None
+    };
+
+    if memory_addr.is_some() {
+        log::info!(
+            "Memory-mapped flash access enabled at {:#010x}",
+            rom_range_start
+        );
+    }
+
+    Ok(AmdSpi100Info {
+        enable,
+        domain: smbus_bdf.segment,
+        bus: smbus_bdf.bus,
+        device: smbus_bdf.device,
+        function: 0,
+        revision_id,
+        spibar_addr: phys_spibar,
+        memory_addr,
+        mapped_len,
+        spirom_enabled,
+    })
 }
 
 /// Enable AMD SPI100 controller
@@ -72,97 +190,16 @@ pub fn enable_amd_spi100(
     device: u8,
     revision_id: u8,
 ) -> Result<AmdSpi100Info, InternalError> {
-    log::info!(
-        "Enabling AMD {} SPI100 controller at {:02x}:{:02x}.0",
-        enable.device_name,
-        bus,
-        device
-    );
-
-    // Read SPI BAR from LPC device (function 3)
-    let spibar = pci_read_config32(bus, device, AMD_LPC_FUNCTION, AMD_SPI_BAR_OFFSET)?;
-
-    if spibar == 0xffffffff {
-        return Err(InternalError::ChipsetEnable(
-            "SPI100 BAR reads all 0xff, aborting",
-        ));
-    }
-
-    // Log SPI BAR configuration bits
-    log::debug!(
-        "SPI BAR config: AltSpiCSEnable={} SpiRomEnable={} AbortEnable={} \
-         RouteTpm2Spi={} PspSpiMmioSel={}",
-        spibar & 1,
-        (spibar >> 1) & 1,
-        (spibar >> 2) & 1,
-        (spibar >> 3) & 1,
-        (spibar >> 4) & 1,
-    );
-
-    let spirom_enabled = (spibar & (1 << 1)) != 0;
-
-    // Extract physical SPI BAR address (lower 8 bits are config/reserved)
-    let phys_spibar = (spibar & !0xff) as u64;
-
-    if phys_spibar == 0 {
-        if spirom_enabled {
-            log::error!("SPI ROM is enabled but SPI BAR is unconfigured");
-            return Err(InternalError::ChipsetEnable(
-                "SPI BAR unconfigured but SPI ROM enabled",
-            ));
-        } else {
-            log::debug!("SPI100 not used");
-            return Err(InternalError::NotSupported("SPI100 not in use"));
-        }
-    }
-
-    log::debug!("SPI100 BAR at {:#010x}", phys_spibar);
-
-    // Read ROM Range 2 configuration (used for memory mapping below 4GB)
-    let rom_range2 = pci_read_config32(bus, device, AMD_LPC_FUNCTION, AMD_ROM_RANGE2_OFFSET)?;
-    let rom_range_end = rom_range2 | 0xffff;
-    let rom_range_start = (rom_range2 & 0xffff) << 16;
-    let mapped_len = if rom_range_end > rom_range_start {
-        (rom_range_end - rom_range_start + 1) as usize
-    } else {
-        0
-    };
-
-    log::debug!(
-        "ROM Range 2: {:#010x}..{:#010x} ({} KB)",
-        rom_range_start,
-        rom_range_end,
-        mapped_len / 1024
-    );
-
-    // Determine if we should use memory mapping
-    let memory_addr = if spirom_enabled && mapped_len > 0 {
-        Some(rom_range_start as u64)
-    } else {
-        None
-    };
-
-    if memory_addr.is_some() {
-        log::info!(
-            "Memory-mapped flash access enabled at {:#010x}",
-            rom_range_start
-        );
-    }
-
-    Ok(AmdSpi100Info {
+    enable_amd_spi100_with_host(
+        &DefaultPciAccess,
         enable,
-        bus,
-        device,
-        function: 0, // SMBus is at function 0
+        Bdf::new(bus, device, 0),
         revision_id,
-        spibar_addr: phys_spibar,
-        memory_addr,
-        mapped_len,
-        spirom_enabled,
-    })
+    )
 }
 
-/// Stub for non-Linux platforms
+/// Stub for unsupported non-Linux platforms. Embedded firmware should call
+/// [`enable_amd_spi100_with_host`] with its own [`PciConfigAccess`] backend.
 #[cfg(not(all(feature = "std", target_os = "linux")))]
 pub fn enable_amd_spi100(
     _enable: &'static AmdChipsetEnable,
@@ -171,12 +208,23 @@ pub fn enable_amd_spi100(
     _revision_id: u8,
 ) -> Result<AmdSpi100Info, InternalError> {
     Err(InternalError::NotSupported(
-        "AMD chipset enable only supported on Linux",
+        "AMD chipset enable not available",
     ))
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::amd_pci::AMD_CHIPSETS;
+    use crate::host::tests::FakeHost;
+
+    fn spi100_enable() -> &'static AmdChipsetEnable {
+        AMD_CHIPSETS
+            .iter()
+            .find(|chipset| chipset.chipset.uses_spi100())
+            .expect("AMD SPI100 chipset table entry")
+    }
+
     #[test]
     fn test_rom_range_calculation() {
         // ROM Range 2 = 0xff000000
@@ -192,5 +240,33 @@ mod tests {
         assert_eq!(rom_range_start, 0x0000_0000);
         assert_eq!(rom_range_end, 0xff00_ffff);
         assert_eq!(mapped_len, 0xff01_0000);
+    }
+
+    #[test]
+    fn test_enable_amd_spi100_with_host_extracts_bars() {
+        let host = FakeHost::default();
+        let lpc_bdf = Bdf::new(0, 0x14, AMD_LPC_FUNCTION);
+        host.set_config32(lpc_bdf, AMD_SPI_BAR_OFFSET as u16, 0xfed8_0203);
+        host.set_config32(lpc_bdf, AMD_ROM_RANGE2_OFFSET as u16, 0xff00_0000);
+
+        let info = enable_amd_spi100_with_host(&host, spi100_enable(), Bdf::new(0, 0x14, 0), 0x51)
+            .unwrap();
+
+        assert_eq!(info.domain, 0);
+        assert_eq!(info.spibar_addr, 0xfed8_0200);
+        assert!(info.spirom_enabled);
+        assert_eq!(info.memory_addr, None);
+        assert_eq!(info.mapped_len, 0xff01_0000);
+    }
+
+    #[test]
+    fn test_enable_amd_spi100_with_host_rejects_unconfigured_bar() {
+        let host = FakeHost::default();
+        let lpc_bdf = Bdf::new(0, 0x14, AMD_LPC_FUNCTION);
+        host.set_config32(lpc_bdf, AMD_SPI_BAR_OFFSET as u16, 0xffff_ffff);
+
+        let err = enable_amd_spi100_with_host(&host, spi100_enable(), Bdf::new(0, 0x14, 0), 0x51)
+            .unwrap_err();
+        assert!(matches!(err, InternalError::ChipsetEnable(_)));
     }
 }

--- a/crates/rflasher-internal/src/amd_spi100.rs
+++ b/crates/rflasher-internal/src/amd_spi100.rs
@@ -22,15 +22,25 @@
 //!
 //! - flashprog/amd_spi100.c - Original C implementation
 
+#![cfg_attr(
+    not(all(feature = "std", target_os = "linux")),
+    allow(dead_code, unused_imports)
+)]
+
 use crate::controller::Controller;
 use crate::error::InternalError;
-use crate::physmap::PhysMap;
+#[cfg(all(feature = "std", target_os = "linux"))]
+use crate::host::LinuxHost;
+use crate::host::{HostAccess, MmioAccess};
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
 use rflasher_core::programmer::{SpiFeatures, SpiMaster};
 use rflasher_core::spi::{AddressWidth, SpiCommand};
 
 /// SPI100 FIFO size (in bytes)
 const SPI100_FIFO_SIZE: usize = 71;
+const SPI_FLASH_PAGE_SIZE: usize = 256;
+const SPI_FLASH_4K_SECTOR: u32 = 4096;
+const SPI_READY_POLL_LIMIT: u32 = 600_000;
 
 /// Maximum data transfer for read operations
 /// Account for up to 4 address bytes
@@ -182,12 +192,14 @@ const SPI_SPEEDS: [SpiSpeed; 8] = [
 ];
 
 /// AMD SPI100 Controller
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub struct Spi100Controller {
+#[cfg(any(all(feature = "std", target_os = "linux"), not(feature = "std")))]
+pub struct Spi100Controller<H: HostAccess> {
+    /// Platform access backend
+    host: H,
     /// Memory-mapped SPI registers
-    spibar: PhysMap,
+    spibar: H::MmioRegion,
     /// Memory-mapped flash region (optional)
-    memory: Option<PhysMap>,
+    memory: Option<H::MmioRegion>,
     /// Size of memory-mapped region
     mapped_len: usize,
     /// Whether 4-byte addressing memory map is disabled
@@ -197,7 +209,7 @@ pub struct Spi100Controller {
 }
 
 #[cfg(all(feature = "std", target_os = "linux"))]
-impl Spi100Controller {
+impl Spi100Controller<LinuxHost> {
     /// Create a new SPI100 controller instance
     ///
     /// # Arguments
@@ -210,21 +222,45 @@ impl Spi100Controller {
         memory_addr: Option<u64>,
         mapped_len: usize,
     ) -> Result<Self, InternalError> {
-        // Map the SPI registers (256 bytes)
-        let spibar = PhysMap::new(spibar_addr, 256)?;
+        Self::new_with_host(LinuxHost::new(), spibar_addr, memory_addr, mapped_len)
+    }
+}
 
-        // Map the memory region if provided
-        let memory = if let Some(addr) = memory_addr {
-            if mapped_len > 0 {
-                Some(PhysMap::new(addr, mapped_len)?)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+#[cfg(any(all(feature = "std", target_os = "linux"), not(feature = "std")))]
+impl<H: HostAccess> Spi100Controller<H> {
+    /// Create a new SPI100 controller instance using caller-provided host access.
+    ///
+    /// # Arguments
+    ///
+    /// * `host` - PCI/MMIO/delay backend for this execution environment
+    /// * `spibar_addr` - Physical address of SPI BAR
+    /// * `memory_addr` - Optional physical address of memory-mapped flash
+    /// * `mapped_len` - Size of memory-mapped flash region (0 if none)
+    pub fn new_with_host(
+        host: H,
+        spibar_addr: u64,
+        memory_addr: Option<u64>,
+        mapped_len: usize,
+    ) -> Result<Self, InternalError> {
+        // Map the SPI registers (256 bytes)
+        // SAFETY: `spibar_addr` comes from chipset enable code or the caller's
+        // platform-specific discovery and must name the SPI100 register window.
+        let spibar = unsafe { host.map_mmio(spibar_addr, 256)? };
+
+        // Map the memory region if provided. A zero address is treated as no
+        // usable memory window so reads fall back to the SPI command engine.
+        let memory = memory_addr
+            .filter(|&addr| addr != 0 && mapped_len > 0)
+            .map(|addr| {
+                // SAFETY: the optional memory window is supplied by chipset
+                // ROM range registers or the caller's platform discovery.
+                unsafe { host.map_mmio(addr, mapped_len) }
+            })
+            .transpose()?;
+        let mapped_len = memory.as_ref().map_or(0, |_| mapped_len);
 
         let mut controller = Self {
+            host,
             spibar,
             memory,
             mapped_len,
@@ -289,26 +325,10 @@ impl Spi100Controller {
         }
     }
 
-    /// Read multiple bytes from SPI register (FIFO)
-    /// Uses aligned 32-bit reads for efficiency
+    /// Read multiple bytes from SPI register (FIFO).
     fn readn(&self, reg: usize, data: &mut [u8]) {
-        let len = data.len();
-        let mut offset = 0;
-
-        // Read full 32-bit words
-        while offset + 4 <= len {
-            let val = self.read32(reg + offset);
-            data[offset] = val as u8;
-            data[offset + 1] = (val >> 8) as u8;
-            data[offset + 2] = (val >> 16) as u8;
-            data[offset + 3] = (val >> 24) as u8;
-            offset += 4;
-        }
-
-        // Read remaining bytes
-        while offset < len {
-            data[offset] = self.read8(reg + offset);
-            offset += 1;
+        for (offset, byte) in data.iter_mut().enumerate() {
+            *byte = self.read8(reg + offset);
         }
     }
 
@@ -381,7 +401,7 @@ impl Spi100Controller {
             }
 
             // Delay 1 microsecond
-            std::thread::sleep(std::time::Duration::from_micros(1));
+            self.host.delay_us(1);
             elapsed_us += 1;
         }
 
@@ -402,31 +422,8 @@ impl Spi100Controller {
             .as_ref()
             .ok_or(InternalError::Io("No memory mapping available"))?;
 
-        // Use aligned 64-bit reads for efficiency
-        let len = dst.len();
-        let mut offset = 0;
-
-        while offset + 8 <= len {
-            let addr = start + offset;
-            // Read as two 32-bit values (PhysMap doesn't have read64)
-            let lo = memory.read32(addr);
-            let hi = memory.read32(addr + 4);
-
-            dst[offset] = lo as u8;
-            dst[offset + 1] = (lo >> 8) as u8;
-            dst[offset + 2] = (lo >> 16) as u8;
-            dst[offset + 3] = (lo >> 24) as u8;
-            dst[offset + 4] = hi as u8;
-            dst[offset + 5] = (hi >> 8) as u8;
-            dst[offset + 6] = (hi >> 16) as u8;
-            dst[offset + 7] = (hi >> 24) as u8;
-            offset += 8;
-        }
-
-        // Read remaining bytes
-        while offset < len {
-            dst[offset] = memory.read8(start + offset);
-            offset += 1;
+        for (offset, byte) in dst.iter_mut().enumerate() {
+            *byte = memory.read8(start + offset);
         }
 
         Ok(())
@@ -609,6 +606,97 @@ impl Spi100Controller {
         self.write16(regs::SPEED_CFG, new_speed_cfg);
     }
 
+    fn write_enable(&self) -> Result<(), InternalError> {
+        self.send_command(&[rflasher_core::spi::opcodes::WREN], &mut [])
+    }
+
+    fn read_status(&self) -> Result<u8, InternalError> {
+        let mut status = [0u8; 1];
+        self.send_command(&[rflasher_core::spi::opcodes::RDSR], &mut status)?;
+        Ok(status[0])
+    }
+
+    fn wait_ready(&self) -> Result<(), InternalError> {
+        for _ in 0..SPI_READY_POLL_LIMIT {
+            if self.read_status()? & 0x01 == 0 {
+                return Ok(());
+            }
+            self.host.delay_us(100);
+        }
+
+        Err(InternalError::Io("SPI flash busy timeout"))
+    }
+
+    /// Write data using 3-byte Page Program commands.
+    pub fn write(&self, addr: u32, data: &[u8]) -> Result<(), InternalError> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let end = addr as u64 + data.len() as u64;
+        if end > 16 * 1024 * 1024 {
+            return Err(InternalError::NotSupported(
+                "AMD SPI100 write currently supports 3-byte addresses only",
+            ));
+        }
+
+        let mut offset = 0usize;
+        while offset < data.len() {
+            let current_addr = addr + offset as u32;
+            let page_remaining =
+                SPI_FLASH_PAGE_SIZE - (current_addr as usize % SPI_FLASH_PAGE_SIZE);
+            let chunk_len = (data.len() - offset)
+                .min(SPI100_MAX_DATA_WRITE - 3)
+                .min(page_remaining);
+
+            self.write_enable()?;
+
+            let chunk = &data[offset..offset + chunk_len];
+            let mut writearr = [0u8; SPI100_FIFO_SIZE + 1];
+            writearr[0] = rflasher_core::spi::opcodes::PP;
+            writearr[1] = (current_addr >> 16) as u8;
+            writearr[2] = (current_addr >> 8) as u8;
+            writearr[3] = current_addr as u8;
+            writearr[4..4 + chunk_len].copy_from_slice(chunk);
+
+            self.send_command(&writearr[..4 + chunk_len], &mut [])?;
+            self.wait_ready()?;
+            offset += chunk_len;
+        }
+
+        Ok(())
+    }
+
+    /// Erase a 4 KiB-sector-aligned region using 3-byte Sector Erase commands.
+    pub fn erase(&self, addr: u32, len: u32) -> Result<(), InternalError> {
+        if addr & (SPI_FLASH_4K_SECTOR - 1) != 0 || len & (SPI_FLASH_4K_SECTOR - 1) != 0 {
+            return Err(InternalError::Io("Erase address/length not 4 KiB aligned"));
+        }
+
+        let end = addr as u64 + len as u64;
+        if end > 16 * 1024 * 1024 {
+            return Err(InternalError::NotSupported(
+                "AMD SPI100 erase currently supports 3-byte addresses only",
+            ));
+        }
+
+        let mut current = addr;
+        while current < addr + len {
+            self.write_enable()?;
+            let cmd = [
+                rflasher_core::spi::opcodes::SE_20,
+                (current >> 16) as u8,
+                (current >> 8) as u8,
+                current as u8,
+            ];
+            self.send_command(&cmd, &mut [])?;
+            self.wait_ready()?;
+            current += SPI_FLASH_4K_SECTOR;
+        }
+
+        Ok(())
+    }
+
     /// Get maximum data read size
     pub fn max_data_read(&self) -> usize {
         SPI100_MAX_DATA_READ
@@ -618,18 +706,67 @@ impl Spi100Controller {
     pub fn max_data_write(&self) -> usize {
         SPI100_MAX_DATA_WRITE
     }
+
+    fn execute_spi_command(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
+        // Build the write array: opcode + address + write data
+        let mut writearr = [0u8; SPI100_FIFO_SIZE + 1];
+        let mut write_len = 1;
+
+        // Opcode
+        writearr[0] = cmd.opcode;
+
+        // Add address if present
+        match cmd.address_width {
+            AddressWidth::None => {}
+            AddressWidth::ThreeByte => {
+                let addr = cmd.address.unwrap_or(0);
+                writearr[1] = (addr >> 16) as u8;
+                writearr[2] = (addr >> 8) as u8;
+                writearr[3] = addr as u8;
+                write_len += 3;
+            }
+            AddressWidth::FourByte => {
+                let addr = cmd.address.unwrap_or(0);
+                writearr[1] = (addr >> 24) as u8;
+                writearr[2] = (addr >> 16) as u8;
+                writearr[3] = (addr >> 8) as u8;
+                writearr[4] = addr as u8;
+                write_len += 4;
+            }
+        }
+
+        // Add write data if present
+        let write_data = cmd.write_data;
+        if !write_data.is_empty() {
+            let data_len = write_data.len().min(SPI100_FIFO_SIZE - write_len + 1);
+            writearr[write_len..write_len + data_len].copy_from_slice(&write_data[..data_len]);
+            write_len += data_len;
+        }
+
+        // Dummy cycles are not directly supported by SPI100 FIFO interface.
+        // The controller handles this internally for known commands.
+        if cmd.dummy_cycles > 0 {
+            log::debug!(
+                "Dummy cycles ({}) will be handled by controller",
+                cmd.dummy_cycles
+            );
+        }
+
+        self.send_command(&writearr[..write_len], cmd.read_buf)
+            .map_err(map_amd_error)
+    }
 }
 
-#[cfg(all(feature = "std", target_os = "linux"))]
-impl Drop for Spi100Controller {
+#[cfg(any(all(feature = "std", target_os = "linux"), not(feature = "std")))]
+impl<H: HostAccess> Drop for Spi100Controller<H> {
     fn drop(&mut self) {
         // Restore original alternate speed
         self.restore_altspeed();
     }
 }
 
-#[cfg(all(feature = "std", target_os = "linux"))]
-impl Controller for Spi100Controller {
+#[cfg(any(all(feature = "std", target_os = "linux"), not(feature = "std")))]
+impl<H: HostAccess> Controller for Spi100Controller<H> {
     fn is_locked(&self) -> bool {
         // AMD SPI100 doesn't have a lock bit like Intel
         false
@@ -669,18 +806,24 @@ impl Controller for Spi100Controller {
         })
     }
 
-    fn controller_write(&mut self, _addr: u32, _data: &[u8]) -> CoreResult<()> {
-        // AMD SPI100 uses SpiMaster for write operations, not OpaqueMaster
-        // Caller should use SpiMaster::execute() with appropriate SPI commands
-        log::warn!("OpaqueMaster::write() not supported for AMD SPI100 - use SpiMaster instead");
-        Err(CoreError::OpcodeNotSupported)
+    fn controller_write(&mut self, addr: u32, data: &[u8]) -> CoreResult<()> {
+        self.write(addr, data).map_err(|e| match e {
+            InternalError::AccessDenied { .. } => CoreError::RegionProtected,
+            InternalError::Io(_) => CoreError::WriteError { addr },
+            InternalError::NotSupported(_) => CoreError::AddressOutOfBounds,
+            _ => CoreError::ProgrammerError,
+        })
     }
 
-    fn controller_erase(&mut self, _addr: u32, _len: u32) -> CoreResult<()> {
-        // AMD SPI100 uses SpiMaster for erase operations, not OpaqueMaster
-        // Caller should use SpiMaster::execute() with appropriate SPI commands
-        log::warn!("OpaqueMaster::erase() not supported for AMD SPI100 - use SpiMaster instead");
-        Err(CoreError::OpcodeNotSupported)
+    fn controller_erase(&mut self, addr: u32, len: u32) -> CoreResult<()> {
+        self.erase(addr, len).map_err(|e| match e {
+            InternalError::AccessDenied { .. } => CoreError::RegionProtected,
+            InternalError::Io(_) => {
+                CoreError::EraseError(rflasher_core::error::EraseFailure::CommandFailed { addr })
+            }
+            InternalError::NotSupported(_) => CoreError::AddressOutOfBounds,
+            _ => CoreError::ProgrammerError,
+        })
     }
 
     fn controller_name(&self) -> &'static str {
@@ -688,33 +831,33 @@ impl Controller for Spi100Controller {
     }
 
     fn features(&self) -> SpiFeatures {
-        <Self as SpiMaster>::features(self)
+        SpiFeatures::empty()
     }
 
     fn max_read_len(&self) -> usize {
-        <Self as SpiMaster>::max_read_len(self)
+        SPI100_MAX_DATA_READ
     }
 
     fn max_write_len(&self) -> usize {
-        <Self as SpiMaster>::max_write_len(self)
+        SPI100_MAX_DATA_WRITE
     }
 
     fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
-        <Self as SpiMaster>::execute(self, cmd)
+        self.execute_spi_command(cmd)
     }
 
-    fn probe_opcode(&self, opcode: u8) -> bool {
-        <Self as SpiMaster>::probe_opcode(self, opcode)
+    fn probe_opcode(&self, _opcode: u8) -> bool {
+        true
     }
 }
 
-// Non-Linux stub
-#[cfg(not(all(feature = "std", target_os = "linux")))]
+// Unsupported std non-Linux stub.
+#[cfg(all(feature = "std", not(target_os = "linux")))]
 pub struct Spi100Controller {
     _private: (),
 }
 
-#[cfg(not(all(feature = "std", target_os = "linux")))]
+#[cfg(all(feature = "std", not(target_os = "linux")))]
 impl Spi100Controller {
     pub fn new(
         _spibar_addr: u64,
@@ -722,19 +865,19 @@ impl Spi100Controller {
         _mapped_len: usize,
     ) -> Result<Self, InternalError> {
         Err(InternalError::NotSupported(
-            "AMD SPI100 controller only supported on Linux",
+            "AMD SPI100 controller not available on this target",
         ))
     }
 
     pub fn send_command(&self, _writearr: &[u8], _readarr: &mut [u8]) -> Result<(), InternalError> {
         Err(InternalError::NotSupported(
-            "AMD SPI100 controller only supported on Linux",
+            "AMD SPI100 controller not available on this target",
         ))
     }
 
     pub fn read(&self, _chip_size: u64, _start: u32, _buf: &mut [u8]) -> Result<(), InternalError> {
         Err(InternalError::NotSupported(
-            "AMD SPI100 controller only supported on Linux",
+            "AMD SPI100 controller not available on this target",
         ))
     }
 
@@ -751,8 +894,11 @@ impl Spi100Controller {
 // SpiMaster trait implementation for AMD SPI100
 // =============================================================================
 
-#[cfg(all(feature = "std", target_os = "linux"))]
-impl SpiMaster for Spi100Controller {
+#[cfg(all(
+    feature = "is_sync",
+    any(all(feature = "std", target_os = "linux"), not(feature = "std"))
+))]
+impl<H: HostAccess> SpiMaster for Spi100Controller<H> {
     fn features(&self) -> SpiFeatures {
         // AMD SPI100 supports standard SPI only (no dual/quad modes exposed to software)
         SpiFeatures::empty()
@@ -767,55 +913,7 @@ impl SpiMaster for Spi100Controller {
     }
 
     fn execute(&mut self, cmd: &mut SpiCommand<'_>) -> CoreResult<()> {
-        // Build the write array: opcode + address + write data
-        let mut writearr = [0u8; SPI100_FIFO_SIZE + 1];
-        let mut write_len = 1;
-
-        // Opcode
-        writearr[0] = cmd.opcode;
-
-        // Add address if present
-        match cmd.address_width {
-            AddressWidth::None => {}
-            AddressWidth::ThreeByte => {
-                let addr = cmd.address.unwrap_or(0);
-                writearr[1] = (addr >> 16) as u8;
-                writearr[2] = (addr >> 8) as u8;
-                writearr[3] = addr as u8;
-                write_len += 3;
-            }
-            AddressWidth::FourByte => {
-                let addr = cmd.address.unwrap_or(0);
-                writearr[1] = (addr >> 24) as u8;
-                writearr[2] = (addr >> 16) as u8;
-                writearr[3] = (addr >> 8) as u8;
-                writearr[4] = addr as u8;
-                write_len += 4;
-            }
-        }
-
-        // Add write data if present
-        let write_data = cmd.write_data;
-        if !write_data.is_empty() {
-            let data_len = write_data.len().min(SPI100_FIFO_SIZE - write_len + 1);
-            writearr[write_len..write_len + data_len].copy_from_slice(&write_data[..data_len]);
-            write_len += data_len;
-        }
-
-        // Dummy cycles are not directly supported by SPI100 FIFO interface
-        // The controller handles this internally for known commands
-        if cmd.dummy_cycles > 0 {
-            log::debug!(
-                "Dummy cycles ({}) will be handled by controller",
-                cmd.dummy_cycles
-            );
-        }
-
-        // Execute the command
-        self.send_command(&writearr[..write_len], cmd.read_buf)
-            .map_err(map_amd_error)?;
-
-        Ok(())
+        self.execute_spi_command(cmd)
     }
 
     fn probe_opcode(&self, _opcode: u8) -> bool {
@@ -824,7 +922,7 @@ impl SpiMaster for Spi100Controller {
     }
 
     fn delay_us(&mut self, us: u32) {
-        std::thread::sleep(std::time::Duration::from_micros(us as u64));
+        self.host.delay_us(us);
     }
 }
 

--- a/crates/rflasher-internal/src/controller.rs
+++ b/crates/rflasher-internal/src/controller.rs
@@ -5,6 +5,7 @@
 //! awkward enum matching.
 
 use crate::error::InternalError;
+use crate::ichspi::SpiMode;
 use rflasher_core::error::Result as CoreResult;
 use rflasher_core::programmer::SpiFeatures;
 use rflasher_core::spi::SpiCommand;
@@ -40,6 +41,14 @@ pub trait Controller {
 
     /// Get a human-readable name for this controller type
     fn controller_name(&self) -> &'static str;
+
+    /// Get the controller sequencing mode reported through the high-level API.
+    ///
+    /// Controllers without Intel-style sequencing report software sequencing so
+    /// callers do not need concrete-type downcasts.
+    fn spi_mode(&self) -> SpiMode {
+        SpiMode::SoftwareSequencing
+    }
 
     // SpiMaster-like methods that we need for InternalProgrammer
 

--- a/crates/rflasher-internal/src/error.rs
+++ b/crates/rflasher-internal/src/error.rs
@@ -45,14 +45,14 @@ pub enum PciAccessError {
         bus: u8,
         device: u8,
         function: u8,
-        register: u8,
+        register: u16,
     },
     /// Failed to write PCI config space
     ConfigWrite {
         bus: u8,
         device: u8,
         function: u8,
-        register: u8,
+        register: u16,
     },
     /// BAR not available or invalid
     InvalidBar(u8),

--- a/crates/rflasher-internal/src/host.rs
+++ b/crates/rflasher-internal/src/host.rs
@@ -1,0 +1,431 @@
+//! Host access abstractions for internal flash controllers.
+//!
+//! This module defines the small platform abstraction layer used by embedded
+//! and userspace backends. Controller logic should depend on these traits
+//! instead of directly opening Linux sysfs files, mapping `/dev/mem`, or
+//! sleeping with `std`.
+
+#![cfg_attr(
+    not(any(all(feature = "std", target_os = "linux"), test)),
+    allow(unused_imports)
+)]
+
+use crate::Result;
+use crate::error::{InternalError, PciAccessError};
+
+/// PCI segment:bus:device.function identifier.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Bdf {
+    /// PCI segment/domain.
+    pub segment: u16,
+    /// PCI bus number.
+    pub bus: u8,
+    /// PCI device number.
+    pub device: u8,
+    /// PCI function number.
+    pub function: u8,
+}
+
+impl Bdf {
+    /// Creates a BDF in PCI segment 0.
+    pub const fn new(bus: u8, device: u8, function: u8) -> Self {
+        Self {
+            segment: 0,
+            bus,
+            device,
+            function,
+        }
+    }
+
+    /// Creates a BDF with an explicit PCI segment/domain.
+    pub const fn with_segment(segment: u16, bus: u8, device: u8, function: u8) -> Self {
+        Self {
+            segment,
+            bus,
+            device,
+            function,
+        }
+    }
+}
+
+impl From<&crate::pci::PciDevice> for Bdf {
+    fn from(device: &crate::pci::PciDevice) -> Self {
+        Self::with_segment(device.domain, device.bus, device.device, device.function)
+    }
+}
+
+/// Provides PCI configuration-space access for visible or hidden devices.
+pub trait PciConfigAccess {
+    /// Reads an 8-bit PCI config-space value.
+    fn read8(&self, bdf: Bdf, offset: u16) -> Result<u8>;
+    /// Reads a 16-bit PCI config-space value.
+    fn read16(&self, bdf: Bdf, offset: u16) -> Result<u16>;
+    /// Reads a 32-bit PCI config-space value.
+    fn read32(&self, bdf: Bdf, offset: u16) -> Result<u32>;
+
+    /// Writes an 8-bit PCI config-space value.
+    fn write8(&self, bdf: Bdf, offset: u16, value: u8) -> Result<()>;
+    /// Writes a 16-bit PCI config-space value.
+    fn write16(&self, bdf: Bdf, offset: u16, value: u16) -> Result<()>;
+    /// Writes a 32-bit PCI config-space value.
+    fn write32(&self, bdf: Bdf, offset: u16, value: u32) -> Result<()>;
+}
+
+/// Provides volatile MMIO access to a mapped controller register window.
+pub trait MmioAccess {
+    /// Reads an 8-bit MMIO value at `offset`.
+    fn read8(&self, offset: usize) -> u8;
+    /// Reads a 16-bit MMIO value at `offset`.
+    fn read16(&self, offset: usize) -> u16;
+    /// Reads a 32-bit MMIO value at `offset`.
+    fn read32(&self, offset: usize) -> u32;
+
+    /// Writes an 8-bit MMIO value at `offset`.
+    fn write8(&self, offset: usize, value: u8);
+    /// Writes a 16-bit MMIO value at `offset`.
+    fn write16(&self, offset: usize, value: u16);
+    /// Writes a 32-bit MMIO value at `offset`.
+    fn write32(&self, offset: usize, value: u32);
+}
+
+/// Provides platform services needed by internal flash controllers.
+pub trait HostAccess: PciConfigAccess {
+    /// Mapped MMIO region type returned by [`HostAccess::map_mmio`].
+    type MmioRegion: MmioAccess;
+
+    /// Maps a physical MMIO range.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `phys_addr..phys_addr + size` is a valid
+    /// MMIO range for the selected controller and that mapping it will not
+    /// violate platform memory attributes or aliasing rules.
+    unsafe fn map_mmio(&self, phys_addr: u64, size: usize) -> Result<Self::MmioRegion>;
+
+    /// Delays for approximately `us` microseconds.
+    fn delay_us(&self, us: u32);
+}
+
+fn offset_to_u8(bdf: Bdf, offset: u16, write: bool) -> Result<u8> {
+    if offset > u8::MAX as u16 {
+        let error = if write {
+            PciAccessError::ConfigWrite {
+                bus: bdf.bus,
+                device: bdf.device,
+                function: bdf.function,
+                register: offset,
+            }
+        } else {
+            PciAccessError::ConfigRead {
+                bus: bdf.bus,
+                device: bdf.device,
+                function: bdf.function,
+                register: offset,
+            }
+        };
+        return Err(InternalError::PciAccess(error));
+    }
+
+    Ok(offset as u8)
+}
+
+/// Default PCI configuration-space backend for the current target.
+///
+/// On Linux userspace this uses sysfs config access and falls back to direct
+/// x86 PCI config I/O for hidden devices. On unsupported targets it returns
+/// [`InternalError::NotSupported`] via the PCI stubs; embedded callers should
+/// provide their own [`PciConfigAccess`] implementation.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DefaultPciAccess;
+
+impl PciConfigAccess for DefaultPciAccess {
+    fn read8(&self, bdf: Bdf, offset: u16) -> Result<u8> {
+        let offset = offset_to_u8(bdf, offset, false)?;
+        #[cfg(all(feature = "std", target_os = "linux"))]
+        {
+            crate::pci::pci_read_config8_at(bdf.segment, bdf.bus, bdf.device, bdf.function, offset)
+        }
+        #[cfg(not(all(feature = "std", target_os = "linux")))]
+        {
+            crate::pci::pci_read_config8(bdf.bus, bdf.device, bdf.function, offset)
+        }
+    }
+
+    fn read16(&self, bdf: Bdf, offset: u16) -> Result<u16> {
+        let offset = offset_to_u8(bdf, offset, false)?;
+        #[cfg(all(feature = "std", target_os = "linux"))]
+        {
+            crate::pci::pci_read_config16_at(bdf.segment, bdf.bus, bdf.device, bdf.function, offset)
+        }
+        #[cfg(not(all(feature = "std", target_os = "linux")))]
+        {
+            crate::pci::pci_read_config16(bdf.bus, bdf.device, bdf.function, offset)
+        }
+    }
+
+    fn read32(&self, bdf: Bdf, offset: u16) -> Result<u32> {
+        let offset = offset_to_u8(bdf, offset, false)?;
+        #[cfg(all(feature = "std", target_os = "linux"))]
+        {
+            crate::pci::pci_read_config32_at(bdf.segment, bdf.bus, bdf.device, bdf.function, offset)
+                .or_else(|err| {
+                    if bdf.segment == 0 {
+                        crate::pci::pci_read_config32_direct(
+                            bdf.bus,
+                            bdf.device,
+                            bdf.function,
+                            offset,
+                        )
+                    } else {
+                        Err(err)
+                    }
+                })
+        }
+        #[cfg(not(all(feature = "std", target_os = "linux")))]
+        {
+            crate::pci::pci_read_config32(bdf.bus, bdf.device, bdf.function, offset).or_else(|_| {
+                crate::pci::pci_read_config32_direct(bdf.bus, bdf.device, bdf.function, offset)
+            })
+        }
+    }
+
+    fn write8(&self, bdf: Bdf, offset: u16, value: u8) -> Result<()> {
+        let offset = offset_to_u8(bdf, offset, true)?;
+        #[cfg(all(feature = "std", target_os = "linux"))]
+        {
+            crate::pci::pci_write_config8_at(
+                bdf.segment,
+                bdf.bus,
+                bdf.device,
+                bdf.function,
+                offset,
+                value,
+            )
+        }
+        #[cfg(not(all(feature = "std", target_os = "linux")))]
+        {
+            crate::pci::pci_write_config8(bdf.bus, bdf.device, bdf.function, offset, value)
+        }
+    }
+
+    fn write16(&self, bdf: Bdf, offset: u16, value: u16) -> Result<()> {
+        let offset = offset_to_u8(bdf, offset, true)?;
+        #[cfg(all(feature = "std", target_os = "linux"))]
+        {
+            crate::pci::pci_write_config16_at(
+                bdf.segment,
+                bdf.bus,
+                bdf.device,
+                bdf.function,
+                offset,
+                value,
+            )
+        }
+        #[cfg(not(all(feature = "std", target_os = "linux")))]
+        {
+            crate::pci::pci_write_config16(bdf.bus, bdf.device, bdf.function, offset, value)
+        }
+    }
+
+    fn write32(&self, bdf: Bdf, offset: u16, value: u32) -> Result<()> {
+        let offset = offset_to_u8(bdf, offset, true)?;
+        #[cfg(all(feature = "std", target_os = "linux"))]
+        {
+            crate::pci::pci_write_config32_at(
+                bdf.segment,
+                bdf.bus,
+                bdf.device,
+                bdf.function,
+                offset,
+                value,
+            )
+        }
+        #[cfg(not(all(feature = "std", target_os = "linux")))]
+        {
+            crate::pci::pci_write_config32(bdf.bus, bdf.device, bdf.function, offset, value)
+        }
+    }
+}
+
+/// Linux userspace host backend.
+#[cfg(all(feature = "std", target_os = "linux"))]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LinuxHost;
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+impl LinuxHost {
+    /// Creates a Linux host backend.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Scans Linux sysfs for PCI devices.
+    #[cfg(target_os = "linux")]
+    pub fn scan_pci_bus(&self) -> Result<alloc::vec::Vec<crate::pci::PciDevice>> {
+        crate::pci::scan_pci_bus()
+    }
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+impl PciConfigAccess for LinuxHost {
+    fn read8(&self, bdf: Bdf, offset: u16) -> Result<u8> {
+        DefaultPciAccess.read8(bdf, offset)
+    }
+
+    fn read16(&self, bdf: Bdf, offset: u16) -> Result<u16> {
+        DefaultPciAccess.read16(bdf, offset)
+    }
+
+    fn read32(&self, bdf: Bdf, offset: u16) -> Result<u32> {
+        DefaultPciAccess.read32(bdf, offset)
+    }
+
+    fn write8(&self, bdf: Bdf, offset: u16, value: u8) -> Result<()> {
+        DefaultPciAccess.write8(bdf, offset, value)
+    }
+
+    fn write16(&self, bdf: Bdf, offset: u16, value: u16) -> Result<()> {
+        DefaultPciAccess.write16(bdf, offset, value)
+    }
+
+    fn write32(&self, bdf: Bdf, offset: u16, value: u32) -> Result<()> {
+        DefaultPciAccess.write32(bdf, offset, value)
+    }
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+impl HostAccess for LinuxHost {
+    type MmioRegion = crate::physmap::PhysMap;
+
+    unsafe fn map_mmio(&self, phys_addr: u64, size: usize) -> Result<Self::MmioRegion> {
+        // SAFETY: HostAccess::map_mmio has the same safety requirements as
+        // PhysMap::new and forwards them to the caller.
+        unsafe { crate::physmap::PhysMap::new(phys_addr, size) }
+    }
+
+    fn delay_us(&self, us: u32) {
+        std::thread::sleep(std::time::Duration::from_micros(us as u64));
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::BTreeMap;
+
+    /// Fake no-heap-shape host used by controller construction tests.
+    #[derive(Default)]
+    pub(crate) struct FakeHost {
+        config: RefCell<BTreeMap<(Bdf, u16), u32>>,
+        writes: RefCell<Vec<(Bdf, u16, u32, u8)>>,
+        delays: RefCell<Vec<u32>>,
+    }
+
+    impl FakeHost {
+        pub(crate) fn set_config32(&self, bdf: Bdf, offset: u16, value: u32) {
+            self.config.borrow_mut().insert((bdf, offset), value);
+        }
+
+        pub(crate) fn delay_log(&self) -> Vec<u32> {
+            self.delays.borrow().clone()
+        }
+    }
+
+    impl PciConfigAccess for FakeHost {
+        fn read8(&self, bdf: Bdf, offset: u16) -> Result<u8> {
+            let aligned = offset & !3;
+            let shift = ((offset & 3) * 8) as u32;
+            Ok(((self.read32(bdf, aligned)? >> shift) & 0xff) as u8)
+        }
+
+        fn read16(&self, bdf: Bdf, offset: u16) -> Result<u16> {
+            let aligned = offset & !3;
+            let shift = ((offset & 2) * 8) as u32;
+            Ok(((self.read32(bdf, aligned)? >> shift) & 0xffff) as u16)
+        }
+
+        fn read32(&self, bdf: Bdf, offset: u16) -> Result<u32> {
+            self.config.borrow().get(&(bdf, offset)).copied().ok_or({
+                InternalError::PciAccess(PciAccessError::ConfigRead {
+                    bus: bdf.bus,
+                    device: bdf.device,
+                    function: bdf.function,
+                    register: offset,
+                })
+            })
+        }
+
+        fn write8(&self, bdf: Bdf, offset: u16, value: u8) -> Result<()> {
+            self.writes
+                .borrow_mut()
+                .push((bdf, offset, value as u32, 1));
+            Ok(())
+        }
+
+        fn write16(&self, bdf: Bdf, offset: u16, value: u16) -> Result<()> {
+            self.writes
+                .borrow_mut()
+                .push((bdf, offset, value as u32, 2));
+            Ok(())
+        }
+
+        fn write32(&self, bdf: Bdf, offset: u16, value: u32) -> Result<()> {
+            self.writes.borrow_mut().push((bdf, offset, value, 4));
+            self.config.borrow_mut().insert((bdf, offset), value);
+            Ok(())
+        }
+    }
+
+    pub(crate) struct FakeMmio;
+
+    impl MmioAccess for FakeMmio {
+        fn read8(&self, _offset: usize) -> u8 {
+            0
+        }
+        fn read16(&self, _offset: usize) -> u16 {
+            0
+        }
+        fn read32(&self, _offset: usize) -> u32 {
+            0
+        }
+        fn write8(&self, _offset: usize, _value: u8) {}
+        fn write16(&self, _offset: usize, _value: u16) {}
+        fn write32(&self, _offset: usize, _value: u32) {}
+    }
+
+    impl HostAccess for FakeHost {
+        type MmioRegion = FakeMmio;
+
+        unsafe fn map_mmio(&self, _phys_addr: u64, _size: usize) -> Result<Self::MmioRegion> {
+            Ok(FakeMmio)
+        }
+
+        fn delay_us(&self, us: u32) {
+            self.delays.borrow_mut().push(us);
+        }
+    }
+
+    #[test]
+    fn test_bdf_preserves_segment() {
+        let bdf = Bdf::with_segment(2, 0, 0x1f, 5);
+        assert_eq!(bdf.segment, 2);
+        assert_eq!(bdf.bus, 0);
+        assert_eq!(bdf.device, 0x1f);
+        assert_eq!(bdf.function, 5);
+    }
+
+    #[test]
+    fn test_fake_host_config_access_and_delay() {
+        let host = FakeHost::default();
+        let bdf = Bdf::new(0, 0x1f, 0);
+        host.set_config32(bdf, 0x10, 0x1234_5678);
+
+        assert_eq!(host.read8(bdf, 0x10).unwrap(), 0x78);
+        assert_eq!(host.read16(bdf, 0x12).unwrap(), 0x1234);
+        assert_eq!(host.read32(bdf, 0x10).unwrap(), 0x1234_5678);
+
+        host.delay_us(7);
+        assert_eq!(host.delay_log(), vec![7]);
+    }
+}

--- a/crates/rflasher-internal/src/ichspi.rs
+++ b/crates/rflasher-internal/src/ichspi.rs
@@ -18,16 +18,85 @@
 //! - **Software Sequencing**: We control the SPI protocol directly.
 //!   More flexible but may not be available on locked-down systems.
 
+#![cfg_attr(
+    all(feature = "std", not(target_os = "linux")),
+    allow(dead_code, unused_imports)
+)]
+
 use crate::DetectedChipset;
 use crate::chipset::IchChipset;
 use crate::controller::Controller;
 use crate::error::InternalError;
+#[cfg(all(feature = "std", target_os = "linux"))]
+use crate::host::LinuxHost;
+use crate::host::{Bdf, HostAccess, MmioAccess, PciConfigAccess};
 use crate::ich_regs::*;
-use crate::pci::{
-    pci_read_config8, pci_read_config32, pci_read_config32_direct, pci_write_config8,
-};
-use crate::physmap::PhysMap;
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
+
+#[inline]
+fn spin_loop() {
+    core::hint::spin_loop();
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+struct Deadline {
+    end_sec: i64,
+    end_nsec: i64,
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+impl Deadline {
+    fn new(timeout_us: u32) -> Self {
+        let mut start = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        // SAFETY: clock_gettime writes to a valid stack timespec.
+        unsafe {
+            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut start);
+        }
+
+        let timeout_ns = (timeout_us as i64) * 1000;
+        let end_nsec = start.tv_nsec + timeout_ns;
+        let end_sec = start.tv_sec + (end_nsec / 1_000_000_000);
+        let end_nsec = end_nsec % 1_000_000_000;
+
+        Self { end_sec, end_nsec }
+    }
+
+    fn expired(&mut self) -> bool {
+        let mut now = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        // SAFETY: clock_gettime writes to a valid stack timespec.
+        unsafe {
+            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now);
+        }
+
+        now.tv_sec > self.end_sec || (now.tv_sec == self.end_sec && now.tv_nsec >= self.end_nsec)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+struct Deadline {
+    polls_left: u32,
+}
+
+#[cfg(not(feature = "std"))]
+impl Deadline {
+    fn new(timeout_us: u32) -> Self {
+        Self {
+            polls_left: timeout_us.saturating_mul(64).max(1),
+        }
+    }
+
+    fn expired(&mut self) -> bool {
+        let expired = self.polls_left == 0;
+        self.polls_left = self.polls_left.saturating_sub(1);
+        expired
+    }
+}
 use rflasher_core::programmer::SpiFeatures;
 use rflasher_core::spi::SpiCommand;
 
@@ -49,22 +118,82 @@ pub enum SpiMode {
 impl SpiMode {
     /// Parse from string (for CLI parameter)
     pub fn parse(s: &str) -> Option<Self> {
-        match s.to_lowercase().as_str() {
-            "auto" => Some(Self::Auto),
-            "hwseq" | "hardware" | "hw" => Some(Self::HardwareSequencing),
-            "swseq" | "software" | "sw" => Some(Self::SoftwareSequencing),
-            _ => None,
+        if s.eq_ignore_ascii_case("auto") {
+            Some(Self::Auto)
+        } else if s.eq_ignore_ascii_case("hwseq")
+            || s.eq_ignore_ascii_case("hardware")
+            || s.eq_ignore_ascii_case("hw")
+        {
+            Some(Self::HardwareSequencing)
+        } else if s.eq_ignore_ascii_case("swseq")
+            || s.eq_ignore_ascii_case("software")
+            || s.eq_ignore_ascii_case("sw")
+        {
+            Some(Self::SoftwareSequencing)
+        } else {
+            None
         }
     }
 }
 
-impl std::fmt::Display for SpiMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for SpiMode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Auto => write!(f, "auto"),
             Self::HardwareSequencing => write!(f, "hwseq"),
             Self::SoftwareSequencing => write!(f, "swseq"),
         }
+    }
+}
+
+/// Gets the SPI BAR physical address using host-provided PCI config access.
+///
+/// This helper is independent from Linux sysfs and can be exercised by
+/// embedded firmware or fake hosts. It covers both PCH100+ hidden SPI function
+/// BAR discovery and legacy RCBA-relative SPI BAR discovery.
+pub fn get_spibar_address_with_host<H: PciConfigAccess>(
+    host: &H,
+    chipset: &DetectedChipset,
+) -> Result<u64, InternalError> {
+    let generation = chipset.chipset_type();
+
+    if generation.is_pch100_compatible() {
+        const SPI_FUNCTION: u8 = 5;
+        let spi_bdf = Bdf::with_segment(chipset.domain, chipset.bus, chipset.device, SPI_FUNCTION);
+        let spibar_raw = host.read32(spi_bdf, PCI_REG_SPIBAR as u16)?;
+        let addr = spibar_raw & 0xffff_f000;
+
+        if addr == 0 || addr == 0xffff_f000 {
+            return Err(InternalError::ChipsetEnable(
+                "SPIBAR is invalid - SPI controller may be hidden or disabled by firmware",
+            ));
+        }
+
+        Ok(addr as u64)
+    } else if generation.is_ich9_compatible() || generation == IchChipset::Ich7 {
+        let lpc_bdf = Bdf::with_segment(
+            chipset.domain,
+            chipset.bus,
+            chipset.device,
+            chipset.function,
+        );
+        let rcba = host.read32(lpc_bdf, PCI_REG_RCBA as u16)?;
+        if rcba & 1 == 0 {
+            return Err(InternalError::ChipsetEnable("RCBA not enabled"));
+        }
+
+        let rcba_base = (rcba & !0x3fff) as u64;
+        let spi_offset = if generation == IchChipset::Ich7 {
+            RCBA_SPI_OFFSET_ICH7
+        } else {
+            RCBA_SPI_OFFSET_ICH9
+        };
+
+        Ok(rcba_base + spi_offset as u64)
+    } else {
+        Err(InternalError::NotSupported(
+            "Unsupported chipset generation",
+        ))
     }
 }
 
@@ -177,13 +306,16 @@ impl Default for Opcodes {
 }
 
 /// Intel ICH/PCH SPI Controller
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub struct IchSpiController {
+#[cfg(any(all(feature = "std", target_os = "linux"), not(feature = "std")))]
+pub struct IchSpiController<H: HostAccess> {
+    /// Platform access backend
+    host: H,
     /// Memory-mapped SPI registers
-    spibar: PhysMap,
+    spibar: H::MmioRegion,
     /// Chipset generation
     generation: IchChipset,
     /// PCI location of LPC/eSPI bridge
+    lpc_segment: u16,
     lpc_bus: u8,
     lpc_device: u8,
     lpc_function: u8,
@@ -210,17 +342,31 @@ pub struct IchSpiController {
 }
 
 #[cfg(all(feature = "std", target_os = "linux"))]
-impl IchSpiController {
-    /// Initialize a new SPI controller for the detected chipset
+impl IchSpiController<LinuxHost> {
+    /// Initialize a new SPI controller for the detected chipset using Linux host access.
     pub fn new(chipset: &DetectedChipset, mode: SpiMode) -> Result<Self, InternalError> {
+        Self::new_with_host(LinuxHost::new(), chipset, mode)
+    }
+}
+
+#[cfg(any(all(feature = "std", target_os = "linux"), not(feature = "std")))]
+impl<H: HostAccess> IchSpiController<H> {
+    /// Initialize a new SPI controller for the detected chipset.
+    pub fn new_with_host(
+        host: H,
+        chipset: &DetectedChipset,
+        mode: SpiMode,
+    ) -> Result<Self, InternalError> {
         let generation = chipset.chipset_type();
 
         // Get SPI BAR address
-        let spibar_addr = Self::get_spibar_address(chipset)?;
+        let spibar_addr = get_spibar_address_with_host(&host, chipset)?;
         log::debug!("SPI BAR at physical address: {:#x}", spibar_addr);
 
         // Map the SPI registers
-        let spibar = PhysMap::new(spibar_addr, 0x200)?;
+        // SAFETY: SPIBAR was discovered from chipset PCI configuration and is
+        // the controller register window for the selected chipset.
+        let spibar = unsafe { host.map_mmio(spibar_addr, 0x200)? };
 
         // Initialize register offsets based on generation
         let (swseq, hwseq) = if generation.is_pch100_compatible() {
@@ -269,8 +415,10 @@ impl IchSpiController {
         };
 
         let mut controller = Self {
+            host,
             spibar,
             generation,
+            lpc_segment: chipset.domain,
             lpc_bus: chipset.bus,
             lpc_device: chipset.device,
             lpc_function: chipset.function,
@@ -290,89 +438,6 @@ impl IchSpiController {
         controller.init()?;
 
         Ok(controller)
-    }
-
-    /// Get the SPI BAR physical address from PCI config space
-    fn get_spibar_address(chipset: &DetectedChipset) -> Result<u64, InternalError> {
-        let r#gen = chipset.chipset_type();
-
-        if r#gen.is_pch100_compatible() {
-            // PCH100+ (Sunrise Point and later): SPI controller is a separate PCI device
-            // at function 5 (00:1f.5), not part of the LPC bridge at function 0.
-            // The chipset detection finds the LPC bridge, but we need to read BAR0
-            // from the SPI controller device.
-            //
-            // IMPORTANT: The SPI device is often hidden by firmware (vendor/device IDs
-            // read as 0xFFFF), so it doesn't appear in sysfs. We must use direct I/O
-            // port access (PCI Configuration Mechanism 1) to read from it.
-            const SPI_FUNCTION: u8 = 5;
-
-            // Use direct I/O port access since the SPI device may be hidden
-            let spibar_raw = pci_read_config32_direct(
-                chipset.bus,
-                chipset.device,
-                SPI_FUNCTION,
-                PCI_REG_SPIBAR,
-            )?;
-
-            // SPIBAR is a 32-bit memory BAR. Mask off the lower 12 bits (BAR type indicators)
-            // to get the physical address (4KB aligned).
-            let addr = (spibar_raw & 0xFFFF_F000) as u64;
-
-            log::debug!(
-                "Raw SPIBAR register: {:#010x}, masked addr: {:#010x}",
-                spibar_raw,
-                addr
-            );
-
-            if addr == 0 {
-                // SPIBAR is 0 - the SPI device may be hidden or disabled
-                // Note: RCBA does NOT exist on PCH100+, so we cannot fall back to it
-                return Err(InternalError::ChipsetEnable(
-                    "SPIBAR is 0 - SPI controller may be hidden or disabled by firmware",
-                ));
-            }
-
-            log::debug!(
-                "Read SPIBAR {:#x} from PCI {:02x}:{:02x}.{} (via direct I/O)",
-                addr,
-                chipset.bus,
-                chipset.device,
-                SPI_FUNCTION
-            );
-
-            Ok(addr)
-        } else if r#gen.is_ich9_compatible() || r#gen == IchChipset::Ich7 {
-            // ICH7-ICH10, 5-9 Series: SPI is at an offset within RCBA
-            Self::get_spibar_via_rcba(chipset)
-        } else {
-            Err(InternalError::NotSupported(
-                "Unsupported chipset generation",
-            ))
-        }
-    }
-
-    /// Get SPI BAR via RCBA (Root Complex Base Address)
-    fn get_spibar_via_rcba(chipset: &DetectedChipset) -> Result<u64, InternalError> {
-        // Read RCBA from LPC bridge config space
-        let rcba = pci_read_config32(chipset.bus, chipset.device, chipset.function, PCI_REG_RCBA)?;
-
-        // Check if RCBA is enabled (bit 0)
-        if rcba & 1 == 0 {
-            return Err(InternalError::ChipsetEnable("RCBA not enabled"));
-        }
-
-        // RCBA is 32-bit aligned, mask off lower bits
-        let rcba_base = (rcba & !0x3FFF) as u64;
-
-        // SPI offset depends on chipset generation
-        let spi_offset = if chipset.chipset_type() == IchChipset::Ich7 {
-            RCBA_SPI_OFFSET_ICH7
-        } else {
-            RCBA_SPI_OFFSET_ICH9
-        };
-
-        Ok(rcba_base + spi_offset as u64)
     }
 
     /// Initialize the SPI controller
@@ -1103,12 +1168,13 @@ impl IchSpiController {
 
     /// Enable BIOS write access via BIOS_CNTL register
     pub fn enable_bios_write(&mut self) -> Result<(), InternalError> {
-        let bios_cntl = pci_read_config8(
+        let lpc_bdf = Bdf::with_segment(
+            self.lpc_segment,
             self.lpc_bus,
             self.lpc_device,
             self.lpc_function,
-            PCI_REG_BIOS_CNTL,
-        )?;
+        );
+        let bios_cntl = self.host.read8(lpc_bdf, PCI_REG_BIOS_CNTL as u16)?;
 
         log::debug!("BIOS_CNTL: {:#04x}", bios_cntl);
 
@@ -1126,21 +1192,11 @@ impl IchSpiController {
         // Enable BIOS Write Enable
         if bios_cntl & BIOS_CNTL_BWE == 0 {
             let new_val = bios_cntl | BIOS_CNTL_BWE;
-            pci_write_config8(
-                self.lpc_bus,
-                self.lpc_device,
-                self.lpc_function,
-                PCI_REG_BIOS_CNTL,
-                new_val,
-            )?;
+            self.host
+                .write8(lpc_bdf, PCI_REG_BIOS_CNTL as u16, new_val)?;
 
             // Verify
-            let verify = pci_read_config8(
-                self.lpc_bus,
-                self.lpc_device,
-                self.lpc_function,
-                PCI_REG_BIOS_CNTL,
-            )?;
+            let verify = self.host.read8(lpc_bdf, PCI_REG_BIOS_CNTL as u16)?;
 
             if verify & BIOS_CNTL_BWE == 0 {
                 log::error!("Failed to enable BIOS Write Enable");
@@ -1164,6 +1220,26 @@ impl IchSpiController {
     #[allow(dead_code)]
     fn is_locked(&self) -> bool {
         self.locked
+    }
+
+    /// Return the BIOS region from the Intel Flash Descriptor, if valid.
+    ///
+    /// The tuple is `(base, limit)` in flash offsets, inclusive. This is used
+    /// by firmware callers to translate top-of-4GiB memory-mapped BIOS
+    /// addresses back to SPI flash offsets.
+    pub fn get_bios_region(&self) -> Option<(u32, u32)> {
+        if !self.desc_valid || self.generation == IchChipset::Ich7 {
+            return None;
+        }
+
+        let freg1 = self.spibar.read32(ICH9_REG_FREG0 + 4);
+        let base = (freg1 & 0x7fff) << 12;
+        let limit = (((freg1 >> 16) & 0x7fff) << 12) | 0x0fff;
+        if base <= limit {
+            Some((base, limit))
+        } else {
+            None
+        }
     }
 
     /// Get the chipset generation
@@ -1192,19 +1268,7 @@ impl IchSpiController {
     fn hwseq_wait_for_cycle(&self, timeout_us: u32) -> Result<(), InternalError> {
         let done_or_err = HSFS_FDONE | HSFS_FCERR;
 
-        // Get start time
-        let mut start = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-        unsafe {
-            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut start);
-        }
-
-        let timeout_ns = (timeout_us as i64) * 1000;
-        let end_nsec = start.tv_nsec as i64 + timeout_ns;
-        let end_sec = start.tv_sec as i64 + (end_nsec / 1_000_000_000);
-        let end_nsec = end_nsec % 1_000_000_000;
+        let mut deadline = Deadline::new(timeout_us);
 
         loop {
             let hsfs = self.spibar.read16(ICH9_REG_HSFS);
@@ -1220,23 +1284,12 @@ impl IchSpiController {
                 return Ok(());
             }
 
-            // Check timeout using clock_gettime (busy loop for precision)
-            let mut now = libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-            unsafe {
-                libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now);
-            }
-
-            if now.tv_sec as i64 > end_sec
-                || (now.tv_sec as i64 == end_sec && now.tv_nsec as i64 >= end_nsec)
-            {
+            if deadline.expired() {
                 return Err(InternalError::Io("Hardware sequencing timeout"));
             }
 
             // Hint to CPU that we're spinning (reduces power, improves perf on hyperthreaded cores)
-            std::hint::spin_loop();
+            spin_loop();
         }
     }
 
@@ -1462,18 +1515,7 @@ impl IchSpiController {
     /// previous one has completed.
     #[allow(clippy::unnecessary_cast)] // Casts needed for i686 where tv_sec/tv_nsec are i32
     fn swseq_wait_idle(&self, timeout_us: u32) -> Result<(), InternalError> {
-        let mut start = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-        unsafe {
-            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut start);
-        }
-
-        let timeout_ns = (timeout_us as i64) * 1000;
-        let end_nsec = start.tv_nsec as i64 + timeout_ns;
-        let end_sec = start.tv_sec as i64 + (end_nsec / 1_000_000_000);
-        let end_nsec = end_nsec % 1_000_000_000;
+        let mut deadline = Deadline::new(timeout_us);
 
         loop {
             let ssfs = self.spibar.read8(self.swseq.ssfsc);
@@ -1482,21 +1524,11 @@ impl IchSpiController {
                 return Ok(());
             }
 
-            let mut now = libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-            unsafe {
-                libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now);
-            }
-
-            if now.tv_sec as i64 > end_sec
-                || (now.tv_sec as i64 == end_sec && now.tv_nsec as i64 >= end_nsec)
-            {
+            if deadline.expired() {
                 return Err(InternalError::Io("SCIP never cleared (swseq busy timeout)"));
             }
 
-            std::hint::spin_loop();
+            spin_loop();
         }
     }
 
@@ -1505,18 +1537,7 @@ impl IchSpiController {
     fn swseq_wait_complete(&self, timeout_us: u32) -> Result<(), InternalError> {
         let done_or_err = SSFS_FDONE | SSFS_FCERR;
 
-        let mut start = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-        unsafe {
-            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut start);
-        }
-
-        let timeout_ns = (timeout_us as i64) * 1000;
-        let end_nsec = start.tv_nsec as i64 + timeout_ns;
-        let end_sec = start.tv_sec as i64 + (end_nsec / 1_000_000_000);
-        let end_nsec = end_nsec % 1_000_000_000;
+        let mut deadline = Deadline::new(timeout_us);
 
         loop {
             let ssfsc = self.spibar.read32(self.swseq.ssfsc);
@@ -1535,21 +1556,11 @@ impl IchSpiController {
                 return Ok(());
             }
 
-            let mut now = libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-            unsafe {
-                libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now);
-            }
-
-            if now.tv_sec as i64 > end_sec
-                || (now.tv_sec as i64 == end_sec && now.tv_nsec as i64 >= end_nsec)
-            {
+            if deadline.expired() {
                 return Err(InternalError::Io("Software sequencing timeout"));
             }
 
-            std::hint::spin_loop();
+            spin_loop();
         }
     }
 
@@ -1665,18 +1676,7 @@ impl IchSpiController {
     /// previous one has completed.
     #[allow(clippy::unnecessary_cast)] // Casts needed for i686 where tv_sec/tv_nsec are i32
     fn ich7_swseq_wait_idle(&self, timeout_us: u32) -> Result<(), InternalError> {
-        let mut start = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-        unsafe {
-            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut start);
-        }
-
-        let timeout_ns = (timeout_us as i64) * 1000;
-        let end_nsec = start.tv_nsec as i64 + timeout_ns;
-        let end_sec = start.tv_sec as i64 + (end_nsec / 1_000_000_000);
-        let end_nsec = end_nsec % 1_000_000_000;
+        let mut deadline = Deadline::new(timeout_us);
 
         loop {
             let spis = self.spibar.read16(self.ich7_swseq.spis);
@@ -1685,23 +1685,13 @@ impl IchSpiController {
                 return Ok(());
             }
 
-            let mut now = libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-            unsafe {
-                libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now);
-            }
-
-            if now.tv_sec as i64 > end_sec
-                || (now.tv_sec as i64 == end_sec && now.tv_nsec as i64 >= end_nsec)
-            {
+            if deadline.expired() {
                 return Err(InternalError::Io(
                     "ICH7: SCIP never cleared (swseq busy timeout)",
                 ));
             }
 
-            std::hint::spin_loop();
+            spin_loop();
         }
     }
 
@@ -1710,18 +1700,7 @@ impl IchSpiController {
     fn ich7_swseq_wait_complete(&self, timeout_us: u32) -> Result<(), InternalError> {
         let done_or_err = SPIS_CDS | SPIS_FCERR;
 
-        let mut start = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-        unsafe {
-            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut start);
-        }
-
-        let timeout_ns = (timeout_us as i64) * 1000;
-        let end_nsec = start.tv_nsec as i64 + timeout_ns;
-        let end_sec = start.tv_sec as i64 + (end_nsec / 1_000_000_000);
-        let end_nsec = end_nsec % 1_000_000_000;
+        let mut deadline = Deadline::new(timeout_us);
 
         loop {
             let spis = self.spibar.read16(self.ich7_swseq.spis);
@@ -1741,21 +1720,11 @@ impl IchSpiController {
                 return Ok(());
             }
 
-            let mut now = libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-            unsafe {
-                libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now);
-            }
-
-            if now.tv_sec as i64 > end_sec
-                || (now.tv_sec as i64 == end_sec && now.tv_nsec as i64 >= end_nsec)
-            {
+            if deadline.expired() {
                 return Err(InternalError::Io("ICH7: Software sequencing timeout"));
             }
 
-            std::hint::spin_loop();
+            spin_loop();
         }
     }
 
@@ -2158,7 +2127,7 @@ impl IchSpiController {
         // Check we have RDSR opcode
         if self.find_opcode_index(JEDEC_RDSR).is_none() {
             // No RDSR available, just wait a fixed time
-            std::thread::sleep(std::time::Duration::from_millis(100));
+            self.host.delay_us(100_000);
             return Ok(());
         }
 
@@ -2175,7 +2144,7 @@ impl IchSpiController {
             }
 
             // Small delay between polls
-            std::thread::sleep(std::time::Duration::from_micros(100));
+            self.host.delay_us(100);
         }
 
         Err(InternalError::Io("Timeout waiting for WIP to clear"))
@@ -2411,7 +2380,7 @@ impl IchSpiController {
         // Check we have RDSR opcode
         if self.find_opcode_index(JEDEC_RDSR).is_none() {
             // No RDSR available, just wait a fixed time
-            std::thread::sleep(std::time::Duration::from_millis(100));
+            self.host.delay_us(100_000);
             return Ok(());
         }
 
@@ -2428,15 +2397,15 @@ impl IchSpiController {
             }
 
             // Small delay between polls
-            std::thread::sleep(std::time::Duration::from_micros(100));
+            self.host.delay_us(100);
         }
 
         Err(InternalError::Io("Timeout waiting for WIP to clear"))
     }
 }
 
-#[cfg(all(feature = "std", target_os = "linux"))]
-impl Controller for IchSpiController {
+#[cfg(any(all(feature = "std", target_os = "linux"), not(feature = "std")))]
+impl<H: HostAccess> Controller for IchSpiController<H> {
     fn is_locked(&self) -> bool {
         self.locked
     }
@@ -2487,6 +2456,10 @@ impl Controller for IchSpiController {
 
     fn controller_name(&self) -> &'static str {
         "Intel ICH/PCH"
+    }
+
+    fn spi_mode(&self) -> SpiMode {
+        self.mode
     }
 
     fn features(&self) -> SpiFeatures {
@@ -2602,8 +2575,8 @@ impl Controller for IchSpiController {
     }
 }
 
-#[cfg(all(feature = "std", target_os = "linux"))]
-impl IchSpiController {
+#[cfg(any(all(feature = "std", target_os = "linux"), not(feature = "std")))]
+impl<H: HostAccess> IchSpiController<H> {
     /// Map InternalError to CoreError
     fn map_internal_error(e: InternalError) -> CoreError {
         match e {
@@ -2624,17 +2597,112 @@ impl IchSpiController {
     }
 }
 
-// Non-Linux stub
-#[cfg(not(all(feature = "std", target_os = "linux")))]
+// Unsupported std non-Linux stub.
+#[cfg(all(feature = "std", not(target_os = "linux")))]
 pub struct IchSpiController {
     _private: (),
 }
 
-#[cfg(not(all(feature = "std", target_os = "linux")))]
+#[cfg(all(feature = "std", not(target_os = "linux")))]
 impl IchSpiController {
     pub fn new(_chipset: &DetectedChipset, _mode: SpiMode) -> Result<Self, InternalError> {
         Err(InternalError::NotSupported(
-            "Intel internal programmer only supported on Linux",
+            "Intel internal programmer not available on this target",
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::tests::FakeHost;
+    use crate::intel_pci::INTEL_CHIPSETS;
+
+    fn detected_with_generation(generation: IchChipset) -> DetectedChipset {
+        let enable = INTEL_CHIPSETS
+            .iter()
+            .find(|chipset| chipset.chipset == generation)
+            .expect("Intel chipset table entry for generation");
+
+        DetectedChipset {
+            enable,
+            domain: 0,
+            bus: 0,
+            device: 0x1f,
+            function: 0,
+            revision_id: 0,
+        }
+    }
+
+    #[test]
+    fn test_spimode_parse_is_no_alloc_case_insensitive() {
+        assert_eq!(SpiMode::parse("AUTO"), Some(SpiMode::Auto));
+        assert_eq!(SpiMode::parse("HwSeq"), Some(SpiMode::HardwareSequencing));
+        assert_eq!(
+            SpiMode::parse("software"),
+            Some(SpiMode::SoftwareSequencing)
+        );
+        assert_eq!(SpiMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_get_spibar_address_with_host_pch100_hidden_spi_function() {
+        let host = FakeHost::default();
+        let chipset = detected_with_generation(IchChipset::Series100SunrisePoint);
+        let spi_bdf = Bdf::with_segment(chipset.domain, chipset.bus, chipset.device, 5);
+        host.set_config32(spi_bdf, PCI_REG_SPIBAR as u16, 0xfed1_c001);
+
+        let spibar = get_spibar_address_with_host(&host, &chipset).unwrap();
+
+        assert_eq!(spibar, 0xfed1_c000);
+    }
+
+    #[test]
+    fn test_get_spibar_address_with_host_rejects_all_ones_spibar() {
+        let host = FakeHost::default();
+        let chipset = detected_with_generation(IchChipset::Series100SunrisePoint);
+        let spi_bdf = Bdf::with_segment(chipset.domain, chipset.bus, chipset.device, 5);
+        host.set_config32(spi_bdf, PCI_REG_SPIBAR as u16, u32::MAX);
+
+        let err = get_spibar_address_with_host(&host, &chipset).unwrap_err();
+
+        assert!(matches!(err, InternalError::ChipsetEnable(_)));
+    }
+
+    #[test]
+    fn test_get_spibar_address_with_host_legacy_rcba() {
+        let host = FakeHost::default();
+        let chipset = detected_with_generation(IchChipset::Ich7);
+        let lpc_bdf = Bdf::with_segment(
+            chipset.domain,
+            chipset.bus,
+            chipset.device,
+            chipset.function,
+        );
+        host.set_config32(lpc_bdf, PCI_REG_RCBA as u16, 0xfed1_8001);
+
+        let spibar = get_spibar_address_with_host(&host, &chipset).unwrap();
+
+        assert_eq!(spibar, 0xfed1_8000 + RCBA_SPI_OFFSET_ICH7 as u64);
+    }
+
+    #[test]
+    fn test_get_spibar_address_with_host_rejects_disabled_rcba() {
+        let host = FakeHost::default();
+        let chipset = detected_with_generation(IchChipset::Ich7);
+        let lpc_bdf = Bdf::with_segment(
+            chipset.domain,
+            chipset.bus,
+            chipset.device,
+            chipset.function,
+        );
+        host.set_config32(lpc_bdf, PCI_REG_RCBA as u16, 0xfed1_8000);
+
+        let err = get_spibar_address_with_host(&host, &chipset).unwrap_err();
+
+        assert!(matches!(
+            err,
+            InternalError::ChipsetEnable("RCBA not enabled")
+        ));
     }
 }

--- a/crates/rflasher-internal/src/lib.rs
+++ b/crates/rflasher-internal/src/lib.rs
@@ -48,6 +48,7 @@ pub mod amd_spi100;
 pub mod chipset;
 pub mod controller;
 pub mod error;
+pub mod host;
 pub mod ich_regs;
 pub mod ichspi;
 pub mod intel_pci;
@@ -55,16 +56,20 @@ pub mod pci;
 pub mod physmap;
 pub mod programmer;
 
-pub use amd_enable::{AmdSpi100Info, enable_amd_spi100};
+pub use amd_enable::{AmdSpi100Info, enable_amd_spi100, enable_amd_spi100_with_host};
 pub use amd_pci::{AMD_CHIPSETS, AMD_VID, AmdChipset, AmdChipsetEnable};
 pub use amd_spi100::Spi100Controller;
 pub use chipset::{BusType, ChipsetEnable, IchChipset, TestStatus};
 pub use error::{InternalError, PciAccessError};
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub use host::LinuxHost;
+pub use host::{Bdf, DefaultPciAccess, HostAccess, MmioAccess, PciConfigAccess};
 pub use ichspi::{IchSpiController, SpiMode};
 pub use intel_pci::{INTEL_CHIPSETS, INTEL_VID, find_chipset};
 pub use pci::{
-    DetectedAmdChipset, PciDevice, find_amd_chipset, find_intel_chipset, scan_for_amd_chipsets,
-    scan_for_intel_chipsets, scan_pci_bus,
+    DetectedAmdChipset, PciDevice, find_amd_chipset, find_amd_chipset_in_devices,
+    find_amd_chipset_in_iter, find_intel_chipset, find_intel_chipset_in_devices,
+    find_intel_chipset_in_iter, scan_for_amd_chipsets, scan_for_intel_chipsets, scan_pci_bus,
 };
 pub use physmap::PhysMap;
 pub use programmer::{InternalOptions, InternalProgrammer, programmer_info};
@@ -80,6 +85,8 @@ pub type Result<T> = core::result::Result<T, InternalError>;
 pub struct DetectedChipset {
     /// The chipset enable entry from the database
     pub enable: &'static ChipsetEnable,
+    /// PCI segment/domain
+    pub domain: u16,
     /// PCI bus number
     pub bus: u8,
     /// PCI device number  

--- a/crates/rflasher-internal/src/pci.rs
+++ b/crates/rflasher-internal/src/pci.rs
@@ -3,6 +3,11 @@
 //! This module provides PCI device scanning functionality using the Linux
 //! sysfs interface (/sys/bus/pci/devices).
 
+#![cfg_attr(
+    not(all(feature = "std", target_os = "linux")),
+    allow(dead_code, unused_imports)
+)]
+
 #[cfg(all(feature = "std", target_os = "linux"))]
 use std::fs;
 #[cfg(all(feature = "std", target_os = "linux"))]
@@ -47,6 +52,102 @@ impl PciDevice {
 }
 
 extern crate alloc;
+
+fn detected_intel_from_device(dev: &PciDevice) -> Option<DetectedChipset> {
+    if dev.vendor_id != INTEL_VID {
+        return None;
+    }
+
+    find_chipset(dev.vendor_id, dev.device_id, Some(dev.revision_id)).map(|enable| {
+        DetectedChipset {
+            enable,
+            domain: dev.domain,
+            bus: dev.bus,
+            device: dev.device,
+            function: dev.function,
+            revision_id: dev.revision_id,
+        }
+    })
+}
+
+fn detected_amd_from_device(dev: &PciDevice) -> Option<DetectedAmdChipset> {
+    if dev.vendor_id != AMD_VID && dev.vendor_id != 0x1002 {
+        return None;
+    }
+
+    find_amd_chipset_entry(dev.vendor_id, dev.device_id, dev.revision_id).map(|enable| {
+        DetectedAmdChipset {
+            enable,
+            domain: dev.domain,
+            bus: dev.bus,
+            device: dev.device,
+            function: dev.function,
+            revision_id: dev.revision_id,
+        }
+    })
+}
+
+/// Finds a single Intel chipset in a caller-provided PCI device list.
+///
+/// This is the embedded-friendly detection path: firmware can provide devices
+/// from its own PCI scanner and avoid Linux sysfs enumeration entirely.
+pub fn find_intel_chipset_in_devices(
+    devices: &[PciDevice],
+) -> Result<Option<DetectedChipset>, InternalError> {
+    find_intel_chipset_in_iter(devices.iter().cloned())
+}
+
+/// Finds a single Intel chipset in a caller-provided PCI device iterator.
+pub fn find_intel_chipset_in_iter<I>(devices: I) -> Result<Option<DetectedChipset>, InternalError>
+where
+    I: IntoIterator<Item = PciDevice>,
+{
+    let mut found = None;
+
+    for dev in devices {
+        let Some(chipset) = detected_intel_from_device(&dev) else {
+            continue;
+        };
+
+        if found.is_some() {
+            return Err(InternalError::MultipleChipsets);
+        }
+
+        found = Some(chipset);
+    }
+
+    if let Some(chipset) = &found
+        && chipset.enable.status.is_bad()
+    {
+        return Err(InternalError::UnsupportedChipset {
+            vendor_id: chipset.enable.vendor_id,
+            device_id: chipset.enable.device_id,
+            name: chipset.enable.device_name,
+        });
+    }
+
+    Ok(found)
+}
+
+/// Finds a single AMD chipset in a caller-provided PCI device list.
+pub fn find_amd_chipset_in_devices(
+    devices: &[PciDevice],
+) -> Result<Option<DetectedAmdChipset>, InternalError> {
+    find_amd_chipset_in_iter(devices.iter().cloned())
+}
+
+/// Finds a single AMD chipset in a caller-provided PCI device iterator.
+///
+/// This preserves the existing Linux behavior for multiple AMD matches by
+/// returning the first match instead of failing.
+pub fn find_amd_chipset_in_iter<I>(devices: I) -> Result<Option<DetectedAmdChipset>, InternalError>
+where
+    I: IntoIterator<Item = PciDevice>,
+{
+    Ok(devices
+        .into_iter()
+        .find_map(|dev| detected_amd_from_device(&dev)))
+}
 
 /// Scan the PCI bus for devices
 ///
@@ -182,6 +283,7 @@ pub fn scan_for_intel_chipsets() -> Result<alloc::vec::Vec<DetectedChipset>, Int
 
             found.push(DetectedChipset {
                 enable,
+                domain: dev.domain,
                 bus: dev.bus,
                 device: dev.device,
                 function: dev.function,
@@ -291,7 +393,7 @@ pub fn pci_read_config32_direct(
             bus,
             device,
             function,
-            register: offset,
+            register: offset as u16,
         }));
     }
 
@@ -337,7 +439,182 @@ pub fn pci_read_config32_direct(
     ))
 }
 
-/// Read a byte from PCI configuration space via sysfs
+#[cfg(all(feature = "std", target_os = "linux"))]
+fn pci_config_path(segment: u16, bus: u8, device: u8, function: u8) -> alloc::string::String {
+    alloc::format!(
+        "/sys/bus/pci/devices/{:04x}:{:02x}:{:02x}.{:x}/config",
+        segment,
+        bus,
+        device,
+        function
+    )
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+fn pci_config_read<const N: usize>(
+    segment: u16,
+    bus: u8,
+    device: u8,
+    function: u8,
+    offset: u8,
+) -> Result<[u8; N], InternalError> {
+    use std::io::{Read, Seek};
+
+    let path = pci_config_path(segment, bus, device, function);
+    let mut file = std::fs::File::open(&path).map_err(|_| {
+        InternalError::PciAccess(PciAccessError::ConfigRead {
+            bus,
+            device,
+            function,
+            register: offset as u16,
+        })
+    })?;
+
+    file.seek(std::io::SeekFrom::Start(offset as u64))
+        .map_err(|_| {
+            InternalError::PciAccess(PciAccessError::ConfigRead {
+                bus,
+                device,
+                function,
+                register: offset as u16,
+            })
+        })?;
+
+    let mut buf = [0u8; N];
+    file.read_exact(&mut buf).map_err(|_| {
+        InternalError::PciAccess(PciAccessError::ConfigRead {
+            bus,
+            device,
+            function,
+            register: offset as u16,
+        })
+    })?;
+
+    Ok(buf)
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+fn pci_config_write(
+    segment: u16,
+    bus: u8,
+    device: u8,
+    function: u8,
+    offset: u8,
+    bytes: &[u8],
+) -> Result<(), InternalError> {
+    use std::fs::OpenOptions;
+    use std::io::{Seek, Write};
+
+    let path = pci_config_path(segment, bus, device, function);
+    let mut file = OpenOptions::new().write(true).open(&path).map_err(|_| {
+        InternalError::PciAccess(PciAccessError::ConfigWrite {
+            bus,
+            device,
+            function,
+            register: offset as u16,
+        })
+    })?;
+
+    file.seek(std::io::SeekFrom::Start(offset as u64))
+        .map_err(|_| {
+            InternalError::PciAccess(PciAccessError::ConfigWrite {
+                bus,
+                device,
+                function,
+                register: offset as u16,
+            })
+        })?;
+
+    file.write_all(bytes).map_err(|_| {
+        InternalError::PciAccess(PciAccessError::ConfigWrite {
+            bus,
+            device,
+            function,
+            register: offset as u16,
+        })
+    })
+}
+
+/// Read a byte from PCI configuration space via sysfs.
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn pci_read_config8_at(
+    segment: u16,
+    bus: u8,
+    device: u8,
+    function: u8,
+    offset: u8,
+) -> Result<u8, InternalError> {
+    Ok(pci_config_read::<1>(segment, bus, device, function, offset)?[0])
+}
+
+/// Read a word from PCI configuration space via sysfs.
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn pci_read_config16_at(
+    segment: u16,
+    bus: u8,
+    device: u8,
+    function: u8,
+    offset: u8,
+) -> Result<u16, InternalError> {
+    Ok(u16::from_le_bytes(pci_config_read::<2>(
+        segment, bus, device, function, offset,
+    )?))
+}
+
+/// Read a dword from PCI configuration space via sysfs.
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn pci_read_config32_at(
+    segment: u16,
+    bus: u8,
+    device: u8,
+    function: u8,
+    offset: u8,
+) -> Result<u32, InternalError> {
+    Ok(u32::from_le_bytes(pci_config_read::<4>(
+        segment, bus, device, function, offset,
+    )?))
+}
+
+/// Write a byte to PCI configuration space via sysfs.
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn pci_write_config8_at(
+    segment: u16,
+    bus: u8,
+    device: u8,
+    function: u8,
+    offset: u8,
+    value: u8,
+) -> Result<(), InternalError> {
+    pci_config_write(segment, bus, device, function, offset, &[value])
+}
+
+/// Write a word to PCI configuration space via sysfs.
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn pci_write_config16_at(
+    segment: u16,
+    bus: u8,
+    device: u8,
+    function: u8,
+    offset: u8,
+    value: u16,
+) -> Result<(), InternalError> {
+    pci_config_write(segment, bus, device, function, offset, &value.to_le_bytes())
+}
+
+/// Write a dword to PCI configuration space via sysfs.
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn pci_write_config32_at(
+    segment: u16,
+    bus: u8,
+    device: u8,
+    function: u8,
+    offset: u8,
+    value: u32,
+) -> Result<(), InternalError> {
+    pci_config_write(segment, bus, device, function, offset, &value.to_le_bytes())
+}
+
+/// Read a byte from PCI configuration space via sysfs in segment 0.
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub fn pci_read_config8(
     bus: u8,
@@ -345,47 +622,10 @@ pub fn pci_read_config8(
     function: u8,
     offset: u8,
 ) -> Result<u8, InternalError> {
-    use std::io::Read;
-
-    let path = format!(
-        "/sys/bus/pci/devices/0000:{:02x}:{:02x}.{:x}/config",
-        bus, device, function
-    );
-
-    let mut file = std::fs::File::open(&path).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigRead {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    use std::io::Seek;
-    file.seek(std::io::SeekFrom::Start(offset as u64))
-        .map_err(|_| {
-            InternalError::PciAccess(PciAccessError::ConfigRead {
-                bus,
-                device,
-                function,
-                register: offset,
-            })
-        })?;
-
-    let mut buf = [0u8; 1];
-    file.read_exact(&mut buf).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigRead {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    Ok(buf[0])
+    pci_read_config8_at(0, bus, device, function, offset)
 }
 
-/// Read a word from PCI configuration space via sysfs
+/// Read a word from PCI configuration space via sysfs in segment 0.
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub fn pci_read_config16(
     bus: u8,
@@ -393,47 +633,10 @@ pub fn pci_read_config16(
     function: u8,
     offset: u8,
 ) -> Result<u16, InternalError> {
-    use std::io::Read;
-
-    let path = format!(
-        "/sys/bus/pci/devices/0000:{:02x}:{:02x}.{:x}/config",
-        bus, device, function
-    );
-
-    let mut file = std::fs::File::open(&path).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigRead {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    use std::io::Seek;
-    file.seek(std::io::SeekFrom::Start(offset as u64))
-        .map_err(|_| {
-            InternalError::PciAccess(PciAccessError::ConfigRead {
-                bus,
-                device,
-                function,
-                register: offset,
-            })
-        })?;
-
-    let mut buf = [0u8; 2];
-    file.read_exact(&mut buf).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigRead {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    Ok(u16::from_le_bytes(buf))
+    pci_read_config16_at(0, bus, device, function, offset)
 }
 
-/// Read a dword from PCI configuration space via sysfs
+/// Read a dword from PCI configuration space via sysfs in segment 0.
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub fn pci_read_config32(
     bus: u8,
@@ -441,47 +644,10 @@ pub fn pci_read_config32(
     function: u8,
     offset: u8,
 ) -> Result<u32, InternalError> {
-    use std::io::Read;
-
-    let path = format!(
-        "/sys/bus/pci/devices/0000:{:02x}:{:02x}.{:x}/config",
-        bus, device, function
-    );
-
-    let mut file = std::fs::File::open(&path).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigRead {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    use std::io::Seek;
-    file.seek(std::io::SeekFrom::Start(offset as u64))
-        .map_err(|_| {
-            InternalError::PciAccess(PciAccessError::ConfigRead {
-                bus,
-                device,
-                function,
-                register: offset,
-            })
-        })?;
-
-    let mut buf = [0u8; 4];
-    file.read_exact(&mut buf).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigRead {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    Ok(u32::from_le_bytes(buf))
+    pci_read_config32_at(0, bus, device, function, offset)
 }
 
-/// Write a byte to PCI configuration space via sysfs
+/// Write a byte to PCI configuration space via sysfs in segment 0.
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub fn pci_write_config8(
     bus: u8,
@@ -490,47 +656,10 @@ pub fn pci_write_config8(
     offset: u8,
     value: u8,
 ) -> Result<(), InternalError> {
-    use std::fs::OpenOptions;
-    use std::io::Write;
-
-    let path = format!(
-        "/sys/bus/pci/devices/0000:{:02x}:{:02x}.{:x}/config",
-        bus, device, function
-    );
-
-    let mut file = OpenOptions::new().write(true).open(&path).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigWrite {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    use std::io::Seek;
-    file.seek(std::io::SeekFrom::Start(offset as u64))
-        .map_err(|_| {
-            InternalError::PciAccess(PciAccessError::ConfigWrite {
-                bus,
-                device,
-                function,
-                register: offset,
-            })
-        })?;
-
-    file.write_all(&[value]).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigWrite {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    Ok(())
+    pci_write_config8_at(0, bus, device, function, offset, value)
 }
 
-/// Write a word to PCI configuration space via sysfs
+/// Write a word to PCI configuration space via sysfs in segment 0.
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub fn pci_write_config16(
     bus: u8,
@@ -539,47 +668,10 @@ pub fn pci_write_config16(
     offset: u8,
     value: u16,
 ) -> Result<(), InternalError> {
-    use std::fs::OpenOptions;
-    use std::io::Write;
-
-    let path = format!(
-        "/sys/bus/pci/devices/0000:{:02x}:{:02x}.{:x}/config",
-        bus, device, function
-    );
-
-    let mut file = OpenOptions::new().write(true).open(&path).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigWrite {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    use std::io::Seek;
-    file.seek(std::io::SeekFrom::Start(offset as u64))
-        .map_err(|_| {
-            InternalError::PciAccess(PciAccessError::ConfigWrite {
-                bus,
-                device,
-                function,
-                register: offset,
-            })
-        })?;
-
-    file.write_all(&value.to_le_bytes()).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigWrite {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    Ok(())
+    pci_write_config16_at(0, bus, device, function, offset, value)
 }
 
-/// Write a dword to PCI configuration space via sysfs
+/// Write a dword to PCI configuration space via sysfs in segment 0.
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub fn pci_write_config32(
     bus: u8,
@@ -588,47 +680,10 @@ pub fn pci_write_config32(
     offset: u8,
     value: u32,
 ) -> Result<(), InternalError> {
-    use std::fs::OpenOptions;
-    use std::io::Write;
-
-    let path = format!(
-        "/sys/bus/pci/devices/0000:{:02x}:{:02x}.{:x}/config",
-        bus, device, function
-    );
-
-    let mut file = OpenOptions::new().write(true).open(&path).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigWrite {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    use std::io::Seek;
-    file.seek(std::io::SeekFrom::Start(offset as u64))
-        .map_err(|_| {
-            InternalError::PciAccess(PciAccessError::ConfigWrite {
-                bus,
-                device,
-                function,
-                register: offset,
-            })
-        })?;
-
-    file.write_all(&value.to_le_bytes()).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigWrite {
-            bus,
-            device,
-            function,
-            register: offset,
-        })
-    })?;
-
-    Ok(())
+    pci_write_config32_at(0, bus, device, function, offset, value)
 }
 
-// Non-Linux stubs
+// Non-Linux stubs.
 #[cfg(not(all(feature = "std", target_os = "linux")))]
 pub fn pci_read_config8(
     _bus: u8,
@@ -637,7 +692,7 @@ pub fn pci_read_config8(
     _offset: u8,
 ) -> Result<u8, InternalError> {
     Err(InternalError::NotSupported(
-        "PCI config access only supported on Linux",
+        "PCI config access not available",
     ))
 }
 
@@ -649,7 +704,7 @@ pub fn pci_read_config16(
     _offset: u8,
 ) -> Result<u16, InternalError> {
     Err(InternalError::NotSupported(
-        "PCI config access only supported on Linux",
+        "PCI config access not available",
     ))
 }
 
@@ -661,7 +716,7 @@ pub fn pci_read_config32(
     _offset: u8,
 ) -> Result<u32, InternalError> {
     Err(InternalError::NotSupported(
-        "PCI config access only supported on Linux",
+        "PCI config access not available",
     ))
 }
 
@@ -674,7 +729,7 @@ pub fn pci_write_config8(
     _value: u8,
 ) -> Result<(), InternalError> {
     Err(InternalError::NotSupported(
-        "PCI config access only supported on Linux",
+        "PCI config access not available",
     ))
 }
 
@@ -687,7 +742,7 @@ pub fn pci_write_config16(
     _value: u16,
 ) -> Result<(), InternalError> {
     Err(InternalError::NotSupported(
-        "PCI config access only supported on Linux",
+        "PCI config access not available",
     ))
 }
 
@@ -700,7 +755,7 @@ pub fn pci_write_config32(
     _value: u32,
 ) -> Result<(), InternalError> {
     Err(InternalError::NotSupported(
-        "PCI config access only supported on Linux",
+        "PCI config access not available",
     ))
 }
 
@@ -735,6 +790,8 @@ pub fn find_intel_chipset() -> Result<Option<DetectedChipset>, InternalError> {
 pub struct DetectedAmdChipset {
     /// The chipset enable entry from the database
     pub enable: &'static AmdChipsetEnable,
+    /// PCI segment/domain
+    pub domain: u16,
     /// PCI bus number
     pub bus: u8,
     /// PCI device number
@@ -844,6 +901,7 @@ pub fn scan_for_amd_chipsets() -> Result<alloc::vec::Vec<DetectedAmdChipset>, In
 
             found.push(DetectedAmdChipset {
                 enable,
+                domain: dev.domain,
                 bus: dev.bus,
                 device: dev.device,
                 function: dev.function,
@@ -901,4 +959,57 @@ pub fn find_amd_chipset() -> Result<Option<DetectedAmdChipset>, InternalError> {
     Err(InternalError::NotSupported(
         "PCI scanning only supported on Linux",
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pci_device(vendor_id: u16, device_id: u16, revision_id: u8) -> PciDevice {
+        PciDevice {
+            domain: 0,
+            bus: 0,
+            device: 0x1f,
+            function: 0,
+            vendor_id,
+            device_id,
+            revision_id,
+            class: 0,
+        }
+    }
+
+    #[test]
+    fn test_find_intel_chipset_in_devices_no_match() {
+        let devices = [pci_device(0x1234, 0x5678, 0)];
+        assert!(find_intel_chipset_in_devices(&devices).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_find_intel_chipset_in_devices_detects_match() {
+        let devices = [pci_device(INTEL_VID, 0x0f1c, 0)];
+        let chipset = find_intel_chipset_in_devices(&devices).unwrap().unwrap();
+        assert_eq!(chipset.enable.vendor_id, INTEL_VID);
+        assert_eq!(chipset.enable.device_id, 0x0f1c);
+        assert_eq!(chipset.bus, 0);
+        assert_eq!(chipset.device, 0x1f);
+    }
+
+    #[test]
+    fn test_find_intel_chipset_in_devices_rejects_multiple_matches() {
+        let devices = [
+            pci_device(INTEL_VID, 0x0f1c, 0),
+            pci_device(INTEL_VID, 0x1c44, 0),
+        ];
+        let err = find_intel_chipset_in_devices(&devices).unwrap_err();
+        assert!(matches!(err, InternalError::MultipleChipsets));
+    }
+
+    #[test]
+    fn test_find_amd_chipset_in_devices_detects_revision_match() {
+        let devices = [pci_device(AMD_VID, 0x790b, 0x51)];
+        let chipset = find_amd_chipset_in_devices(&devices).unwrap().unwrap();
+        assert_eq!(chipset.enable.vendor_id, AMD_VID);
+        assert_eq!(chipset.enable.device_id, 0x790b);
+        assert_eq!(chipset.revision_id, 0x51);
+    }
 }

--- a/crates/rflasher-internal/src/physmap.rs
+++ b/crates/rflasher-internal/src/physmap.rs
@@ -1,48 +1,38 @@
-//! Physical memory mapping for MMIO access
+//! Physical memory mapping for MMIO access.
 //!
-//! This module provides safe wrappers around physical memory mapping
-//! using /dev/mem on Linux. This is required to access the SPI controller
-//! registers in the chipset.
-//!
-//! # Safety
-//!
-//! Accessing physical memory is inherently unsafe and requires root privileges.
-//! The mapping functions ensure proper alignment and size constraints.
+//! Linux userspace maps controller registers through `/dev/mem`. Firmware
+//! builds use direct physical-address MMIO and rely on the caller/platform to
+//! have installed suitable mappings and memory attributes.
 
 use crate::error::InternalError;
 
-/// A mapped region of physical memory
-#[cfg(all(feature = "std", target_os = "linux"))]
+/// A mapped region of physical memory.
 pub struct PhysMap {
-    /// Pointer to the mapped memory
+    /// Pointer to the mapped memory.
     ptr: *mut u8,
-    /// Size of the mapping
+    /// Requested window size.
     size: usize,
-    /// Physical address (for error reporting)
+    /// Actual mapped size, after host page alignment.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    map_size: usize,
+    /// Physical address, for reporting and Linux unmapping.
     phys_addr: u64,
 }
 
-#[cfg(all(feature = "std", target_os = "linux"))]
 impl PhysMap {
-    /// Map a region of physical memory for MMIO access
-    ///
-    /// # Arguments
-    ///
-    /// * `phys_addr` - Physical address to map
-    /// * `size` - Size of the region to map
+    /// Maps a physical MMIO range on Linux through `/dev/mem`.
     ///
     /// # Safety
     ///
-    /// The caller must ensure that:
-    /// - The physical address range is valid and safe to access
-    /// - No other code is accessing the same region
-    /// - The region corresponds to MMIO registers (not RAM)
-    pub fn new(phys_addr: u64, size: usize) -> Result<Self, InternalError> {
+    /// The caller must ensure that the requested physical range is a valid
+    /// MMIO window and that accessing it with volatile loads/stores will not
+    /// violate platform memory attributes or device ownership rules.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    pub unsafe fn new(phys_addr: u64, size: usize) -> Result<Self, InternalError> {
         use std::fs::OpenOptions;
         use std::os::unix::fs::OpenOptionsExt;
         use std::os::unix::io::AsRawFd;
 
-        // Open /dev/mem with O_SYNC for uncached access (required for MMIO)
         let file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -53,17 +43,16 @@ impl PhysMap {
                 size,
             })?;
 
-        // Calculate page-aligned address and offset
+        // SAFETY: sysconf is thread-safe and does not touch Rust-managed memory.
         let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
         let page_mask = page_size - 1;
         let offset = (phys_addr as usize) & page_mask;
         let aligned_addr = phys_addr & !(page_mask as u64);
         let aligned_size = size + offset;
-
-        // Round up size to page boundary
         let map_size = (aligned_size + page_mask) & !page_mask;
 
-        // mmap the region
+        // SAFETY: arguments are derived from the requested physical range; the
+        // caller is responsible for only mapping valid MMIO.
         let ptr = unsafe {
             libc::mmap(
                 std::ptr::null_mut(),
@@ -82,98 +71,134 @@ impl PhysMap {
             });
         }
 
-        // Adjust pointer to account for page alignment offset
+        // SAFETY: `offset` is within the mapped page-aligned range.
         let adjusted_ptr = unsafe { (ptr as *mut u8).add(offset) };
 
         Ok(Self {
             ptr: adjusted_ptr,
-            size: map_size,
+            size,
+            map_size,
             phys_addr,
         })
     }
 
-    /// Read an 8-bit value from the mapped region
+    /// Uses direct physical-address MMIO for firmware/embedded builds.
     ///
     /// # Safety
     ///
-    /// The offset must be within the mapped region.
+    /// The caller must ensure this physical range is valid, already mapped
+    /// with suitable device memory attributes, and exclusively owned for the
+    /// volatile accesses performed through this object.
+    #[cfg(not(feature = "std"))]
+    pub unsafe fn new(phys_addr: u64, size: usize) -> Result<Self, InternalError> {
+        if phys_addr == 0 || size == 0 {
+            return Err(InternalError::MemoryMap {
+                address: phys_addr,
+                size,
+            });
+        }
+
+        Ok(Self {
+            ptr: phys_addr as *mut u8,
+            size,
+            phys_addr,
+        })
+    }
+
+    /// Reports unsupported physical mapping on non-Linux std targets.
+    ///
+    /// # Safety
+    ///
+    /// This target does not create a mapping, but the constructor is unsafe to
+    /// keep the API consistent with targets that do.
+    #[cfg(all(feature = "std", not(target_os = "linux")))]
+    pub unsafe fn new(phys_addr: u64, size: usize) -> Result<Self, InternalError> {
+        let _ = (phys_addr, size);
+        Err(InternalError::NotSupported(
+            "Physical memory mapping not available on this target",
+        ))
+    }
+
+    /// Reads an 8-bit value from the mapped region.
     #[inline(always)]
     pub fn read8(&self, offset: usize) -> u8 {
-        debug_assert!(offset < self.size);
+        assert!(offset < self.size, "8-bit MMIO read out of range");
+        // SAFETY: `ptr` points at a valid MMIO window for this mapping.
         unsafe { core::ptr::read_volatile(self.ptr.add(offset)) }
     }
 
-    /// Read a 16-bit value from the mapped region
-    ///
-    /// # Safety
-    ///
-    /// The offset must be within the mapped region and properly aligned.
+    /// Reads a 16-bit value from the mapped region.
     #[inline(always)]
     pub fn read16(&self, offset: usize) -> u16 {
-        debug_assert!(offset + 2 <= self.size);
-        debug_assert!(offset & 1 == 0, "unaligned 16-bit read");
+        assert!(
+            offset <= self.size.saturating_sub(2),
+            "16-bit MMIO read out of range"
+        );
+        assert!(offset & 1 == 0, "unaligned 16-bit MMIO read");
+        // SAFETY: bounds/alignment are checked above; MMIO validity is a
+        // constructor invariant.
         unsafe { core::ptr::read_volatile(self.ptr.add(offset) as *const u16) }
     }
 
-    /// Read a 32-bit value from the mapped region
-    ///
-    /// # Safety
-    ///
-    /// The offset must be within the mapped region and properly aligned.
+    /// Reads a 32-bit value from the mapped region.
     #[inline(always)]
     pub fn read32(&self, offset: usize) -> u32 {
-        debug_assert!(offset + 4 <= self.size);
-        debug_assert!(offset & 3 == 0, "unaligned 32-bit read");
+        assert!(
+            offset <= self.size.saturating_sub(4),
+            "32-bit MMIO read out of range"
+        );
+        assert!(offset & 3 == 0, "unaligned 32-bit MMIO read");
+        // SAFETY: bounds/alignment are checked above; MMIO validity is a
+        // constructor invariant.
         unsafe { core::ptr::read_volatile(self.ptr.add(offset) as *const u32) }
     }
 
-    /// Write an 8-bit value to the mapped region
-    ///
-    /// # Safety
-    ///
-    /// The offset must be within the mapped region.
+    /// Writes an 8-bit value to the mapped region.
     #[inline(always)]
     pub fn write8(&self, offset: usize, value: u8) {
-        debug_assert!(offset < self.size);
+        assert!(offset < self.size, "8-bit MMIO write out of range");
+        // SAFETY: `ptr` points at a valid MMIO window for this mapping.
         unsafe {
             core::ptr::write_volatile(self.ptr.add(offset), value);
         }
     }
 
-    /// Write a 16-bit value to the mapped region
-    ///
-    /// # Safety
-    ///
-    /// The offset must be within the mapped region and properly aligned.
+    /// Writes a 16-bit value to the mapped region.
     #[inline(always)]
     pub fn write16(&self, offset: usize, value: u16) {
-        debug_assert!(offset + 2 <= self.size);
-        debug_assert!(offset & 1 == 0, "unaligned 16-bit write");
+        assert!(
+            offset <= self.size.saturating_sub(2),
+            "16-bit MMIO write out of range"
+        );
+        assert!(offset & 1 == 0, "unaligned 16-bit MMIO write");
+        // SAFETY: bounds/alignment are checked above; MMIO validity is a
+        // constructor invariant.
         unsafe {
             core::ptr::write_volatile(self.ptr.add(offset) as *mut u16, value);
         }
     }
 
-    /// Write a 32-bit value to the mapped region
-    ///
-    /// # Safety
-    ///
-    /// The offset must be within the mapped region and properly aligned.
+    /// Writes a 32-bit value to the mapped region.
     #[inline(always)]
     pub fn write32(&self, offset: usize, value: u32) {
-        debug_assert!(offset + 4 <= self.size);
-        debug_assert!(offset & 3 == 0, "unaligned 32-bit write");
+        assert!(
+            offset <= self.size.saturating_sub(4),
+            "32-bit MMIO write out of range"
+        );
+        assert!(offset & 3 == 0, "unaligned 32-bit MMIO write");
+        // SAFETY: bounds/alignment are checked above; MMIO validity is a
+        // constructor invariant.
         unsafe {
             core::ptr::write_volatile(self.ptr.add(offset) as *mut u32, value);
         }
     }
 
-    /// Get the physical address of this mapping
+    /// Returns the physical address of this mapping.
     pub fn phys_addr(&self) -> u64 {
         self.phys_addr
     }
 
-    /// Get the size of this mapping
+    /// Returns the size of this mapping.
     pub fn size(&self) -> usize {
         self.size
     }
@@ -182,65 +207,57 @@ impl PhysMap {
 #[cfg(all(feature = "std", target_os = "linux"))]
 impl Drop for PhysMap {
     fn drop(&mut self) {
-        // Calculate the original mmap pointer (before offset adjustment)
+        // SAFETY: sysconf is thread-safe and does not touch Rust-managed memory.
         let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
         let page_mask = page_size - 1;
         let offset = (self.phys_addr as usize) & page_mask;
+        // SAFETY: `ptr` was adjusted by exactly this offset in `new`.
         let original_ptr = unsafe { self.ptr.sub(offset) };
 
+        // SAFETY: this unmaps the same range created by mmap in `new`.
         unsafe {
-            libc::munmap(original_ptr as *mut libc::c_void, self.size);
+            libc::munmap(original_ptr as *mut libc::c_void, self.map_size);
         }
     }
 }
 
-// Send + Sync are safe because we're accessing MMIO registers which
-// don't have the usual memory aliasing concerns
-#[cfg(all(feature = "std", target_os = "linux"))]
+// Send + Sync are safe because these pointers refer to MMIO registers, not
+// Rust-owned memory. Hardware/register-level synchronization is the caller's
+// responsibility.
 unsafe impl Send for PhysMap {}
-#[cfg(all(feature = "std", target_os = "linux"))]
 unsafe impl Sync for PhysMap {}
 
-// Stub for non-Linux platforms
-#[cfg(not(all(feature = "std", target_os = "linux")))]
-pub struct PhysMap {
-    _private: (),
-}
-
-#[cfg(not(all(feature = "std", target_os = "linux")))]
-impl PhysMap {
-    pub fn new(phys_addr: u64, size: usize) -> Result<Self, InternalError> {
-        Err(InternalError::NotSupported(
-            "Physical memory mapping only supported on Linux",
-        ))
+impl crate::host::MmioAccess for PhysMap {
+    fn read8(&self, offset: usize) -> u8 {
+        self.read8(offset)
     }
 
-    pub fn read8(&self, _offset: usize) -> u8 {
-        0
+    fn read16(&self, offset: usize) -> u16 {
+        self.read16(offset)
     }
-    pub fn read16(&self, _offset: usize) -> u16 {
-        0
+
+    fn read32(&self, offset: usize) -> u32 {
+        self.read32(offset)
     }
-    pub fn read32(&self, _offset: usize) -> u32 {
-        0
+
+    fn write8(&self, offset: usize, value: u8) {
+        self.write8(offset, value);
     }
-    pub fn write8(&self, _offset: usize, _value: u8) {}
-    pub fn write16(&self, _offset: usize, _value: u16) {}
-    pub fn write32(&self, _offset: usize, _value: u32) {}
-    pub fn phys_addr(&self) -> u64 {
-        0
+
+    fn write16(&self, offset: usize, value: u16) {
+        self.write16(offset, value);
     }
-    pub fn size(&self) -> usize {
-        0
+
+    fn write32(&self, offset: usize, value: u32) {
+        self.write32(offset, value);
     }
 }
 
 #[cfg(test)]
 mod tests {
     #[test]
-    #[ignore] // Requires root and /dev/mem access
+    #[ignore]
     fn test_physmap_create() {
-        // This test would need to map a safe address
-        // For now, just verify the struct compiles
+        // Requires root and /dev/mem on Linux or a mapped MMIO address in firmware.
     }
 }

--- a/crates/rflasher-internal/src/programmer.rs
+++ b/crates/rflasher-internal/src/programmer.rs
@@ -4,9 +4,12 @@
 //! the low-level controllers (Intel ICH/PCH or AMD SPI100) and implements
 //! the appropriate trait (SpiMaster or OpaqueMaster).
 
-use crate::amd_enable::enable_amd_spi100;
+#![cfg_attr(not(all(feature = "std", target_os = "linux")), allow(unused_imports))]
+
+use crate::amd_enable::enable_amd_spi100_with_host;
 use crate::controller::Controller;
 use crate::error::InternalError;
+use crate::host::{Bdf, DefaultPciAccess};
 use crate::ichspi::{IchSpiController, SpiMode};
 use crate::{AnyDetectedChipset, DetectedAmdChipset, DetectedChipset};
 
@@ -118,11 +121,16 @@ impl InternalProgrammer {
         chipset: &DetectedAmdChipset,
         _options: InternalOptions,
     ) -> Result<Self, InternalError> {
-        // Enable the AMD SPI100 controller
-        let info = enable_amd_spi100(
+        // Enable the AMD SPI100 controller using the detected PCI segment.
+        let info = enable_amd_spi100_with_host(
+            &DefaultPciAccess,
             chipset.enable,
-            chipset.bus,
-            chipset.device,
+            Bdf::with_segment(
+                chipset.domain,
+                chipset.bus,
+                chipset.device,
+                chipset.function,
+            ),
             chipset.revision_id,
         )?;
 
@@ -159,34 +167,12 @@ impl InternalProgrammer {
     ///
     /// Returns SoftwareSequencing for AMD controllers
     pub fn mode(&self) -> SpiMode {
-        self.intel_controller()
-            .map(|c| c.mode())
-            .unwrap_or(SpiMode::SoftwareSequencing)
+        self.controller.spi_mode()
     }
 
     /// Check if writes are enabled (internal helper)
     fn writes_enabled(&self) -> bool {
         self.controller.writes_enabled()
-    }
-
-    /// Check if this is an Intel controller (internal helper)
-    fn is_intel(&self) -> bool {
-        self.controller.controller_name() == "Intel ICH/PCH"
-    }
-
-    /// Get a reference to the underlying Intel controller (internal helper)
-    ///
-    /// Returns None for AMD controllers.
-    fn intel_controller(&self) -> Option<&IchSpiController> {
-        // SAFETY: We use controller_name to determine the type
-        if self.is_intel() {
-            // Downcast the trait object to the concrete type
-            let controller_ptr = &*self.controller as *const dyn Controller;
-            let intel_ptr = controller_ptr as *const IchSpiController;
-            unsafe { Some(&*intel_ptr) }
-        } else {
-            None
-        }
     }
 }
 
@@ -287,7 +273,7 @@ impl InternalProgrammer {
     }
 }
 
-#[cfg(not(all(feature = "std", target_os = "linux")))]
+#[cfg(all(feature = "is_sync", not(all(feature = "std", target_os = "linux"))))]
 impl OpaqueMaster for InternalProgrammer {
     fn size(&self) -> usize {
         0
@@ -306,7 +292,7 @@ impl OpaqueMaster for InternalProgrammer {
     }
 }
 
-#[cfg(not(all(feature = "std", target_os = "linux")))]
+#[cfg(all(feature = "is_sync", not(all(feature = "std", target_os = "linux"))))]
 impl SpiMaster for InternalProgrammer {
     fn features(&self) -> SpiFeatures {
         SpiFeatures::empty()


### PR DESCRIPTION
## Summary

Introduces a platform abstraction layer (`host.rs`) in `rflasher-internal` so that Intel ICH/PCH and AMD SPI100 controller logic can be compiled and tested independently of Linux userspace. Adds `embedded-host` and `linux-host` feature flags, CI checks for `x86_64-unknown-none` no-std builds, and unit tests exercising controller logic through a fake host implementation.

## Changes

**New `host.rs` abstraction module**
- Introduces `PciConfigAccess`, `MmioAccess`, and `HostAccess` traits to decouple controller logic from Linux-specific mechanisms (`/sys/bus/pci`, `/dev/mem`, `libc`, `std::thread::sleep`)
- Adds a segment-aware `Bdf` (Bus:Device.Function) type that replaces bare `(bus, device, function)` tuples and aligns with UEFI's segment-aware PCI access
- Implements `LinuxHost` backed by existing Linux sysfs/devmem code behind `linux-host` feature
- Adds `FakeHost` and `FakeMmio` test helpers for unit-testing controller logic without hardware or root

**Feature flag restructuring in `rflasher-internal`**
- New features: `linux-host` (implies `std`), `embedded-host` (implies `is_sync`), `alloc`, `is_sync`
- `libc` is now an optional dependency pulled in only by `linux-host`/`std`
- `default` includes `std`, `linux-host`, `alloc`, `is_sync` — no change in behavior for existing users

**Controller logic decoupled from Linux**
- `enable_amd_spi100_with_host<H: PciConfigAccess>` extracted as a platform-independent helper; the Linux `enable_amd_spi100` wrapper delegates to it via a `LinuxPci` adapter struct
- `get_spibar_address_with_host<H: PciConfigAccess>` extracted similarly from `ichspi.rs` for both PCH100+ hidden SPI function and legacy RCBA paths
- `SpiMode::parse` and `Display` impl migrated from `std::` to `core::` equivalents
- `AmdSpi100Info` and `DetectedChipset` gain a `domain: u16` field for PCI segment support

**Embedded-friendly PCI detection**
- `find_intel_chipset_in_devices` / `find_intel_chipset_in_iter` and AMD equivalents added to `pci.rs` — accept a caller-supplied device list instead of scanning Linux sysfs
- `PciAccessError` register field widened from `u8` to `u16` to support extended config space offsets

**CI**
- New `no-std` CI job checks `rflasher-core` and `rflasher-internal` against `x86_64-unknown-none` for bare-metal / UEFI firmware use cases

**Documentation**
- Adds `docs/crabefi-embedded-plan.md` describing the full roadmap for making `rflasher` usable from CrabEFI embedded firmware, including migration strategy and acceptance criteria