### PR TITLE
Prepare workspace for crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,15 +51,15 @@ default-members = [
 version = "0.1.0"
 edition = "2024"
 license = "GPL-2.0-or-later"
-repository = "https://github.com/user/rflasher"
+repository = "https://github.com/ArthurHeymans/rflasher"
 
 [workspace.dependencies]
 # Internal crates - NOTE: is_sync is NOT included here to allow async builds (WASM)
 # Crates that need sync mode should add `features = ["is_sync"]` explicitly
-rflasher-chip-types = { path = "crates/rflasher-chip-types", default-features = false }
-rflasher-core = { path = "crates/rflasher-core", default-features = false }
-rflasher-chips = { path = "crates/rflasher-chips" }
-rflasher-pci = { path = "crates/rflasher-pci", default-features = false }
+rflasher-chip-types = { version = "0.1.0", path = "crates/rflasher-chip-types", default-features = false }
+rflasher-core = { version = "0.1.0", path = "crates/rflasher-core", default-features = false }
+rflasher-chips = { version = "0.1.0", path = "crates/rflasher-chips" }
+rflasher-pci = { version = "0.1.0", path = "crates/rflasher-pci", default-features = false }
 
 # Core
 bitflags = "2"
@@ -94,6 +94,18 @@ name = "rflasher"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+description = "Command-line flash chip programming tool"
+readme = "README.md"
+exclude = [
+    "/.github",
+    "/.pi-lens",
+    "/docs",
+    "/firmware",
+    "/flake.*",
+    "/rflasher.png",
+    "/web",
+]
 
 [features]
 default = ["dummy", "ch341a", "ch347", "dediprog", "serprog", "ft4222", "ftdi", "linux-spi", "linux-mtd", "internal", "raiden", "sunxi-fel"]
@@ -130,8 +142,8 @@ portable-programmers = ["dummy", "ch341a", "ch347", "dediprog", "serprog", "ftdi
 [dependencies]
 rflasher-core = { workspace = true, features = ["std", "is_sync"] }
 rflasher-chips.workspace = true
-rflasher-flash = { path = "crates/rflasher-flash", features = ["std", "is_sync"] }
-rflasher-repl = { path = "crates/rflasher-repl", optional = true }
+rflasher-flash = { version = "0.1.0", path = "crates/rflasher-flash", features = ["std", "is_sync"] }
+rflasher-repl = { version = "0.1.0", path = "crates/rflasher-repl", optional = true }
 clap.workspace = true
 clap_mangen = "0.2"
 env_logger.workspace = true

--- a/crates/rflasher-ch341a/Cargo.toml
+++ b/crates/rflasher-ch341a/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-ch341a"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "CH341A USB programmer support for rflasher"
 
 [features]

--- a/crates/rflasher-ch347/Cargo.toml
+++ b/crates/rflasher-ch347/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-ch347"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "CH347 USB programmer support for rflasher"
 
 [features]

--- a/crates/rflasher-chip-types/Cargo.toml
+++ b/crates/rflasher-chip-types/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-chip-types"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Shared no_std SPI NOR flash chip data model"
 
 [features]

--- a/crates/rflasher-chips-codegen/Cargo.toml
+++ b/crates/rflasher-chips-codegen/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-chips-codegen"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Build-time code generator for flash chip database"
 
 [dependencies]

--- a/crates/rflasher-chips/Cargo.toml
+++ b/crates/rflasher-chips/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-chips"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Runtime and compiled flash chip database providers"
 
 [features]
@@ -19,4 +20,4 @@ ron.workspace = true
 once_cell = { workspace = true, features = ["std"] }
 
 [build-dependencies]
-rflasher-chips-codegen = { path = "../rflasher-chips-codegen", optional = true }
+rflasher-chips-codegen = { version = "0.1.0", path = "../rflasher-chips-codegen", optional = true }

--- a/crates/rflasher-core/Cargo.toml
+++ b/crates/rflasher-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Core library for flash chip programming (no_std compatible)"
 
 [features]

--- a/crates/rflasher-core/src/layout/fmap.rs
+++ b/crates/rflasher-core/src/layout/fmap.rs
@@ -4,7 +4,7 @@
 //! flash regions. The FMAP structure can be embedded anywhere in the
 //! flash image.
 //!
-//! Reference: flashprog/fmap.c and https://chromium.googlesource.com/chromiumos/platform/flashmap
+//! Reference: flashprog/fmap.c and <https://chromium.googlesource.com/chromiumos/platform/flashmap>
 
 use std::format;
 use std::string::{String, ToString};

--- a/crates/rflasher-core/src/sfdp/types.rs
+++ b/crates/rflasher-core/src/sfdp/types.rs
@@ -64,7 +64,7 @@ impl FastReadParams {
 
     /// Parse from DWORD half (instruction in high byte, mode/dummy in lower bits)
     ///
-    /// Layout: [31:24] instruction, [23:21] mode clocks, [20:16] dummy clocks
+    /// Layout: bits `31:24` instruction, `23:21` mode clocks, `20:16` dummy clocks
     pub fn from_high_half(dword: u32) -> Self {
         let opcode = ((dword >> 24) & 0xFF) as u8;
         let mode_clocks = ((dword >> 21) & 0x07) as u8;
@@ -79,7 +79,7 @@ impl FastReadParams {
 
     /// Parse from DWORD low half
     ///
-    /// Layout: [15:8] instruction, [7:5] mode clocks, [4:0] dummy clocks
+    /// Layout: bits `15:8` instruction, `7:5` mode clocks, `4:0` dummy clocks
     pub fn from_low_half(dword: u32) -> Self {
         let opcode = ((dword >> 8) & 0xFF) as u8;
         let mode_clocks = ((dword >> 5) & 0x07) as u8;
@@ -247,7 +247,7 @@ pub enum AddressMode {
 }
 
 impl AddressMode {
-    /// Parse from BFPT DWORD 1 bits [18:17]
+    /// Parse from BFPT DWORD 1 bits `18:17`
     pub fn from_bfpt(value: u8) -> Self {
         match value & 0x03 {
             0b00 => Self::ThreeByteOnly,
@@ -340,7 +340,7 @@ pub enum QuadEnableRequirement {
 }
 
 impl QuadEnableRequirement {
-    /// Parse from BFPT DWORD 15 bits [22:20]
+    /// Parse from BFPT DWORD 15 bits `22:20`
     pub fn from_bfpt(value: u8) -> Self {
         match value & 0x07 {
             0b000 => Self::None,
@@ -382,7 +382,7 @@ impl FourByteEntryMethods {
     /// Always operates in 4-byte mode
     pub const ALWAYS_4BYTE: u8 = 0x10;
 
-    /// Parse from BFPT DWORD 16 bits [31:24]
+    /// Parse from BFPT DWORD 16 bits `31:24`
     pub fn from_bfpt(value: u8) -> Self {
         Self { methods: value }
     }
@@ -417,7 +417,7 @@ impl SoftResetSupport {
     /// Exit 0-4-4 mode required before reset
     pub const EXIT_044_REQUIRED: u8 = 0x01;
 
-    /// Parse from BFPT DWORD 16 bits [13:8]
+    /// Parse from BFPT DWORD 16 bits `13:8`
     pub fn from_bfpt(value: u8) -> Self {
         Self {
             methods: value & 0x3F,

--- a/crates/rflasher-dediprog/Cargo.toml
+++ b/crates/rflasher-dediprog/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-dediprog"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Dediprog SF100/SF200/SF600/SF700 USB programmer support for rflasher"
 
 [features]

--- a/crates/rflasher-dummy/Cargo.toml
+++ b/crates/rflasher-dummy/Cargo.toml
@@ -3,12 +3,14 @@ name = "rflasher-dummy"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Dummy/emulator flash programmer for testing"
 
 [features]
 default = ["std"]
-std = ["rflasher-core/std", "alloc"]
+std = ["rflasher-core/std", "alloc", "is_sync"]
 alloc = ["rflasher-core/alloc"]
+is_sync = ["rflasher-core/is_sync"]
 
 [dependencies]
 rflasher-core.workspace = true

--- a/crates/rflasher-flash/Cargo.toml
+++ b/crates/rflasher-flash/Cargo.toml
@@ -1,26 +1,29 @@
 [package]
 name = "rflasher-flash"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Convenience facade for rflasher programmer backends"
 
 [dependencies]
-rflasher-core = { path = "../rflasher-core" }
+rflasher-core = { version = "0.1.0", path = "../rflasher-core" }
 log = "0.4"
 
 # Optional programmer dependencies
-rflasher-dummy = { path = "../rflasher-dummy", optional = true }
-rflasher-ch341a = { path = "../rflasher-ch341a", optional = true }
-rflasher-ch347 = { path = "../rflasher-ch347", optional = true }
-rflasher-dediprog = { path = "../rflasher-dediprog", optional = true }
-rflasher-serprog = { path = "../rflasher-serprog", optional = true }
-rflasher-ftdi = { path = "../rflasher-ftdi", optional = true, default-features = false }
-rflasher-ft4222 = { path = "../rflasher-ft4222", optional = true }
-rflasher-linux-spi = { path = "../rflasher-linux-spi", optional = true }
-rflasher-linux-mtd = { path = "../rflasher-linux-mtd", optional = true }
-rflasher-linux-gpio = { path = "../rflasher-linux-gpio", optional = true }
-rflasher-internal = { path = "../rflasher-internal", optional = true }
-rflasher-raiden = { path = "../rflasher-raiden", optional = true }
-rflasher-sunxi-fel = { path = "../rflasher-sunxi-fel", optional = true }
+rflasher-dummy = { version = "0.1.0", path = "../rflasher-dummy", optional = true }
+rflasher-ch341a = { version = "0.1.0", path = "../rflasher-ch341a", optional = true }
+rflasher-ch347 = { version = "0.1.0", path = "../rflasher-ch347", optional = true }
+rflasher-dediprog = { version = "0.1.0", path = "../rflasher-dediprog", optional = true }
+rflasher-serprog = { version = "0.1.0", path = "../rflasher-serprog", optional = true }
+rflasher-ftdi = { version = "0.1.0", path = "../rflasher-ftdi", optional = true, default-features = false }
+rflasher-ft4222 = { version = "0.1.0", path = "../rflasher-ft4222", optional = true }
+rflasher-linux-spi = { version = "0.1.0", path = "../rflasher-linux-spi", optional = true }
+rflasher-linux-mtd = { version = "0.1.0", path = "../rflasher-linux-mtd", optional = true }
+rflasher-linux-gpio = { version = "0.1.0", path = "../rflasher-linux-gpio", optional = true }
+rflasher-internal = { version = "0.1.0", path = "../rflasher-internal", optional = true }
+rflasher-raiden = { version = "0.1.0", path = "../rflasher-raiden", optional = true }
+rflasher-sunxi-fel = { version = "0.1.0", path = "../rflasher-sunxi-fel", optional = true }
 
 [features]
 default = ["std", "is_sync"]

--- a/crates/rflasher-ft4222/Cargo.toml
+++ b/crates/rflasher-ft4222/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-ft4222"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "FT4222H USB SPI programmer support for rflasher"
 
 [features]

--- a/crates/rflasher-ftdi/Cargo.toml
+++ b/crates/rflasher-ftdi/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-ftdi"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "FTDI MPSSE programmer support for rflasher"
 
 [features]

--- a/crates/rflasher-ftdi/src/device.rs
+++ b/crates/rflasher-ftdi/src/device.rs
@@ -359,7 +359,7 @@ impl std::fmt::Display for FtdiDeviceInfo {
 
 /// Parse programmer options from a string
 ///
-/// Format: "type=<type>,port=<A|B|C|D>,divisor=<N>,serial=<serial>,gpiol0=<H|L|C>"
+/// Format: `type=<type>,port=<A|B|C|D>,divisor=<N>,serial=<serial>,gpiol0=<H|L|C>`
 pub fn parse_options(options: &[(&str, &str)]) -> Result<FtdiConfig> {
     let mut config = FtdiConfig::default();
 

--- a/crates/rflasher-internal/Cargo.toml
+++ b/crates/rflasher-internal/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-internal"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Intel chipset internal flash programmer support for rflasher"
 
 [features]

--- a/crates/rflasher-linux-gpio/Cargo.toml
+++ b/crates/rflasher-linux-gpio/Cargo.toml
@@ -3,11 +3,13 @@ name = "rflasher-linux-gpio"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Linux GPIO bitbang SPI support for rflasher"
 
 [features]
 default = ["std"]
-std = ["rflasher-core/std"]
+std = ["rflasher-core/std", "is_sync"]
+is_sync = ["rflasher-core/is_sync"]
 
 [dependencies]
 rflasher-core.workspace = true

--- a/crates/rflasher-linux-mtd/Cargo.toml
+++ b/crates/rflasher-linux-mtd/Cargo.toml
@@ -3,11 +3,13 @@ name = "rflasher-linux-mtd"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Linux MTD (Memory Technology Device) support for rflasher"
 
 [features]
 default = ["std"]
-std = ["rflasher-core/std"]
+std = ["rflasher-core/std", "is_sync"]
+is_sync = ["rflasher-core/is_sync"]
 
 [dependencies]
 rflasher-core.workspace = true

--- a/crates/rflasher-linux-spi/Cargo.toml
+++ b/crates/rflasher-linux-spi/Cargo.toml
@@ -3,11 +3,13 @@ name = "rflasher-linux-spi"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Linux spidev support for rflasher"
 
 [features]
 default = ["std"]
-std = ["rflasher-core/std"]
+std = ["rflasher-core/std", "is_sync"]
+is_sync = ["rflasher-core/is_sync"]
 
 [dependencies]
 rflasher-core.workspace = true

--- a/crates/rflasher-pci/Cargo.toml
+++ b/crates/rflasher-pci/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-pci"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Pure-Rust PCI configuration-space access for rflasher"
 
 [features]

--- a/crates/rflasher-raiden/Cargo.toml
+++ b/crates/rflasher-raiden/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-raiden"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Raiden Debug SPI (Chrome OS EC USB) programmer support for rflasher"
 
 [features]

--- a/crates/rflasher-raiden/src/protocol.rs
+++ b/crates/rflasher-raiden/src/protocol.rs
@@ -4,7 +4,7 @@
 //! ChromiumOS EC USB SPI bridges (Raiden Debug SPI).
 //!
 //! The protocol is defined in the ChromiumOS EC repository:
-//! https://chromium.googlesource.com/chromiumos/platform/ec
+//! <https://chromium.googlesource.com/chromiumos/platform/ec>
 //! Files: chip/stm32/usb_spi.h and chip/stm32/usb_spi.c
 
 #![allow(dead_code)]

--- a/crates/rflasher-repl/Cargo.toml
+++ b/crates/rflasher-repl/Cargo.toml
@@ -3,10 +3,11 @@ name = "rflasher-repl"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Steel Scheme REPL for scripting raw SPI commands"
 
 [dependencies]
-rflasher-core = { workspace = true, features = ["std"] }
+rflasher-core = { workspace = true, features = ["std", "is_sync"] }
 steel-core = "0.7"
 steel-parser = "0.7"
 rustyline = { version = "14.0", features = ["derive"] }

--- a/crates/rflasher-serprog/Cargo.toml
+++ b/crates/rflasher-serprog/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-serprog"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Serial Flasher Protocol (serprog) support for rflasher"
 
 [features]

--- a/crates/rflasher-sunxi-fel/Cargo.toml
+++ b/crates/rflasher-sunxi-fel/Cargo.toml
@@ -3,6 +3,7 @@ name = "rflasher-sunxi-fel"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Allwinner sunxi FEL SPI NOR programmer support for rflasher"
 
 [features]

--- a/crates/rflasher-wasm/Cargo.toml
+++ b/crates/rflasher-wasm/Cargo.toml
@@ -3,7 +3,9 @@ name = "rflasher-wasm"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Web interface for rflasher using egui and WebSerial/WebUSB"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -14,15 +16,15 @@ default = []
 [dependencies]
 # Internal crates (async mode - explicitly NO is_sync feature)
 # We override the workspace dependency to ensure async mode for WASM
-rflasher-core = { path = "../rflasher-core", default-features = false, features = ["std", "alloc"] }
-rflasher-chips = { path = "../rflasher-chips", features = ["static-chips"] }
-rflasher-serprog = { path = "../rflasher-serprog", default-features = false, features = ["std", "wasm"] }
-rflasher-ch341a = { path = "../rflasher-ch341a", default-features = false, features = ["wasm"] }
-rflasher-ch347 = { path = "../rflasher-ch347", default-features = false, features = ["wasm"] }
-rflasher-ftdi = { path = "../rflasher-ftdi", default-features = false, features = ["wasm"] }
-rflasher-ft4222 = { path = "../rflasher-ft4222", default-features = false, features = ["wasm"] }
-rflasher-dediprog = { path = "../rflasher-dediprog", default-features = false, features = ["wasm"] }
-rflasher-raiden = { path = "../rflasher-raiden", default-features = false, features = ["wasm"] }
+rflasher-core = { version = "0.1.0", path = "../rflasher-core", default-features = false, features = ["std", "alloc"] }
+rflasher-chips = { version = "0.1.0", path = "../rflasher-chips", features = ["static-chips"] }
+rflasher-serprog = { version = "0.1.0", path = "../rflasher-serprog", default-features = false, features = ["std", "wasm"] }
+rflasher-ch341a = { version = "0.1.0", path = "../rflasher-ch341a", default-features = false, features = ["wasm"] }
+rflasher-ch347 = { version = "0.1.0", path = "../rflasher-ch347", default-features = false, features = ["wasm"] }
+rflasher-ftdi = { version = "0.1.0", path = "../rflasher-ftdi", default-features = false, features = ["wasm"] }
+rflasher-ft4222 = { version = "0.1.0", path = "../rflasher-ft4222", default-features = false, features = ["wasm"] }
+rflasher-dediprog = { version = "0.1.0", path = "../rflasher-dediprog", default-features = false, features = ["wasm"] }
+rflasher-raiden = { version = "0.1.0", path = "../rflasher-raiden", default-features = false, features = ["wasm"] }
 
 # GUI
 eframe = { version = "0.33", default-features = false, features = [


### PR DESCRIPTION
## Summary
- add crates.io package metadata and versioned internal path dependencies
- use publishable crates.io dependencies while keeping local WebUSB patches for wasm builds
- switch pure-Rust FTDI backend to the published `ftdi-nusb` crate name
- mark the wasm frontend as unpublished and exclude docs/web assets from the CLI package

## Validation
- `cargo fmt --check`
- `cargo check -p rflasher --all-features`
- `cargo check -p rflasher-wasm --target wasm32-unknown-unknown`
- `cargo test -p rflasher-core --lib`
- `cargo publish --dry-run -p rflasher-ftdi --allow-dirty --config patch.crates-io.rflasher-core.path="crates/rflasher-core"` verifies the default/non-wasm package path

## Notes
- No crates were published.
- The workspace keeps `[patch.crates-io]` overrides for local WASM support until the required WebUSB support is published upstream.
- Publishing the `wasm` feature of `rflasher-ftdi` still depends on a crates.io `ftdi-nusb` release that exposes its `wasm` feature; the default native package path is dry-run verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved inline code formatting and link presentation across technical documentation.
  - Added consistent package descriptions, repository information, README references, and publishing metadata.

- **Build and Configuration**
  - Standardized package versioning and internal dependency declarations.
  - Added synchronization support across applicable platform, hardware, and command-line components.
  - Improved consistency of default feature configurations across supported builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->