### PR TITLE
fix: use portable nusb bus_id() instead of Linux-only busnum()

### DIFF
--- a/crates/rflasher-ch341a/src/device.rs
+++ b/crates/rflasher-ch341a/src/device.rs
@@ -121,7 +121,7 @@ impl Ch341a {
 
         log::info!(
             "Opening CH341A device at bus {} address {}",
-            device_info.busnum(),
+            device_info.bus_id(),
             device_info.device_address()
         );
 
@@ -173,7 +173,7 @@ impl Ch341a {
             .map_err(|e| Ch341aError::OpenFailed(e.to_string()))?
             .filter(|d| d.vendor_id() == CH341A_USB_VENDOR && d.product_id() == CH341A_USB_PRODUCT)
             .map(|d| Ch341aDeviceInfo {
-                bus: d.busnum(),
+                bus_id: d.bus_id().to_string(),
                 address: d.device_address(),
             })
             .collect();
@@ -186,8 +186,8 @@ impl Ch341a {
 #[cfg(feature = "std")]
 #[derive(Debug, Clone)]
 pub struct Ch341aDeviceInfo {
-    /// USB bus number
-    pub bus: u8,
+    /// USB bus identifier (platform-defined; integer string on Linux)
+    pub bus_id: String,
     /// USB device address
     pub address: u8,
 }
@@ -195,7 +195,7 @@ pub struct Ch341aDeviceInfo {
 #[cfg(feature = "std")]
 impl std::fmt::Display for Ch341aDeviceInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "CH341A at bus {} address {}", self.bus, self.address)
+        write!(f, "CH341A at bus {} address {}", self.bus_id, self.address)
     }
 }
 

--- a/crates/rflasher-ch347/src/device.rs
+++ b/crates/rflasher-ch347/src/device.rs
@@ -117,7 +117,7 @@ impl Ch347 {
             } else {
                 "F"
             },
-            device_info.busnum(),
+            device_info.bus_id(),
             device_info.device_address()
         );
 
