### PR TITLE
Add portable programmer build feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,22 @@ jobs:
       - name: Build
         run: cargo build --workspace --exclude rflasher-wasm --all-features --release
 
+  build-portable:
+    name: Build portable (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build portable programmers
+        run: cargo build -p rflasher --no-default-features --features portable-programmers --release
+
   no-std:
     name: no_std embedded checks
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,10 @@ all-programmers = ["dummy", "ch341a", "ch347", "dediprog", "serprog", "ftdi", "f
 # Enable all programmers with pure-Rust FTDI backend
 all-programmers-native = ["dummy", "ch341a", "ch347", "dediprog", "serprog", "ftdi-native", "ft4222", "linux-spi", "linux-mtd", "linux-gpio", "internal", "raiden", "sunxi-fel"]
 
+# Cross-platform desktop programmers: nusb-backed USB programmers plus serprog and dummy.
+# Excludes Linux-only devices and the Linux userspace internal chipset backend.
+portable-programmers = ["dummy", "ch341a", "ch347", "dediprog", "serprog", "ftdi-native", "ft4222", "raiden", "sunxi-fel"]
+
 [dependencies]
 rflasher-core = { workspace = true, features = ["std", "is_sync"] }
 rflasher-flash = { path = "crates/rflasher-flash", features = ["std", "is_sync"] }

--- a/crates/rflasher-flash/Cargo.toml
+++ b/crates/rflasher-flash/Cargo.toml
@@ -13,7 +13,7 @@ rflasher-ch341a = { path = "../rflasher-ch341a", optional = true }
 rflasher-ch347 = { path = "../rflasher-ch347", optional = true }
 rflasher-dediprog = { path = "../rflasher-dediprog", optional = true }
 rflasher-serprog = { path = "../rflasher-serprog", optional = true }
-rflasher-ftdi = { path = "../rflasher-ftdi", optional = true }
+rflasher-ftdi = { path = "../rflasher-ftdi", optional = true, default-features = false }
 rflasher-ft4222 = { path = "../rflasher-ft4222", optional = true }
 rflasher-linux-spi = { path = "../rflasher-linux-spi", optional = true }
 rflasher-linux-mtd = { path = "../rflasher-linux-mtd", optional = true }
@@ -35,7 +35,7 @@ ch341a = ["dep:rflasher-ch341a"]
 ch347 = ["dep:rflasher-ch347"]
 dediprog = ["dep:rflasher-dediprog"]
 serprog = ["dep:rflasher-serprog"]
-ftdi = ["dep:rflasher-ftdi"]
+ftdi = ["dep:rflasher-ftdi", "rflasher-ftdi/std"]
 # Use pure-Rust rs-ftdi backend for FTDI MPSSE (instead of C libftdi1)
 ftdi-native = ["dep:rflasher-ftdi", "rflasher-ftdi/native"]
 ft4222 = ["dep:rflasher-ft4222"]
@@ -45,3 +45,7 @@ linux-gpio = ["dep:rflasher-linux-gpio"]
 internal = ["dep:rflasher-internal"]
 raiden = ["dep:rflasher-raiden"]
 sunxi-fel = ["dep:rflasher-sunxi-fel"]
+
+# Cross-platform desktop programmers: nusb-backed USB programmers plus serprog and dummy.
+# Excludes Linux-only devices and the Linux userspace internal chipset backend.
+portable-programmers = ["std", "is_sync", "dummy", "ch341a", "ch347", "dediprog", "serprog", "ftdi-native", "ft4222", "raiden", "sunxi-fel"]

--- a/crates/rflasher-flash/src/handle.rs
+++ b/crates/rflasher-flash/src/handle.rs
@@ -93,6 +93,7 @@ impl FlashHandle {
     }
 
     /// Create a new handle without chip information (opaque programmers)
+    #[cfg(any(feature = "linux-mtd", feature = "internal"))]
     pub(crate) fn without_chip_info(device: Box<dyn FlashDevice>) -> Self {
         Self {
             device,

--- a/crates/rflasher-flash/src/registry.rs
+++ b/crates/rflasher-flash/src/registry.rs
@@ -7,10 +7,12 @@ use crate::handle::{ChipInfo, FlashHandle};
 use rflasher_core::chip::ChipDatabase;
 #[allow(unused_imports)] // Used in feature-gated code
 use rflasher_core::flash::FlashDevice;
-use rflasher_core::flash::{
-    HybridFlashDevice, OpaqueFlashDevice, ProbeResult, SpiFlashDevice, probe_detailed,
-};
+#[cfg(any(feature = "linux-mtd", feature = "internal"))]
+use rflasher_core::flash::OpaqueFlashDevice;
+use rflasher_core::flash::{HybridFlashDevice, ProbeResult, SpiFlashDevice, probe_detailed};
+#[cfg(feature = "internal")]
 use rflasher_core::layout::parse_ifd;
+#[cfg(feature = "internal")]
 use rflasher_core::programmer::OpaqueMaster;
 use rflasher_core::sfdp::SfdpMismatch;
 use std::collections::HashMap;
@@ -303,7 +305,7 @@ pub fn open_spi_programmer(programmer: &str) -> Result<BoxedSpiMaster, Box<dyn s
             }
         }
 
-        #[cfg(feature = "ftdi")]
+        #[cfg(any(feature = "ftdi", feature = "ftdi-native"))]
         "ftdi" | "ft2232_spi" | "ft4232_spi" => {
             use rflasher_ftdi::{parse_options, Ftdi};
             log::info!("Opening FTDI programmer for REPL...");
@@ -439,7 +441,7 @@ pub fn open_flash(
         #[cfg(feature = "serprog")]
         "serprog" => open_serprog(&params, db),
 
-        #[cfg(feature = "ftdi")]
+        #[cfg(any(feature = "ftdi", feature = "ftdi-native"))]
         "ftdi" | "ft2232_spi" | "ft4232_spi" => open_ftdi(&params, db),
 
         #[cfg(feature = "ft4222")]
@@ -470,6 +472,7 @@ pub fn open_flash(
 }
 
 // Helper to get flash size from IFD for opaque programmers
+#[cfg(feature = "internal")]
 fn get_flash_size_from_ifd(
     master: &mut dyn OpaqueMaster,
 ) -> Result<u32, Box<dyn std::error::Error>> {
@@ -665,7 +668,7 @@ fn open_serprog(
     }
 }
 
-#[cfg(feature = "ftdi")]
+#[cfg(any(feature = "ftdi", feature = "ftdi-native"))]
 fn open_ftdi(
     params: &ProgrammerParams,
     db: &ChipDatabase,
@@ -965,7 +968,7 @@ pub fn available_programmers() -> Vec<ProgrammerInfo> {
             "Serial Flasher Protocol over serial/network (dev=<port>,ip=<host:port>,spispeed=<khz>)",
     });
 
-    #[cfg(feature = "ftdi")]
+    #[cfg(any(feature = "ftdi", feature = "ftdi-native"))]
     programmers.push(ProgrammerInfo {
         name: "ftdi",
         aliases: &["ft2232_spi", "ft4232_spi"],

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -31,7 +31,7 @@ pub fn list_programmers() {
         feature = "dummy",
         feature = "ch341a",
         feature = "serprog",
-        feature = "ftdi",
+        any(feature = "ftdi", feature = "ftdi-native"),
         feature = "linux-spi",
         feature = "internal"
     )))]


### PR DESCRIPTION
Build it in CI on Windows and macOS, and allow FTDI support to be
compiled through the native backend without enabling libftdi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new portable build option for desktop platforms, enabling cross-platform flashing with a curated set of devices.
  * Expanded CI to produce portable release builds on Windows and macOS.

* **Bug Fixes**
  * Improved FTDI programmer detection so FTDI support is recognized across more build configurations.
  * Refined the “programmers may be disabled at compile time” message to account for FTDI native builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->