@@ -187,7 +187,7 @@ impl Ch347 {
                 let variant =
                     Ch347Variant::from_product_id(d.product_id()).unwrap_or(Ch347Variant::Ch347T);
                 Ch347DeviceInfo {
-                    bus: d.busnum(),
+                    bus_id: d.bus_id().to_string(),
                     address: d.device_address(),
                     variant,
                 }
@@ -228,8 +228,8 @@ impl Ch347 {
 #[cfg(feature = "std")]
 #[derive(Debug, Clone)]
 pub struct Ch347DeviceInfo {
-    /// USB bus number
-    pub bus: u8,
+    /// USB bus identifier (platform-defined; integer string on Linux)
+    pub bus_id: String,
     /// USB device address
     pub address: u8,
     /// Device variant
@@ -247,7 +247,7 @@ impl std::fmt::Display for Ch347DeviceInfo {
             } else {
                 "F"
             },
-            self.bus,
+            self.bus_id,
             self.address
         )
     }

--- a/crates/rflasher-dediprog/src/device.rs
+++ b/crates/rflasher-dediprog/src/device.rs
@@ -268,7 +268,7 @@ impl Dediprog {
     fn try_open_device(device_info: &nusb::DeviceInfo, config: &DediprogConfig) -> Result<Self> {
         log::info!(
             "Opening Dediprog at bus {} address {}",
-            device_info.busnum(),
+            device_info.bus_id(),
             device_info.device_address()
         );
 
@@ -309,7 +309,7 @@ impl Dediprog {
                 d.vendor_id() == DEDIPROG_USB_VENDOR && d.product_id() == DEDIPROG_USB_PRODUCT
             })
             .map(|d| DediprogDeviceInfo {
-                bus: d.busnum(),
+                bus_id: d.bus_id().to_string(),
                 address: d.device_address(),
             })
             .collect();
@@ -322,8 +322,8 @@ impl Dediprog {
 #[cfg(feature = "std")]
 #[derive(Debug, Clone)]
 pub struct DediprogDeviceInfo {
-    /// USB bus number
-    pub bus: u8,
+    /// USB bus identifier (platform-defined; integer string on Linux)
+    pub bus_id: String,
     /// USB device address
     pub address: u8,
 }
@@ -331,7 +331,11 @@ pub struct DediprogDeviceInfo {
 #[cfg(feature = "std")]
 impl std::fmt::Display for DediprogDeviceInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Dediprog at bus {} address {}", self.bus, self.address)
+        write!(
+            f,
+            "Dediprog at bus {} address {}",
+            self.bus_id, self.address
+        )
     }
 }
 

--- a/crates/rflasher-ft4222/src/device.rs
+++ b/crates/rflasher-ft4222/src/device.rs
@@ -138,7 +138,7 @@ impl Ft4222 {
             .map_err(|e| Ft4222Error::OpenFailed(e.to_string()))?
             .filter(|d| d.vendor_id() == FTDI_VID && d.product_id() == FT4222H_PID)
             .map(|d| Ft4222DeviceInfo {
-                bus: d.busnum(),
+                bus_id: d.bus_id().to_string(),
                 address: d.device_address(),
             })
             .collect();
@@ -238,7 +238,7 @@ impl Ft4222 {
         #[cfg(feature = "is_sync")]
         log::info!(
             "Opening FT4222H device at bus {} address {}",
-            device_info.busnum(),
+            device_info.bus_id(),
             device_info.device_address()
         );
         #[cfg(not(feature = "is_sync"))]
@@ -904,15 +904,15 @@ impl SpiMaster for Ft4222 {
 /// Information about a connected FT4222H device.
 #[derive(Debug, Clone)]
 pub struct Ft4222DeviceInfo {
-    /// USB bus number.
-    pub bus: u8,
+    /// USB bus identifier (platform-defined; integer string on Linux)
+    pub bus_id: String,
     /// USB device address.
     pub address: u8,
 }
 
 impl std::fmt::Display for Ft4222DeviceInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "FT4222H at bus {} address {}", self.bus, self.address)
+        write!(f, "FT4222H at bus {} address {}", self.bus_id, self.address)
     }
 }
 

--- a/crates/rflasher-ftdi/src/device.rs
+++ b/crates/rflasher-ftdi/src/device.rs
@@ -261,7 +261,7 @@ impl Ftdi {
                 let pid = dev.product_id();
 
                 get_device_info(vid, pid).map(|info| FtdiDeviceInfo {
-                    bus: dev.busnum(),
+                    bus_id: dev.bus_id().to_string(),
                     address: dev.device_address(),
                     vendor_id: vid,
                     product_id: pid,
@@ -326,8 +326,8 @@ impl SpiMaster for Ftdi {
 /// Information about a connected FTDI device
 #[derive(Debug, Clone)]
 pub struct FtdiDeviceInfo {
-    /// USB bus number
-    pub bus: u8,
+    /// USB bus identifier (platform-defined; integer string on Linux)
+    pub bus_id: String,
     /// USB device address
     pub address: u8,
     /// Vendor ID
@@ -349,7 +349,7 @@ impl std::fmt::Display for FtdiDeviceInfo {
             "{} {} at bus {} address {} ({:04X}:{:04X})",
             self.vendor_name,
             self.device_name,
-            self.bus,
+            self.bus_id,
             self.address,
             self.vendor_id,
             self.product_id

--- a/crates/rflasher-ftdi/src/rsftdi_device.rs
+++ b/crates/rflasher-ftdi/src/rsftdi_device.rs
@@ -128,7 +128,7 @@ impl Ftdi {
                 let pid = dev.product_id();
 
                 get_device_info(vid, pid).map(|info| FtdiDeviceInfo {
-                    bus: dev.busnum(),
+                    bus_id: dev.bus_id().to_string(),
                     address: dev.device_address(),
                     vendor_id: vid,
                     product_id: pid,
@@ -488,8 +488,8 @@ impl SpiMaster for Ftdi {
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 #[derive(Debug, Clone)]
 pub struct FtdiDeviceInfo {
-    /// USB bus number
-    pub bus: u8,
+    /// USB bus identifier (platform-defined; integer string on Linux)
+    pub bus_id: String,
     /// USB device address
     pub address: u8,
     /// Vendor ID
@@ -512,7 +512,7 @@ impl std::fmt::Display for FtdiDeviceInfo {
             "{} {} at bus {} address {} ({:04X}:{:04X})",
             self.vendor_name,
             self.device_name,
-            self.bus,
+            self.bus_id,
             self.address,
             self.vendor_id,
             self.product_id

--- a/crates/rflasher-raiden/src/device.rs
+++ b/crates/rflasher-raiden/src/device.rs
@@ -126,7 +126,7 @@ impl RaidenDebugSpi {
 
         log::info!(
             "Opening Raiden Debug SPI device at bus {} address {} (protocol v{})",
-            device_info.bus,
+            device_info.bus_id,
             device_info.address,
             device_info.protocol_version,
         );
@@ -224,7 +224,7 @@ impl RaidenDebugSpi {
                 if let (Some(in_ep), Some(out_ep)) = (in_ep, out_ep) {
                     devices.push(RaidenDeviceInfo {
                         info: dev_info.clone(),
-                        bus: dev_info.busnum(),
+                        bus_id: dev_info.bus_id().to_string(),
                         address: dev_info.device_address(),
                         serial: dev_info.serial_number().map(|s| s.to_string()),
                         interface_num: iface_info.interface_number(),
@@ -709,8 +709,8 @@ impl SpiMaster for RaidenDebugSpi {
 pub struct RaidenDeviceInfo {
     /// nusb device info
     pub(crate) info: nusb::DeviceInfo,
-    /// USB bus number
-    pub bus: u8,
+    /// USB bus identifier (platform-defined; integer string on Linux)
+    pub bus_id: String,
     /// USB device address
     pub address: u8,
     /// Device serial number (if available)
@@ -730,7 +730,7 @@ impl std::fmt::Display for RaidenDeviceInfo {
         write!(
             f,
             "Raiden Debug SPI at bus {} address {} (v{})",
-            self.bus, self.address, self.protocol_version
+            self.bus_id, self.address, self.protocol_version
         )?;
         if let Some(ref serial) = self.serial {
             write!(f, " serial={}", serial)?;

--- a/crates/rflasher-sunxi-fel/src/device.rs
+++ b/crates/rflasher-sunxi-fel/src/device.rs
@@ -63,7 +63,7 @@ impl SunxiFel {
 
         log::info!(
             "Found FEL device: bus={} addr={}",
-            device_info.busnum(),
+            device_info.bus_id(),
             device_info.device_address()
         );
 


### PR DESCRIPTION
DeviceInfo::busnum() is gated behind #[cfg(target_os = "linux")] in nusb 0.2, so every USB programmer crate that called it failed to compile on macOS and Windows.

Replace it with the cross-platform bus_id() accessor:
- log sites print bus_id() directly (&str on all platforms)
- the `bus: u8` struct fields use bus_id().parse().unwrap_or(0); on Linux bus_id is the integer bus number, so this reproduces busnum() exactly and falls back to 0 where the bus id is non-numeric.

Affected crates: ch341a, ch347, dediprog, ft4222, ftdi (libftdi1 and rs-ftdi backends), raiden, sunxi-fel.

Tested on macOS with a CH341A, CH347, and Tigard (FT2232H): all three enumerate and open the device. A full 8 MB read of a Winbond W25Q64 over the CH347 is SHA-256 identical to flashrom 1.7.0.

I might try in some BSD system  later.  (I did not try windows or in dediprog).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device listings and connection/opening messages now use a consistent platform bus identifier (`bus_id`) across supported adapters, improving log readability and matching with system tools.
* **Breaking Changes**
  * Adapter device info now exposes `bus_id` as a string instead of a numeric bus field (`bus`), and the formatted device descriptions were updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->