### PR TITLE
Extract PCI access into rflasher-pci crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -211,6 +211,12 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -700,7 +706,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1000,7 +1006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2514,6 +2520,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pci_types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c2a105c657261a938ff68ee231c199a3d80eef33976004829de761ef5b1a9b"
+dependencies = [
+ "bit_field",
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3071,6 +3087,7 @@ dependencies = [
  "libc",
  "log",
  "rflasher-core",
+ "rflasher-pci",
  "thiserror 2.0.17",
 ]
 
@@ -3104,6 +3121,14 @@ dependencies = [
  "nix 0.29.0",
  "rflasher-core",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "rflasher-pci"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "pci_types",
 ]
 
 [[package]]
@@ -3231,7 +3256,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4151,7 +4176,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/rflasher-ftdi",
     "crates/rflasher-ft4222",
     "crates/rflasher-internal",
+    "crates/rflasher-pci",
     "crates/rflasher-linux-spi",
     "crates/rflasher-linux-mtd",
     "crates/rflasher-linux-gpio",
@@ -36,6 +37,7 @@ default-members = [
     "crates/rflasher-ftdi",
     "crates/rflasher-ft4222",
     "crates/rflasher-internal",
+    "crates/rflasher-pci",
     "crates/rflasher-linux-spi",
     "crates/rflasher-linux-mtd",
     "crates/rflasher-linux-gpio",
@@ -57,6 +59,7 @@ repository = "https://github.com/user/rflasher"
 rflasher-chip-types = { path = "crates/rflasher-chip-types", default-features = false }
 rflasher-core = { path = "crates/rflasher-core", default-features = false }
 rflasher-chips = { path = "crates/rflasher-chips" }
+rflasher-pci = { path = "crates/rflasher-pci", default-features = false }
 
 # Core
 bitflags = "2"

--- a/crates/rflasher-internal/Cargo.toml
+++ b/crates/rflasher-internal/Cargo.toml
@@ -7,12 +7,13 @@ description = "Intel chipset internal flash programmer support for rflasher"
 
 [features]
 default = ["std"]
-std = ["alloc", "is_sync", "rflasher-core/std", "dep:thiserror", "dep:libc"]
+std = ["alloc", "is_sync", "rflasher-core/std", "rflasher-pci/std", "dep:thiserror", "dep:libc"]
 alloc = ["rflasher-core/alloc"]
 is_sync = ["rflasher-core/is_sync"]
 
 [dependencies]
 rflasher-core.workspace = true
+rflasher-pci.workspace = true
 log.workspace = true
 thiserror = { workspace = true, optional = true }
 libc = { version = "0.2", optional = true }

--- a/crates/rflasher-internal/src/amd_enable.rs
+++ b/crates/rflasher-internal/src/amd_enable.rs
@@ -10,7 +10,7 @@ use crate::error::InternalError;
 use crate::host::DefaultPciAccess;
 #[cfg(all(feature = "std", target_os = "linux"))]
 use crate::host::LinuxHost;
-use crate::host::{Bdf, HostAccess, PciConfigAccess};
+use crate::host::{HostAccess, PciAddress, PciConfigAccess};
 
 /// PCI register offset for SPI BAR in AMD FCH LPC device
 const AMD_SPI_BAR_OFFSET: u8 = 0xa0;
@@ -68,23 +68,23 @@ impl AmdSpi100Info {
 /// This helper contains the platform-independent BAR and ROM range discovery
 /// logic. Linux userspace and embedded firmware can use the same code with
 /// different [`PciConfigAccess`] implementations.
-pub fn enable_amd_spi100_with_host<H: PciConfigAccess>(
+pub fn enable_amd_spi100_with_host<H: PciConfigAccess<Error = InternalError>>(
     host: &H,
     enable: &'static AmdChipsetEnable,
-    smbus_bdf: Bdf,
+    smbus_bdf: PciAddress,
     revision_id: u8,
 ) -> Result<AmdSpi100Info, InternalError> {
     log::info!(
         "Enabling AMD {} SPI100 controller at {:02x}:{:02x}.0",
         enable.device_name,
-        smbus_bdf.bus,
-        smbus_bdf.device
+        smbus_bdf.bus(),
+        smbus_bdf.device()
     );
 
-    let lpc_bdf = Bdf::with_segment(
-        smbus_bdf.segment,
-        smbus_bdf.bus,
-        smbus_bdf.device,
+    let lpc_bdf = PciAddress::new(
+        smbus_bdf.segment(),
+        smbus_bdf.bus(),
+        smbus_bdf.device(),
         AMD_LPC_FUNCTION,
     );
     let spibar = host.read32(lpc_bdf, AMD_SPI_BAR_OFFSET as u16)?;
@@ -153,9 +153,9 @@ pub fn enable_amd_spi100_with_host<H: PciConfigAccess>(
 
     Ok(AmdSpi100Info {
         enable,
-        domain: smbus_bdf.segment,
-        bus: smbus_bdf.bus,
-        device: smbus_bdf.device,
+        domain: smbus_bdf.segment(),
+        bus: smbus_bdf.bus(),
+        device: smbus_bdf.device(),
         function: 0,
         revision_id,
         spibar_addr: phys_spibar,
@@ -193,7 +193,7 @@ pub fn enable_amd_spi100(
     enable_amd_spi100_with_host(
         &DefaultPciAccess,
         enable,
-        Bdf::new(bus, device, 0),
+        PciAddress::new(0, bus, device, 0),
         revision_id,
     )
 }
@@ -245,12 +245,17 @@ mod tests {
     #[test]
     fn test_enable_amd_spi100_with_host_extracts_bars() {
         let host = FakeHost::default();
-        let lpc_bdf = Bdf::new(0, 0x14, AMD_LPC_FUNCTION);
+        let lpc_bdf = PciAddress::new(0, 0, 0x14, AMD_LPC_FUNCTION);
         host.set_config32(lpc_bdf, AMD_SPI_BAR_OFFSET as u16, 0xfed8_0203);
         host.set_config32(lpc_bdf, AMD_ROM_RANGE2_OFFSET as u16, 0xff00_0000);
 
-        let info = enable_amd_spi100_with_host(&host, spi100_enable(), Bdf::new(0, 0x14, 0), 0x51)
-            .unwrap();
+        let info = enable_amd_spi100_with_host(
+            &host,
+            spi100_enable(),
+            PciAddress::new(0, 0, 0x14, 0),
+            0x51,
+        )
+        .unwrap();
 
         assert_eq!(info.domain, 0);
         assert_eq!(info.spibar_addr, 0xfed8_0200);
@@ -262,11 +267,16 @@ mod tests {
     #[test]
     fn test_enable_amd_spi100_with_host_rejects_unconfigured_bar() {
         let host = FakeHost::default();
-        let lpc_bdf = Bdf::new(0, 0x14, AMD_LPC_FUNCTION);
+        let lpc_bdf = PciAddress::new(0, 0, 0x14, AMD_LPC_FUNCTION);
         host.set_config32(lpc_bdf, AMD_SPI_BAR_OFFSET as u16, 0xffff_ffff);
 
-        let err = enable_amd_spi100_with_host(&host, spi100_enable(), Bdf::new(0, 0x14, 0), 0x51)
-            .unwrap_err();
+        let err = enable_amd_spi100_with_host(
+            &host,
+            spi100_enable(),
+            PciAddress::new(0, 0, 0x14, 0),
+            0x51,
+        )
+        .unwrap_err();
         assert!(matches!(err, InternalError::ChipsetEnable(_)));
     }
 }

--- a/crates/rflasher-internal/src/error.rs
+++ b/crates/rflasher-internal/src/error.rs
@@ -54,8 +54,48 @@ pub enum PciAccessError {
         function: u8,
         register: u16,
     },
+    /// Invalid PCI configuration-space address, offset, or width.
+    InvalidAccess {
+        bus: u8,
+        device: u8,
+        function: u8,
+        register: u16,
+    },
     /// BAR not available or invalid
     InvalidBar(u8),
+}
+
+impl From<rflasher_pci::PciError> for InternalError {
+    fn from(error: rflasher_pci::PciError) -> Self {
+        match error {
+            rflasher_pci::PciError::NotSupported(message) => Self::NotSupported(message),
+            rflasher_pci::PciError::Scan => Self::PciAccess(PciAccessError::Scan),
+            rflasher_pci::PciError::ConfigRead { address, offset } => {
+                Self::PciAccess(PciAccessError::ConfigRead {
+                    bus: address.bus(),
+                    device: address.device(),
+                    function: address.function(),
+                    register: offset,
+                })
+            }
+            rflasher_pci::PciError::ConfigWrite { address, offset } => {
+                Self::PciAccess(PciAccessError::ConfigWrite {
+                    bus: address.bus(),
+                    device: address.device(),
+                    function: address.function(),
+                    register: offset,
+                })
+            }
+            rflasher_pci::PciError::InvalidAccess { address, offset } => {
+                Self::PciAccess(PciAccessError::InvalidAccess {
+                    bus: address.bus(),
+                    device: address.device(),
+                    function: address.function(),
+                    register: offset,
+                })
+            }
+        }
+    }
 }
 
 impl fmt::Display for InternalError {
@@ -113,6 +153,16 @@ impl fmt::Display for PciAccessError {
             } => write!(
                 f,
                 "failed to write PCI config at {:02x}:{:02x}.{:x} reg {:#x}",
+                bus, device, function, register
+            ),
+            Self::InvalidAccess {
+                bus,
+                device,
+                function,
+                register,
+            } => write!(
+                f,
+                "invalid PCI config access at {:02x}:{:02x}.{:x} reg {:#x}",
                 bus, device, function, register
             ),
             Self::InvalidBar(bar) => write!(f, "BAR{} not available or invalid", bar),

--- a/crates/rflasher-internal/src/host.rs
+++ b/crates/rflasher-internal/src/host.rs
@@ -11,65 +11,9 @@
 )]
 
 use crate::Result;
-use crate::error::{InternalError, PciAccessError};
+use crate::error::InternalError;
 
-/// PCI segment:bus:device.function identifier.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Bdf {
-    /// PCI segment/domain.
-    pub segment: u16,
-    /// PCI bus number.
-    pub bus: u8,
-    /// PCI device number.
-    pub device: u8,
-    /// PCI function number.
-    pub function: u8,
-}
-
-impl Bdf {
-    /// Creates a BDF in PCI segment 0.
-    pub const fn new(bus: u8, device: u8, function: u8) -> Self {
-        Self {
-            segment: 0,
-            bus,
-            device,
-            function,
-        }
-    }
-
-    /// Creates a BDF with an explicit PCI segment/domain.
-    pub const fn with_segment(segment: u16, bus: u8, device: u8, function: u8) -> Self {
-        Self {
-            segment,
-            bus,
-            device,
-            function,
-        }
-    }
-}
-
-impl From<&crate::pci::PciDevice> for Bdf {
-    fn from(device: &crate::pci::PciDevice) -> Self {
-        Self::with_segment(device.domain, device.bus, device.device, device.function)
-    }
-}
-
-/// Provides PCI configuration-space access for visible or hidden devices.
-pub trait PciConfigAccess {
-    /// Reads an 8-bit PCI config-space value.
-    fn read8(&self, bdf: Bdf, offset: u16) -> Result<u8>;
-    /// Reads a 16-bit PCI config-space value.
-    fn read16(&self, bdf: Bdf, offset: u16) -> Result<u16>;
-    /// Reads a 32-bit PCI config-space value.
-    fn read32(&self, bdf: Bdf, offset: u16) -> Result<u32>;
-
-    /// Writes an 8-bit PCI config-space value.
-    fn write8(&self, bdf: Bdf, offset: u16, value: u8) -> Result<()>;
-    /// Writes a 16-bit PCI config-space value.
-    fn write16(&self, bdf: Bdf, offset: u16, value: u16) -> Result<()>;
-    /// Writes a 32-bit PCI config-space value.
-    fn write32(&self, bdf: Bdf, offset: u16, value: u32) -> Result<()>;
-}
+pub use rflasher_pci::{PciAddress, PciConfigAccess};
 
 /// Provides volatile MMIO access to a mapped controller register window.
 pub trait MmioAccess {
@@ -89,7 +33,7 @@ pub trait MmioAccess {
 }
 
 /// Provides platform services needed by internal flash controllers.
-pub trait HostAccess: PciConfigAccess {
+pub trait HostAccess: PciConfigAccess<Error = InternalError> {
     /// Mapped MMIO region type returned by [`HostAccess::map_mmio`].
     type MmioRegion: MmioAccess;
 
@@ -106,29 +50,6 @@ pub trait HostAccess: PciConfigAccess {
     fn delay_us(&self, us: u32);
 }
 
-fn offset_to_u8(bdf: Bdf, offset: u16, write: bool) -> Result<u8> {
-    if offset > u8::MAX as u16 {
-        let error = if write {
-            PciAccessError::ConfigWrite {
-                bus: bdf.bus,
-                device: bdf.device,
-                function: bdf.function,
-                register: offset,
-            }
-        } else {
-            PciAccessError::ConfigRead {
-                bus: bdf.bus,
-                device: bdf.device,
-                function: bdf.function,
-                register: offset,
-            }
-        };
-        return Err(InternalError::PciAccess(error));
-    }
-
-    Ok(offset as u8)
-}
-
 /// Default PCI configuration-space backend for the current target.
 ///
 /// On Linux userspace this uses sysfs config access and falls back to direct
@@ -139,111 +60,91 @@ fn offset_to_u8(bdf: Bdf, offset: u16, write: bool) -> Result<u8> {
 pub struct DefaultPciAccess;
 
 impl PciConfigAccess for DefaultPciAccess {
-    fn read8(&self, bdf: Bdf, offset: u16) -> Result<u8> {
-        let offset = offset_to_u8(bdf, offset, false)?;
+    type Error = InternalError;
+
+    fn read8(&self, address: PciAddress, offset: u16) -> Result<u8> {
+        let _ = (address, offset);
         #[cfg(all(feature = "std", target_os = "linux"))]
         {
-            crate::pci::pci_read_config8_at(bdf.segment, bdf.bus, bdf.device, bdf.function, offset)
+            rflasher_pci::SysfsPci::system()
+                .read8(address, offset)
+                .map_err(Into::into)
         }
         #[cfg(not(all(feature = "std", target_os = "linux")))]
-        {
-            crate::pci::pci_read_config8(bdf.bus, bdf.device, bdf.function, offset)
-        }
+        Err(InternalError::NotSupported(
+            "PCI config access not available",
+        ))
     }
 
-    fn read16(&self, bdf: Bdf, offset: u16) -> Result<u16> {
-        let offset = offset_to_u8(bdf, offset, false)?;
+    fn read16(&self, address: PciAddress, offset: u16) -> Result<u16> {
+        let _ = (address, offset);
         #[cfg(all(feature = "std", target_os = "linux"))]
         {
-            crate::pci::pci_read_config16_at(bdf.segment, bdf.bus, bdf.device, bdf.function, offset)
+            rflasher_pci::SysfsPci::system()
+                .read16(address, offset)
+                .map_err(Into::into)
         }
         #[cfg(not(all(feature = "std", target_os = "linux")))]
-        {
-            crate::pci::pci_read_config16(bdf.bus, bdf.device, bdf.function, offset)
-        }
+        Err(InternalError::NotSupported(
+            "PCI config access not available",
+        ))
     }
 
-    fn read32(&self, bdf: Bdf, offset: u16) -> Result<u32> {
-        let offset = offset_to_u8(bdf, offset, false)?;
+    fn read32(&self, address: PciAddress, offset: u16) -> Result<u32> {
+        let _ = (address, offset);
         #[cfg(all(feature = "std", target_os = "linux"))]
         {
-            crate::pci::pci_read_config32_at(bdf.segment, bdf.bus, bdf.device, bdf.function, offset)
-                .or_else(|err| {
-                    if bdf.segment == 0 {
-                        crate::pci::pci_read_config32_direct(
-                            bdf.bus,
-                            bdf.device,
-                            bdf.function,
-                            offset,
-                        )
+            rflasher_pci::SysfsPci::system()
+                .read32(address, offset)
+                .or_else(|error| {
+                    if address.segment() == 0 {
+                        rflasher_pci::read32_direct(address, offset)
                     } else {
-                        Err(err)
+                        Err(error)
                     }
                 })
+                .map_err(Into::into)
         }
         #[cfg(not(all(feature = "std", target_os = "linux")))]
-        {
-            crate::pci::pci_read_config32(bdf.bus, bdf.device, bdf.function, offset).or_else(|_| {
-                crate::pci::pci_read_config32_direct(bdf.bus, bdf.device, bdf.function, offset)
-            })
-        }
+        Err(InternalError::NotSupported(
+            "PCI config access not available",
+        ))
     }
 
-    fn write8(&self, bdf: Bdf, offset: u16, value: u8) -> Result<()> {
-        let offset = offset_to_u8(bdf, offset, true)?;
+    fn write8(&self, address: PciAddress, offset: u16, value: u8) -> Result<()> {
+        let _ = (address, offset, value);
         #[cfg(all(feature = "std", target_os = "linux"))]
-        {
-            crate::pci::pci_write_config8_at(
-                bdf.segment,
-                bdf.bus,
-                bdf.device,
-                bdf.function,
-                offset,
-                value,
-            )
-        }
+        return rflasher_pci::SysfsPci::system()
+            .write8(address, offset, value)
+            .map_err(Into::into);
         #[cfg(not(all(feature = "std", target_os = "linux")))]
-        {
-            crate::pci::pci_write_config8(bdf.bus, bdf.device, bdf.function, offset, value)
-        }
+        Err(InternalError::NotSupported(
+            "PCI config access not available",
+        ))
     }
 
-    fn write16(&self, bdf: Bdf, offset: u16, value: u16) -> Result<()> {
-        let offset = offset_to_u8(bdf, offset, true)?;
+    fn write16(&self, address: PciAddress, offset: u16, value: u16) -> Result<()> {
+        let _ = (address, offset, value);
         #[cfg(all(feature = "std", target_os = "linux"))]
-        {
-            crate::pci::pci_write_config16_at(
-                bdf.segment,
-                bdf.bus,
-                bdf.device,
-                bdf.function,
-                offset,
-                value,
-            )
-        }
+        return rflasher_pci::SysfsPci::system()
+            .write16(address, offset, value)
+            .map_err(Into::into);
         #[cfg(not(all(feature = "std", target_os = "linux")))]
-        {
-            crate::pci::pci_write_config16(bdf.bus, bdf.device, bdf.function, offset, value)
-        }
+        Err(InternalError::NotSupported(
+            "PCI config access not available",
+        ))
     }
 
-    fn write32(&self, bdf: Bdf, offset: u16, value: u32) -> Result<()> {
-        let offset = offset_to_u8(bdf, offset, true)?;
+    fn write32(&self, address: PciAddress, offset: u16, value: u32) -> Result<()> {
+        let _ = (address, offset, value);
         #[cfg(all(feature = "std", target_os = "linux"))]
-        {
-            crate::pci::pci_write_config32_at(
-                bdf.segment,
-                bdf.bus,
-                bdf.device,
-                bdf.function,
-                offset,
-                value,
-            )
-        }
+        return rflasher_pci::SysfsPci::system()
+            .write32(address, offset, value)
+            .map_err(Into::into);
         #[cfg(not(all(feature = "std", target_os = "linux")))]
-        {
-            crate::pci::pci_write_config32(bdf.bus, bdf.device, bdf.function, offset, value)
-        }
+        Err(InternalError::NotSupported(
+            "PCI config access not available",
+        ))
     }
 }
 
@@ -268,27 +169,29 @@ impl LinuxHost {
 
 #[cfg(all(feature = "std", target_os = "linux"))]
 impl PciConfigAccess for LinuxHost {
-    fn read8(&self, bdf: Bdf, offset: u16) -> Result<u8> {
+    type Error = InternalError;
+
+    fn read8(&self, bdf: PciAddress, offset: u16) -> Result<u8> {
         DefaultPciAccess.read8(bdf, offset)
     }
 
-    fn read16(&self, bdf: Bdf, offset: u16) -> Result<u16> {
+    fn read16(&self, bdf: PciAddress, offset: u16) -> Result<u16> {
         DefaultPciAccess.read16(bdf, offset)
     }
 
-    fn read32(&self, bdf: Bdf, offset: u16) -> Result<u32> {
+    fn read32(&self, bdf: PciAddress, offset: u16) -> Result<u32> {
         DefaultPciAccess.read32(bdf, offset)
     }
 
-    fn write8(&self, bdf: Bdf, offset: u16, value: u8) -> Result<()> {
+    fn write8(&self, bdf: PciAddress, offset: u16, value: u8) -> Result<()> {
         DefaultPciAccess.write8(bdf, offset, value)
     }
 
-    fn write16(&self, bdf: Bdf, offset: u16, value: u16) -> Result<()> {
+    fn write16(&self, bdf: PciAddress, offset: u16, value: u16) -> Result<()> {
         DefaultPciAccess.write16(bdf, offset, value)
     }
 
-    fn write32(&self, bdf: Bdf, offset: u16, value: u32) -> Result<()> {
+    fn write32(&self, bdf: PciAddress, offset: u16, value: u32) -> Result<()> {
         DefaultPciAccess.write32(bdf, offset, value)
     }
 }
@@ -311,19 +214,20 @@ impl HostAccess for LinuxHost {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use crate::error::PciAccessError;
     use std::cell::RefCell;
     use std::collections::BTreeMap;
 
     /// Fake no-heap-shape host used by controller construction tests.
     #[derive(Default)]
     pub(crate) struct FakeHost {
-        config: RefCell<BTreeMap<(Bdf, u16), u32>>,
-        writes: RefCell<Vec<(Bdf, u16, u32, u8)>>,
+        config: RefCell<BTreeMap<(PciAddress, u16), u32>>,
+        writes: RefCell<Vec<(PciAddress, u16, u32, u8)>>,
         delays: RefCell<Vec<u32>>,
     }
 
     impl FakeHost {
-        pub(crate) fn set_config32(&self, bdf: Bdf, offset: u16, value: u32) {
+        pub(crate) fn set_config32(&self, bdf: PciAddress, offset: u16, value: u32) {
             self.config.borrow_mut().insert((bdf, offset), value);
         }
 
@@ -333,44 +237,46 @@ pub(crate) mod tests {
     }
 
     impl PciConfigAccess for FakeHost {
-        fn read8(&self, bdf: Bdf, offset: u16) -> Result<u8> {
+        type Error = InternalError;
+
+        fn read8(&self, bdf: PciAddress, offset: u16) -> Result<u8> {
             let aligned = offset & !3;
             let shift = ((offset & 3) * 8) as u32;
             Ok(((self.read32(bdf, aligned)? >> shift) & 0xff) as u8)
         }
 
-        fn read16(&self, bdf: Bdf, offset: u16) -> Result<u16> {
+        fn read16(&self, bdf: PciAddress, offset: u16) -> Result<u16> {
             let aligned = offset & !3;
             let shift = ((offset & 2) * 8) as u32;
             Ok(((self.read32(bdf, aligned)? >> shift) & 0xffff) as u16)
         }
 
-        fn read32(&self, bdf: Bdf, offset: u16) -> Result<u32> {
+        fn read32(&self, bdf: PciAddress, offset: u16) -> Result<u32> {
             self.config.borrow().get(&(bdf, offset)).copied().ok_or({
                 InternalError::PciAccess(PciAccessError::ConfigRead {
-                    bus: bdf.bus,
-                    device: bdf.device,
-                    function: bdf.function,
+                    bus: bdf.bus(),
+                    device: bdf.device(),
+                    function: bdf.function(),
                     register: offset,
                 })
             })
         }
 
-        fn write8(&self, bdf: Bdf, offset: u16, value: u8) -> Result<()> {
+        fn write8(&self, bdf: PciAddress, offset: u16, value: u8) -> Result<()> {
             self.writes
                 .borrow_mut()
                 .push((bdf, offset, value as u32, 1));
             Ok(())
         }
 
-        fn write16(&self, bdf: Bdf, offset: u16, value: u16) -> Result<()> {
+        fn write16(&self, bdf: PciAddress, offset: u16, value: u16) -> Result<()> {
             self.writes
                 .borrow_mut()
                 .push((bdf, offset, value as u32, 2));
             Ok(())
         }
 
-        fn write32(&self, bdf: Bdf, offset: u16, value: u32) -> Result<()> {
+        fn write32(&self, bdf: PciAddress, offset: u16, value: u32) -> Result<()> {
             self.writes.borrow_mut().push((bdf, offset, value, 4));
             self.config.borrow_mut().insert((bdf, offset), value);
             Ok(())
@@ -407,18 +313,18 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_bdf_preserves_segment() {
-        let bdf = Bdf::with_segment(2, 0, 0x1f, 5);
-        assert_eq!(bdf.segment, 2);
-        assert_eq!(bdf.bus, 0);
-        assert_eq!(bdf.device, 0x1f);
-        assert_eq!(bdf.function, 5);
+    fn pci_address_preserves_segment() {
+        let bdf = PciAddress::new(2, 0, 0x1f, 5);
+        assert_eq!(bdf.segment(), 2);
+        assert_eq!(bdf.bus(), 0);
+        assert_eq!(bdf.device(), 0x1f);
+        assert_eq!(bdf.function(), 5);
     }
 
     #[test]
     fn test_fake_host_config_access_and_delay() {
         let host = FakeHost::default();
-        let bdf = Bdf::new(0, 0x1f, 0);
+        let bdf = PciAddress::new(0, 0, 0x1f, 0);
         host.set_config32(bdf, 0x10, 0x1234_5678);
 
         assert_eq!(host.read8(bdf, 0x10).unwrap(), 0x78);

--- a/crates/rflasher-internal/src/ichspi.rs
+++ b/crates/rflasher-internal/src/ichspi.rs
@@ -30,7 +30,7 @@ use crate::controller::Controller;
 use crate::error::InternalError;
 #[cfg(all(feature = "std", target_os = "linux"))]
 use crate::host::LinuxHost;
-use crate::host::{Bdf, HostAccess, MmioAccess, PciConfigAccess};
+use crate::host::{HostAccess, MmioAccess, PciAddress, PciConfigAccess};
 use crate::ich_regs::*;
 use rflasher_core::error::{Error as CoreError, Result as CoreResult};
 
@@ -152,7 +152,7 @@ impl core::fmt::Display for SpiMode {
 /// This helper is independent from Linux sysfs and can be exercised by
 /// embedded firmware or fake hosts. It covers both PCH100+ hidden SPI function
 /// BAR discovery and legacy RCBA-relative SPI BAR discovery.
-pub fn get_spibar_address_with_host<H: PciConfigAccess>(
+pub fn get_spibar_address_with_host<H: PciConfigAccess<Error = InternalError>>(
     host: &H,
     chipset: &DetectedChipset,
 ) -> Result<u64, InternalError> {
@@ -160,7 +160,7 @@ pub fn get_spibar_address_with_host<H: PciConfigAccess>(
 
     if generation.is_pch100_compatible() {
         const SPI_FUNCTION: u8 = 5;
-        let spi_bdf = Bdf::with_segment(chipset.domain, chipset.bus, chipset.device, SPI_FUNCTION);
+        let spi_bdf = PciAddress::new(chipset.domain, chipset.bus, chipset.device, SPI_FUNCTION);
         let spibar_raw = host.read32(spi_bdf, PCI_REG_SPIBAR as u16)?;
         let addr = spibar_raw & 0xffff_f000;
 
@@ -172,7 +172,7 @@ pub fn get_spibar_address_with_host<H: PciConfigAccess>(
 
         Ok(addr as u64)
     } else if generation.is_ich9_compatible() || generation == IchChipset::Ich7 {
-        let lpc_bdf = Bdf::with_segment(
+        let lpc_bdf = PciAddress::new(
             chipset.domain,
             chipset.bus,
             chipset.device,
@@ -1170,7 +1170,7 @@ impl<H: HostAccess> IchSpiController<H> {
 
     /// Enable BIOS write access via BIOS_CNTL register
     pub fn enable_bios_write(&mut self) -> Result<(), InternalError> {
-        let lpc_bdf = Bdf::with_segment(
+        let lpc_bdf = PciAddress::new(
             self.lpc_segment,
             self.lpc_bus,
             self.lpc_device,
@@ -2651,7 +2651,7 @@ mod tests {
     fn test_get_spibar_address_with_host_pch100_hidden_spi_function() {
         let host = FakeHost::default();
         let chipset = detected_with_generation(IchChipset::Series100SunrisePoint);
-        let spi_bdf = Bdf::with_segment(chipset.domain, chipset.bus, chipset.device, 5);
+        let spi_bdf = PciAddress::new(chipset.domain, chipset.bus, chipset.device, 5);
         host.set_config32(spi_bdf, PCI_REG_SPIBAR as u16, 0xfed1_c001);
 
         let spibar = get_spibar_address_with_host(&host, &chipset).unwrap();
@@ -2663,7 +2663,7 @@ mod tests {
     fn test_get_spibar_address_with_host_rejects_all_ones_spibar() {
         let host = FakeHost::default();
         let chipset = detected_with_generation(IchChipset::Series100SunrisePoint);
-        let spi_bdf = Bdf::with_segment(chipset.domain, chipset.bus, chipset.device, 5);
+        let spi_bdf = PciAddress::new(chipset.domain, chipset.bus, chipset.device, 5);
         host.set_config32(spi_bdf, PCI_REG_SPIBAR as u16, u32::MAX);
 
         let err = get_spibar_address_with_host(&host, &chipset).unwrap_err();
@@ -2675,7 +2675,7 @@ mod tests {
     fn test_get_spibar_address_with_host_ich7_legacy_rcba() {
         let host = FakeHost::default();
         let chipset = detected_with_generation(IchChipset::Ich7);
-        let lpc_bdf = Bdf::with_segment(
+        let lpc_bdf = PciAddress::new(
             chipset.domain,
             chipset.bus,
             chipset.device,
@@ -2692,7 +2692,7 @@ mod tests {
     fn test_get_spibar_address_with_host_ich8_uses_ich7_rcba_offset() {
         let host = FakeHost::default();
         let chipset = detected_with_generation(IchChipset::Ich8);
-        let lpc_bdf = Bdf::with_segment(
+        let lpc_bdf = PciAddress::new(
             chipset.domain,
             chipset.bus,
             chipset.device,
@@ -2709,7 +2709,7 @@ mod tests {
     fn test_get_spibar_address_with_host_ich9_uses_ich9_rcba_offset() {
         let host = FakeHost::default();
         let chipset = detected_with_generation(IchChipset::Ich9);
-        let lpc_bdf = Bdf::with_segment(
+        let lpc_bdf = PciAddress::new(
             chipset.domain,
             chipset.bus,
             chipset.device,
@@ -2726,7 +2726,7 @@ mod tests {
     fn test_get_spibar_address_with_host_rejects_disabled_rcba() {
         let host = FakeHost::default();
         let chipset = detected_with_generation(IchChipset::Ich7);
-        let lpc_bdf = Bdf::with_segment(
+        let lpc_bdf = PciAddress::new(
             chipset.domain,
             chipset.bus,
             chipset.device,

--- a/crates/rflasher-internal/src/lib.rs
+++ b/crates/rflasher-internal/src/lib.rs
@@ -63,7 +63,7 @@ pub use chipset::{BusType, ChipsetEnable, IchChipset, TestStatus};
 pub use error::{InternalError, PciAccessError};
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub use host::LinuxHost;
-pub use host::{Bdf, DefaultPciAccess, HostAccess, MmioAccess, PciConfigAccess};
+pub use host::{DefaultPciAccess, HostAccess, MmioAccess, PciAddress, PciConfigAccess};
 pub use ichspi::{IchSpiController, SpiMode};
 pub use intel_pci::{INTEL_CHIPSETS, INTEL_VID, find_chipset};
 pub use pci::{

--- a/crates/rflasher-internal/src/pci.rs
+++ b/crates/rflasher-internal/src/pci.rs
@@ -1,57 +1,14 @@
-//! PCI device scanning and access
+//! Intel and AMD chipset detection over generic PCI devices.
 //!
-//! This module provides PCI device scanning functionality using the Linux
-//! sysfs interface (/sys/bus/pci/devices).
-
-#![cfg_attr(
-    not(all(feature = "std", target_os = "linux")),
-    allow(dead_code, unused_imports)
-)]
-
-#[cfg(all(feature = "std", target_os = "linux"))]
-use std::fs;
-#[cfg(all(feature = "std", target_os = "linux"))]
-use std::path::Path;
+//! PCI enumeration and configuration-space access live in [`rflasher_pci`].
+//! This module deliberately contains only rflasher-internal chipset policy.
 
 use crate::DetectedChipset;
 use crate::amd_pci::{AMD_VID, AmdChipsetEnable, find_chipset as find_amd_chipset_entry};
-use crate::error::{InternalError, PciAccessError};
+use crate::error::InternalError;
 use crate::intel_pci::{INTEL_VID, find_chipset};
 
-/// PCI device information
-#[derive(Debug, Clone)]
-pub struct PciDevice {
-    /// PCI domain (usually 0)
-    pub domain: u16,
-    /// PCI bus number
-    pub bus: u8,
-    /// PCI device (slot) number
-    pub device: u8,
-    /// PCI function number
-    pub function: u8,
-    /// Vendor ID
-    pub vendor_id: u16,
-    /// Device ID
-    pub device_id: u16,
-    /// Revision ID
-    pub revision_id: u8,
-    /// Class code (3 bytes, upper 24 bits)
-    pub class: u32,
-}
-
-impl PciDevice {
-    /// Check if this device matches a vendor/device ID pair
-    pub fn matches(&self, vendor_id: u16, device_id: u16) -> bool {
-        self.vendor_id == vendor_id && self.device_id == device_id
-    }
-
-    /// Get the BDF (Bus:Device.Function) string
-    pub fn bdf(&self) -> alloc::string::String {
-        alloc::format!("{:02x}:{:02x}.{:x}", self.bus, self.device, self.function)
-    }
-}
-
-extern crate alloc;
+pub use rflasher_pci::PciDevice;
 
 fn detected_intel_from_device(dev: &PciDevice) -> Option<DetectedChipset> {
     if dev.vendor_id != INTEL_VID {
@@ -61,10 +18,10 @@ fn detected_intel_from_device(dev: &PciDevice) -> Option<DetectedChipset> {
     find_chipset(dev.vendor_id, dev.device_id, Some(dev.revision_id)).map(|enable| {
         DetectedChipset {
             enable,
-            domain: dev.domain,
-            bus: dev.bus,
-            device: dev.device,
-            function: dev.function,
+            domain: dev.address.segment(),
+            bus: dev.address.bus(),
+            device: dev.address.device(),
+            function: dev.address.function(),
             revision_id: dev.revision_id,
         }
     })
@@ -78,23 +35,20 @@ fn detected_amd_from_device(dev: &PciDevice) -> Option<DetectedAmdChipset> {
     find_amd_chipset_entry(dev.vendor_id, dev.device_id, dev.revision_id).map(|enable| {
         DetectedAmdChipset {
             enable,
-            domain: dev.domain,
-            bus: dev.bus,
-            device: dev.device,
-            function: dev.function,
+            domain: dev.address.segment(),
+            bus: dev.address.bus(),
+            device: dev.address.device(),
+            function: dev.address.function(),
             revision_id: dev.revision_id,
         }
     })
 }
 
 /// Finds a single Intel chipset in a caller-provided PCI device list.
-///
-/// This is the embedded-friendly detection path: firmware can provide devices
-/// from its own PCI scanner and avoid Linux sysfs enumeration entirely.
 pub fn find_intel_chipset_in_devices(
     devices: &[PciDevice],
 ) -> Result<Option<DetectedChipset>, InternalError> {
-    find_intel_chipset_in_iter(devices.iter().cloned())
+    find_intel_chipset_in_iter(devices.iter().copied())
 }
 
 /// Finds a single Intel chipset in a caller-provided PCI device iterator.
@@ -103,16 +57,13 @@ where
     I: IntoIterator<Item = PciDevice>,
 {
     let mut found = None;
-
     for dev in devices {
         let Some(chipset) = detected_intel_from_device(&dev) else {
             continue;
         };
-
         if found.is_some() {
             return Err(InternalError::MultipleChipsets);
         }
-
         found = Some(chipset);
     }
 
@@ -125,7 +76,6 @@ where
             name: chipset.enable.device_name,
         });
     }
-
     Ok(found)
 }
 
@@ -133,638 +83,63 @@ where
 pub fn find_amd_chipset_in_devices(
     devices: &[PciDevice],
 ) -> Result<Option<DetectedAmdChipset>, InternalError> {
-    find_amd_chipset_in_iter(devices.iter().cloned())
+    find_amd_chipset_in_iter(devices.iter().copied())
 }
 
-/// Finds a single AMD chipset in a caller-provided PCI device iterator.
-///
-/// This preserves the existing Linux behavior for multiple AMD matches by
-/// returning the first match instead of failing.
+/// Finds the first AMD chipset in a caller-provided PCI device iterator.
 pub fn find_amd_chipset_in_iter<I>(devices: I) -> Result<Option<DetectedAmdChipset>, InternalError>
 where
     I: IntoIterator<Item = PciDevice>,
 {
-    Ok(devices
-        .into_iter()
-        .find_map(|dev| detected_amd_from_device(&dev)))
-}
-
-/// Scan the PCI bus for devices
-///
-/// This uses the Linux sysfs interface to enumerate PCI devices.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn scan_pci_bus() -> Result<alloc::vec::Vec<PciDevice>, InternalError> {
-    let pci_path = Path::new("/sys/bus/pci/devices");
-
-    if !pci_path.exists() {
-        return Err(InternalError::PciAccess(PciAccessError::Init));
-    }
-
-    let mut devices = alloc::vec::Vec::new();
-
-    let entries =
-        fs::read_dir(pci_path).map_err(|_| InternalError::PciAccess(PciAccessError::Scan))?;
-
-    for entry in entries {
-        let entry = entry.map_err(|_| InternalError::PciAccess(PciAccessError::Scan))?;
-        let path = entry.path();
-
-        // Parse the device name (format: "0000:00:1f.0")
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-
-        if let Some(dev) = parse_pci_device(&path, &name_str) {
-            devices.push(dev);
-        }
-    }
-
-    Ok(devices)
-}
-
-/// Parse a PCI device from sysfs
-#[cfg(all(feature = "std", target_os = "linux"))]
-fn parse_pci_device(path: &Path, name: &str) -> Option<PciDevice> {
-    // Parse domain:bus:device.function from name
-    // Format: "0000:00:1f.0"
-    let parts: alloc::vec::Vec<&str> = name.split(':').collect();
-    if parts.len() != 3 {
-        return None;
-    }
-
-    let domain = u16::from_str_radix(parts[0], 16).ok()?;
-    let bus = u8::from_str_radix(parts[1], 16).ok()?;
-
-    // Parse device.function
-    let dev_func: alloc::vec::Vec<&str> = parts[2].split('.').collect();
-    if dev_func.len() != 2 {
-        return None;
-    }
-
-    let device = u8::from_str_radix(dev_func[0], 16).ok()?;
-    let function = u8::from_str_radix(dev_func[1], 16).ok()?;
-
-    // Read vendor ID
-    let vendor_id = read_sysfs_hex_u16(&path.join("vendor"))?;
-
-    // Read device ID
-    let device_id = read_sysfs_hex_u16(&path.join("device"))?;
-
-    // Read revision (optional, default to 0)
-    let revision_id = read_sysfs_hex_u8(&path.join("revision")).unwrap_or(0);
-
-    // Read class (optional, default to 0)
-    let class = read_sysfs_hex_u32(&path.join("class")).unwrap_or(0);
-
-    Some(PciDevice {
-        domain,
-        bus,
-        device,
-        function,
-        vendor_id,
-        device_id,
-        revision_id,
-        class,
-    })
-}
-
-/// Read a hex u16 value from a sysfs file
-#[cfg(all(feature = "std", target_os = "linux"))]
-fn read_sysfs_hex_u16(path: &Path) -> Option<u16> {
-    let content = fs::read_to_string(path).ok()?;
-    let content = content.trim();
-    // Handle "0x" prefix
-    let hex_str = content.strip_prefix("0x").unwrap_or(content);
-    u16::from_str_radix(hex_str, 16).ok()
-}
-
-/// Read a hex u8 value from a sysfs file
-#[cfg(all(feature = "std", target_os = "linux"))]
-fn read_sysfs_hex_u8(path: &Path) -> Option<u8> {
-    let content = fs::read_to_string(path).ok()?;
-    let content = content.trim();
-    let hex_str = content.strip_prefix("0x").unwrap_or(content);
-    u8::from_str_radix(hex_str, 16).ok()
-}
-
-/// Read a hex u32 value from a sysfs file
-#[cfg(all(feature = "std", target_os = "linux"))]
-fn read_sysfs_hex_u32(path: &Path) -> Option<u32> {
-    let content = fs::read_to_string(path).ok()?;
-    let content = content.trim();
-    let hex_str = content.strip_prefix("0x").unwrap_or(content);
-    u32::from_str_radix(hex_str, 16).ok()
-}
-
-/// Scan for Intel chipsets and return any matches
-///
-/// This function scans the PCI bus and looks for known Intel chipsets
-/// in the chipset enable table.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn scan_for_intel_chipsets() -> Result<alloc::vec::Vec<DetectedChipset>, InternalError> {
-    let devices = scan_pci_bus()?;
-    let mut found = alloc::vec::Vec::new();
-
-    for dev in devices {
-        // Only check Intel devices
-        if dev.vendor_id != INTEL_VID {
+    let mut found: Option<DetectedAmdChipset> = None;
+    for device in devices {
+        let Some(chipset) = detected_amd_from_device(&device) else {
             continue;
-        }
-
-        // Look up in our chipset table
-        if let Some(enable) = find_chipset(dev.vendor_id, dev.device_id, Some(dev.revision_id)) {
-            log::debug!(
-                "Found chipset {} {} at {:02x}:{:02x}.{:x}",
-                enable.vendor_name,
-                enable.device_name,
-                dev.bus,
-                dev.device,
-                dev.function
+        };
+        if let Some(first) = &found {
+            log::warn!(
+                "Multiple AMD chipsets found; using {} {} at {:02x}:{:02x}.{:x} and ignoring {} {} at {:02x}:{:02x}.{:x}",
+                first.vendor(),
+                first.name(),
+                first.bus,
+                first.device,
+                first.function,
+                chipset.vendor(),
+                chipset.name(),
+                chipset.bus,
+                chipset.device,
+                chipset.function,
             );
-
-            found.push(DetectedChipset {
-                enable,
-                domain: dev.domain,
-                bus: dev.bus,
-                device: dev.device,
-                function: dev.function,
-                revision_id: dev.revision_id,
-            });
+        } else {
+            found = Some(chipset);
         }
     }
-
     Ok(found)
 }
 
-/// Find a single Intel chipset, warning about duplicates
+/// Scans Linux sysfs for PCI devices.
 #[cfg(all(feature = "std", target_os = "linux"))]
-pub fn find_intel_chipset() -> Result<Option<DetectedChipset>, InternalError> {
-    let chipsets = scan_for_intel_chipsets()?;
-
-    match chipsets.len() {
-        0 => Ok(None),
-        1 => {
-            let chipset = chipsets.into_iter().next().unwrap();
-
-            // Log info about the found chipset
-            log::info!(
-                "Found chipset \"{}\" {} with PCI ID {:04x}:{:04x}",
-                chipset.enable.vendor_name,
-                chipset.enable.device_name,
-                chipset.enable.vendor_id,
-                chipset.enable.device_id
-            );
-
-            // Log any warnings
-            chipset.log_warnings();
-
-            // Check if chipset is known bad
-            if chipset.enable.status.is_bad() {
-                return Err(InternalError::UnsupportedChipset {
-                    vendor_id: chipset.enable.vendor_id,
-                    device_id: chipset.enable.device_id,
-                    name: chipset.enable.device_name,
-                });
-            }
-
-            Ok(Some(chipset))
-        }
-        _ => {
-            // Multiple chipsets found - warn and return error
-            log::warn!("Multiple supported chipsets found:");
-            for chipset in &chipsets {
-                log::warn!(
-                    "  {} {} at {:02x}:{:02x}.{:x}",
-                    chipset.enable.vendor_name,
-                    chipset.enable.device_name,
-                    chipset.bus,
-                    chipset.device,
-                    chipset.function
-                );
-            }
-            // For now, return an error - in the future we could allow selecting one
-            // via programmer options
-            Err(InternalError::MultipleChipsets)
-        }
-    }
+pub fn scan_pci_bus() -> Result<alloc::vec::Vec<PciDevice>, InternalError> {
+    rflasher_pci::SysfsPci::system()
+        .enumerate()
+        .map_err(InternalError::from)
 }
 
-// ============================================================================
-// PCI Configuration Space Access
-// ============================================================================
-
-// PCI Configuration Mechanism 1 I/O ports
-const PCI_CONFIG_ADDR: u16 = 0xCF8;
-const PCI_CONFIG_DATA: u16 = 0xCFC;
-
-/// Build a PCI Configuration Mechanism 1 address
-#[inline]
-fn pci_cfg_addr(bus: u8, device: u8, function: u8, offset: u8) -> u32 {
-    0x8000_0000
-        | ((bus as u32) << 16)
-        | ((device as u32) << 11)
-        | ((function as u32) << 8)
-        | ((offset as u32) & 0xFC)
-}
-
-/// Read a dword from PCI config space using direct I/O port access (Mechanism 1)
-///
-/// This works even for hidden PCI devices that don't appear in sysfs.
-/// Requires root/CAP_SYS_RAWIO and x86 architecture.
-#[cfg(all(
-    feature = "std",
-    target_os = "linux",
-    any(target_arch = "x86", target_arch = "x86_64")
-))]
-pub fn pci_read_config32_direct(
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-) -> Result<u32, InternalError> {
-    // Request I/O port access permission for PCI config ports (0xCF8-0xCFF)
-    // This requires CAP_SYS_RAWIO (usually root)
-    let ret = unsafe { libc::iopl(3) };
-    if ret != 0 {
-        log::debug!(
-            "iopl(3) failed with error: {}",
-            std::io::Error::last_os_error()
-        );
-        return Err(InternalError::PciAccess(PciAccessError::ConfigRead {
-            bus,
-            device,
-            function,
-            register: offset as u16,
-        }));
-    }
-
-    // Build the PCI config address
-    let addr = pci_cfg_addr(bus, device, function, offset);
-
-    // Use inline assembly for proper 32-bit I/O port access
-    let data: u32;
-    unsafe {
-        // Write address to CONFIG_ADDRESS port (0xCF8)
-        std::arch::asm!(
-            "out dx, eax",
-            in("dx") PCI_CONFIG_ADDR,
-            in("eax") addr,
-            options(nomem, nostack, preserves_flags)
-        );
-
-        // Read data from CONFIG_DATA port (0xCFC)
-        std::arch::asm!(
-            "in eax, dx",
-            in("dx") PCI_CONFIG_DATA,
-            out("eax") data,
-            options(nomem, nostack, preserves_flags)
-        );
-    }
-
-    Ok(data)
-}
-
-#[cfg(not(all(
-    feature = "std",
-    target_os = "linux",
-    any(target_arch = "x86", target_arch = "x86_64")
-)))]
-pub fn pci_read_config32_direct(
-    _bus: u8,
-    _device: u8,
-    _function: u8,
-    _offset: u8,
-) -> Result<u32, InternalError> {
-    Err(InternalError::NotSupported(
-        "Direct PCI access only supported on x86 Linux",
-    ))
-}
-
-#[cfg(all(feature = "std", target_os = "linux"))]
-fn pci_config_path(segment: u16, bus: u8, device: u8, function: u8) -> alloc::string::String {
-    alloc::format!(
-        "/sys/bus/pci/devices/{:04x}:{:02x}:{:02x}.{:x}/config",
-        segment,
-        bus,
-        device,
-        function
-    )
-}
-
-#[cfg(all(feature = "std", target_os = "linux"))]
-fn pci_config_read<const N: usize>(
-    segment: u16,
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-) -> Result<[u8; N], InternalError> {
-    use std::io::{Read, Seek};
-
-    let path = pci_config_path(segment, bus, device, function);
-    let mut file = std::fs::File::open(&path).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigRead {
-            bus,
-            device,
-            function,
-            register: offset as u16,
-        })
-    })?;
-
-    file.seek(std::io::SeekFrom::Start(offset as u64))
-        .map_err(|_| {
-            InternalError::PciAccess(PciAccessError::ConfigRead {
-                bus,
-                device,
-                function,
-                register: offset as u16,
-            })
-        })?;
-
-    let mut buf = [0u8; N];
-    file.read_exact(&mut buf).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigRead {
-            bus,
-            device,
-            function,
-            register: offset as u16,
-        })
-    })?;
-
-    Ok(buf)
-}
-
-#[cfg(all(feature = "std", target_os = "linux"))]
-fn pci_config_write(
-    segment: u16,
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-    bytes: &[u8],
-) -> Result<(), InternalError> {
-    use std::fs::OpenOptions;
-    use std::io::{Seek, Write};
-
-    let path = pci_config_path(segment, bus, device, function);
-    let mut file = OpenOptions::new().write(true).open(&path).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigWrite {
-            bus,
-            device,
-            function,
-            register: offset as u16,
-        })
-    })?;
-
-    file.seek(std::io::SeekFrom::Start(offset as u64))
-        .map_err(|_| {
-            InternalError::PciAccess(PciAccessError::ConfigWrite {
-                bus,
-                device,
-                function,
-                register: offset as u16,
-            })
-        })?;
-
-    file.write_all(bytes).map_err(|_| {
-        InternalError::PciAccess(PciAccessError::ConfigWrite {
-            bus,
-            device,
-            function,
-            register: offset as u16,
-        })
-    })
-}
-
-/// Read a byte from PCI configuration space via sysfs.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_read_config8_at(
-    segment: u16,
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-) -> Result<u8, InternalError> {
-    Ok(pci_config_read::<1>(segment, bus, device, function, offset)?[0])
-}
-
-/// Read a word from PCI configuration space via sysfs.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_read_config16_at(
-    segment: u16,
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-) -> Result<u16, InternalError> {
-    Ok(u16::from_le_bytes(pci_config_read::<2>(
-        segment, bus, device, function, offset,
-    )?))
-}
-
-/// Read a dword from PCI configuration space via sysfs.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_read_config32_at(
-    segment: u16,
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-) -> Result<u32, InternalError> {
-    Ok(u32::from_le_bytes(pci_config_read::<4>(
-        segment, bus, device, function, offset,
-    )?))
-}
-
-/// Write a byte to PCI configuration space via sysfs.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_write_config8_at(
-    segment: u16,
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-    value: u8,
-) -> Result<(), InternalError> {
-    pci_config_write(segment, bus, device, function, offset, &[value])
-}
-
-/// Write a word to PCI configuration space via sysfs.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_write_config16_at(
-    segment: u16,
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-    value: u16,
-) -> Result<(), InternalError> {
-    pci_config_write(segment, bus, device, function, offset, &value.to_le_bytes())
-}
-
-/// Write a dword to PCI configuration space via sysfs.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_write_config32_at(
-    segment: u16,
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-    value: u32,
-) -> Result<(), InternalError> {
-    pci_config_write(segment, bus, device, function, offset, &value.to_le_bytes())
-}
-
-/// Read a byte from PCI configuration space via sysfs in segment 0.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_read_config8(
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-) -> Result<u8, InternalError> {
-    pci_read_config8_at(0, bus, device, function, offset)
-}
-
-/// Read a word from PCI configuration space via sysfs in segment 0.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_read_config16(
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-) -> Result<u16, InternalError> {
-    pci_read_config16_at(0, bus, device, function, offset)
-}
-
-/// Read a dword from PCI configuration space via sysfs in segment 0.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_read_config32(
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-) -> Result<u32, InternalError> {
-    pci_read_config32_at(0, bus, device, function, offset)
-}
-
-/// Write a byte to PCI configuration space via sysfs in segment 0.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_write_config8(
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-    value: u8,
-) -> Result<(), InternalError> {
-    pci_write_config8_at(0, bus, device, function, offset, value)
-}
-
-/// Write a word to PCI configuration space via sysfs in segment 0.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_write_config16(
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-    value: u16,
-) -> Result<(), InternalError> {
-    pci_write_config16_at(0, bus, device, function, offset, value)
-}
-
-/// Write a dword to PCI configuration space via sysfs in segment 0.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn pci_write_config32(
-    bus: u8,
-    device: u8,
-    function: u8,
-    offset: u8,
-    value: u32,
-) -> Result<(), InternalError> {
-    pci_write_config32_at(0, bus, device, function, offset, value)
-}
-
-// Non-Linux stubs.
-#[cfg(not(all(feature = "std", target_os = "linux")))]
-pub fn pci_read_config8(
-    _bus: u8,
-    _device: u8,
-    _function: u8,
-    _offset: u8,
-) -> Result<u8, InternalError> {
-    Err(InternalError::NotSupported(
-        "PCI config access not available",
-    ))
-}
-
-#[cfg(not(all(feature = "std", target_os = "linux")))]
-pub fn pci_read_config16(
-    _bus: u8,
-    _device: u8,
-    _function: u8,
-    _offset: u8,
-) -> Result<u16, InternalError> {
-    Err(InternalError::NotSupported(
-        "PCI config access not available",
-    ))
-}
-
-#[cfg(not(all(feature = "std", target_os = "linux")))]
-pub fn pci_read_config32(
-    _bus: u8,
-    _device: u8,
-    _function: u8,
-    _offset: u8,
-) -> Result<u32, InternalError> {
-    Err(InternalError::NotSupported(
-        "PCI config access not available",
-    ))
-}
-
-#[cfg(not(all(feature = "std", target_os = "linux")))]
-pub fn pci_write_config8(
-    _bus: u8,
-    _device: u8,
-    _function: u8,
-    _offset: u8,
-    _value: u8,
-) -> Result<(), InternalError> {
-    Err(InternalError::NotSupported(
-        "PCI config access not available",
-    ))
-}
-
-#[cfg(not(all(feature = "std", target_os = "linux")))]
-pub fn pci_write_config16(
-    _bus: u8,
-    _device: u8,
-    _function: u8,
-    _offset: u8,
-    _value: u16,
-) -> Result<(), InternalError> {
-    Err(InternalError::NotSupported(
-        "PCI config access not available",
-    ))
-}
-
-#[cfg(not(all(feature = "std", target_os = "linux")))]
-pub fn pci_write_config32(
-    _bus: u8,
-    _device: u8,
-    _function: u8,
-    _offset: u8,
-    _value: u32,
-) -> Result<(), InternalError> {
-    Err(InternalError::NotSupported(
-        "PCI config access not available",
-    ))
-}
-
-// Non-Linux stubs for scan functions
 #[cfg(not(all(feature = "std", target_os = "linux")))]
 pub fn scan_pci_bus() -> Result<alloc::vec::Vec<PciDevice>, InternalError> {
     Err(InternalError::NotSupported(
         "PCI scanning only supported on Linux",
     ))
+}
+
+/// Scan Linux PCI devices for supported Intel chipsets.
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn scan_for_intel_chipsets() -> Result<alloc::vec::Vec<DetectedChipset>, InternalError> {
+    let devices = scan_pci_bus()?;
+    Ok(devices
+        .iter()
+        .filter_map(detected_intel_from_device)
+        .collect())
 }
 
 #[cfg(not(all(feature = "std", target_os = "linux")))]
@@ -774,6 +149,12 @@ pub fn scan_for_intel_chipsets() -> Result<alloc::vec::Vec<DetectedChipset>, Int
     ))
 }
 
+/// Finds one supported Intel chipset on Linux.
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn find_intel_chipset() -> Result<Option<DetectedChipset>, InternalError> {
+    find_intel_chipset_in_iter(scan_pci_bus()?)
+}
+
 #[cfg(not(all(feature = "std", target_os = "linux")))]
 pub fn find_intel_chipset() -> Result<Option<DetectedChipset>, InternalError> {
     Err(InternalError::NotSupported(
@@ -781,177 +162,89 @@ pub fn find_intel_chipset() -> Result<Option<DetectedChipset>, InternalError> {
     ))
 }
 
-// =============================================================================
-// AMD Chipset Detection
-// =============================================================================
-
-/// Information about a detected AMD chipset
+/// Information about a detected AMD chipset.
 #[derive(Debug, Clone)]
 pub struct DetectedAmdChipset {
-    /// The chipset enable entry from the database
+    /// The chipset enable entry from the database.
     pub enable: &'static AmdChipsetEnable,
-    /// PCI segment/domain
+    /// PCI segment/domain.
     pub domain: u16,
-    /// PCI bus number
+    /// PCI bus number.
     pub bus: u8,
-    /// PCI device number
+    /// PCI device number.
     pub device: u8,
-    /// PCI function number
+    /// PCI function number.
     pub function: u8,
-    /// PCI revision ID
+    /// PCI revision ID.
     pub revision_id: u8,
 }
 
 impl DetectedAmdChipset {
-    /// Returns the chipset name
     pub fn name(&self) -> &'static str {
         self.enable.device_name
     }
-
-    /// Returns the vendor name
     pub fn vendor(&self) -> &'static str {
         self.enable.vendor_name
     }
-
-    /// Returns the test status
     pub fn status(&self) -> crate::chipset::TestStatus {
         self.enable.status
     }
-
-    /// Returns the chipset type
     pub fn chipset_type(&self) -> crate::amd_pci::AmdChipset {
         self.enable.chipset
     }
-
-    /// Returns true if this chipset should generate a warning
     pub fn should_warn(&self) -> bool {
         self.enable.status.should_warn()
     }
-
-    /// Get the warning/status message for this chipset
     pub fn status_message(&self) -> Option<&'static str> {
         self.enable.status.message()
     }
 
-    /// Log warnings for untested/dependent chipsets
     pub fn log_warnings(&self) {
         use crate::chipset::TestStatus;
         match self.enable.status {
-            TestStatus::Untested => {
-                log::warn!(
-                    "Chipset {} {} ({:04x}:{:04x} rev {:02x}) is UNTESTED.",
-                    self.enable.vendor_name,
-                    self.enable.device_name,
-                    self.enable.vendor_id,
-                    self.enable.device_id,
-                    self.revision_id
-                );
-                log::warn!(
-                    "If you are using an up-to-date version and were (not) able to \
-                     successfully access flash with it, please report your results."
-                );
-            }
-            TestStatus::Depends => {
-                log::info!(
-                    "Support for {} {} depends on configuration \
-                     (e.g., BIOS settings, flash descriptor).",
-                    self.enable.vendor_name,
-                    self.enable.device_name
-                );
-            }
-            TestStatus::Bad => {
-                log::error!(
-                    "Chipset {} {} is NOT SUPPORTED.",
-                    self.enable.vendor_name,
-                    self.enable.device_name
-                );
-            }
+            TestStatus::Untested => log::warn!(
+                "Chipset {} {} ({:04x}:{:04x} rev {:02x}) is UNTESTED.",
+                self.enable.vendor_name,
+                self.enable.device_name,
+                self.enable.vendor_id,
+                self.enable.device_id,
+                self.revision_id
+            ),
+            TestStatus::Depends => log::info!(
+                "Support for {} {} depends on configuration (e.g., BIOS settings, flash descriptor).",
+                self.enable.vendor_name,
+                self.enable.device_name
+            ),
+            TestStatus::Bad => log::error!(
+                "Chipset {} {} is NOT SUPPORTED.",
+                self.enable.vendor_name,
+                self.enable.device_name
+            ),
             _ => {}
         }
     }
 }
 
-/// Scan for AMD chipsets and return any matches
-///
-/// This function scans the PCI bus and looks for known AMD chipsets
-/// in the chipset enable table.
+/// Scan Linux PCI devices for supported AMD chipsets.
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub fn scan_for_amd_chipsets() -> Result<alloc::vec::Vec<DetectedAmdChipset>, InternalError> {
-    let devices = scan_pci_bus()?;
-    let mut found = alloc::vec::Vec::new();
-
-    for dev in devices {
-        // Only check AMD devices (0x1022 and old ATI 0x1002)
-        if dev.vendor_id != AMD_VID && dev.vendor_id != 0x1002 {
-            continue;
-        }
-
-        // Look up in our chipset table
-        if let Some(enable) = find_amd_chipset_entry(dev.vendor_id, dev.device_id, dev.revision_id)
-        {
-            log::debug!(
-                "Found AMD chipset {} {} (rev {:02x}) at {:02x}:{:02x}.{:x}",
-                enable.vendor_name,
-                enable.device_name,
-                dev.revision_id,
-                dev.bus,
-                dev.device,
-                dev.function
-            );
-
-            found.push(DetectedAmdChipset {
-                enable,
-                domain: dev.domain,
-                bus: dev.bus,
-                device: dev.device,
-                function: dev.function,
-                revision_id: dev.revision_id,
-            });
-        }
-    }
-
-    Ok(found)
+    Ok(scan_pci_bus()?
+        .iter()
+        .filter_map(detected_amd_from_device)
+        .collect())
 }
 
-/// Find a single AMD chipset, warning about duplicates
-///
-/// This function scans for AMD chipsets and returns the first one found,
-/// logging a warning if multiple chipsets are detected.
-#[cfg(all(feature = "std", target_os = "linux"))]
-pub fn find_amd_chipset() -> Result<Option<DetectedAmdChipset>, InternalError> {
-    let chipsets = scan_for_amd_chipsets()?;
-
-    match chipsets.len() {
-        0 => Ok(None),
-        1 => Ok(Some(chipsets[0].clone())),
-        _ => {
-            log::warn!("Multiple AMD chipsets found:");
-            for cs in &chipsets {
-                log::warn!(
-                    "  {} {} at {:02x}:{:02x}.{:x}",
-                    cs.vendor(),
-                    cs.name(),
-                    cs.bus,
-                    cs.device,
-                    cs.function
-                );
-            }
-            log::warn!(
-                "Using first chipset: {} {}",
-                chipsets[0].vendor(),
-                chipsets[0].name()
-            );
-            Ok(Some(chipsets[0].clone()))
-        }
-    }
-}
-
-// Non-Linux stubs for AMD functions
 #[cfg(not(all(feature = "std", target_os = "linux")))]
 pub fn scan_for_amd_chipsets() -> Result<alloc::vec::Vec<DetectedAmdChipset>, InternalError> {
     Err(InternalError::NotSupported(
         "PCI scanning only supported on Linux",
     ))
+}
+
+/// Finds the first supported AMD chipset on Linux.
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub fn find_amd_chipset() -> Result<Option<DetectedAmdChipset>, InternalError> {
+    find_amd_chipset_in_iter(scan_pci_bus()?)
 }
 
 #[cfg(not(all(feature = "std", target_os = "linux")))]
@@ -964,13 +257,11 @@ pub fn find_amd_chipset() -> Result<Option<DetectedAmdChipset>, InternalError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rflasher_pci::PciAddress;
 
     fn pci_device(vendor_id: u16, device_id: u16, revision_id: u8) -> PciDevice {
         PciDevice {
-            domain: 0,
-            bus: 0,
-            device: 0x1f,
-            function: 0,
+            address: PciAddress::new(0, 0, 0x1f, 0),
             vendor_id,
             device_id,
             revision_id,
@@ -979,37 +270,41 @@ mod tests {
     }
 
     #[test]
-    fn test_find_intel_chipset_in_devices_no_match() {
-        let devices = [pci_device(0x1234, 0x5678, 0)];
-        assert!(find_intel_chipset_in_devices(&devices).unwrap().is_none());
-    }
-
-    #[test]
-    fn test_find_intel_chipset_in_devices_detects_match() {
-        let devices = [pci_device(INTEL_VID, 0x0f1c, 0)];
-        let chipset = find_intel_chipset_in_devices(&devices).unwrap().unwrap();
+    fn finds_an_intel_chipset() {
+        let chipset = find_intel_chipset_in_devices(&[pci_device(INTEL_VID, 0x0f1c, 0)])
+            .unwrap()
+            .unwrap();
         assert_eq!(chipset.enable.vendor_id, INTEL_VID);
-        assert_eq!(chipset.enable.device_id, 0x0f1c);
-        assert_eq!(chipset.bus, 0);
-        assert_eq!(chipset.device, 0x1f);
     }
 
     #[test]
-    fn test_find_intel_chipset_in_devices_rejects_multiple_matches() {
+    fn rejects_multiple_intel_chipsets() {
         let devices = [
             pci_device(INTEL_VID, 0x0f1c, 0),
             pci_device(INTEL_VID, 0x1c44, 0),
         ];
-        let err = find_intel_chipset_in_devices(&devices).unwrap_err();
-        assert!(matches!(err, InternalError::MultipleChipsets));
+        assert!(matches!(
+            find_intel_chipset_in_devices(&devices),
+            Err(InternalError::MultipleChipsets)
+        ));
     }
 
     #[test]
-    fn test_find_amd_chipset_in_devices_detects_revision_match() {
-        let devices = [pci_device(AMD_VID, 0x790b, 0x51)];
-        let chipset = find_amd_chipset_in_devices(&devices).unwrap().unwrap();
-        assert_eq!(chipset.enable.vendor_id, AMD_VID);
-        assert_eq!(chipset.enable.device_id, 0x790b);
+    fn finds_an_amd_chipset() {
+        let chipset = find_amd_chipset_in_devices(&[pci_device(AMD_VID, 0x790b, 0x51)])
+            .unwrap()
+            .unwrap();
         assert_eq!(chipset.revision_id, 0x51);
+    }
+
+    #[test]
+    fn multiple_amd_chipsets_keep_the_first_match() {
+        let chipset = find_amd_chipset_in_devices(&[
+            pci_device(AMD_VID, 0x790b, 0x51),
+            pci_device(0x1002, 0x438d, 0),
+        ])
+        .unwrap()
+        .unwrap();
+        assert_eq!(chipset.enable.device_id, 0x790b);
     }
 }

--- a/crates/rflasher-internal/src/programmer.rs
+++ b/crates/rflasher-internal/src/programmer.rs
@@ -9,7 +9,7 @@
 use crate::amd_enable::enable_amd_spi100_with_host;
 use crate::controller::Controller;
 use crate::error::InternalError;
-use crate::host::{Bdf, DefaultPciAccess};
+use crate::host::{DefaultPciAccess, PciAddress};
 use crate::ichspi::{IchSpiController, SpiMode};
 use crate::{AnyDetectedChipset, DetectedAmdChipset, DetectedChipset};
 
@@ -125,7 +125,7 @@ impl InternalProgrammer {
         let info = enable_amd_spi100_with_host(
             &DefaultPciAccess,
             chipset.enable,
-            Bdf::with_segment(
+            PciAddress::new(
                 chipset.domain,
                 chipset.bus,
                 chipset.device,

--- a/crates/rflasher-pci/Cargo.toml
+++ b/crates/rflasher-pci/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rflasher-pci"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Pure-Rust PCI configuration-space access for rflasher"
+
+[features]
+default = []
+alloc = []
+std = ["alloc", "dep:libc"]
+
+[dependencies]
+pci_types = "0.10.1"
+libc = { version = "0.2", optional = true }

--- a/crates/rflasher-pci/src/lib.rs
+++ b/crates/rflasher-pci/src/lib.rs
@@ -1,0 +1,482 @@
+//! Pure-Rust PCI configuration-space types and access backends.
+//!
+//! This crate is `no_std` by default.  It re-exports [`pci_types`] for PCI
+//! headers and capabilities, while [`PciConfigAccess`] adds the fallible
+//! configuration-space access required by userspace backends.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+pub use pci_types;
+pub use pci_types::{
+    BaseClass, DeviceId, DeviceRevision, Interface, PciAddress, SubClass, VendorId,
+};
+
+/// A PCI function discovered by a platform-specific enumerator.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PciDevice {
+    /// Full PCI segment:bus:device.function address.
+    pub address: PciAddress,
+    /// PCI vendor ID.
+    pub vendor_id: VendorId,
+    /// PCI device ID.
+    pub device_id: DeviceId,
+    /// PCI revision ID.
+    pub revision_id: DeviceRevision,
+    /// PCI class code, stored in the low 24 bits.
+    pub class: u32,
+}
+
+impl PciDevice {
+    /// Returns whether this function has the supplied vendor and device IDs.
+    pub const fn matches(&self, vendor_id: VendorId, device_id: DeviceId) -> bool {
+        self.vendor_id == vendor_id && self.device_id == device_id
+    }
+
+    /// Returns the PCI base class code.
+    pub const fn base_class(&self) -> BaseClass {
+        ((self.class >> 16) & 0xff) as BaseClass
+    }
+
+    /// Returns the PCI subclass code.
+    pub const fn sub_class(&self) -> SubClass {
+        ((self.class >> 8) & 0xff) as SubClass
+    }
+
+    /// Returns the PCI programming interface code.
+    pub const fn interface(&self) -> Interface {
+        (self.class & 0xff) as Interface
+    }
+}
+
+/// Error produced by a PCI access backend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PciError {
+    /// The platform does not provide this PCI access mechanism.
+    NotSupported(&'static str),
+    /// A PCI bus scan could not be started or completed.
+    Scan,
+    /// A PCI configuration-space read failed.
+    ConfigRead { address: PciAddress, offset: u16 },
+    /// A PCI configuration-space write failed.
+    ConfigWrite { address: PciAddress, offset: u16 },
+    /// The address, register offset, or access width is invalid for the backend.
+    InvalidAccess { address: PciAddress, offset: u16 },
+}
+
+impl core::fmt::Display for PciError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NotSupported(message) => write!(f, "not supported: {message}"),
+            Self::Scan => write!(f, "failed to scan PCI bus"),
+            Self::ConfigRead { address, offset } => {
+                write!(f, "failed to read PCI config at {address} reg {offset:#x}")
+            }
+            Self::ConfigWrite { address, offset } => {
+                write!(f, "failed to write PCI config at {address} reg {offset:#x}")
+            }
+            Self::InvalidAccess { address, offset } => {
+                write!(f, "invalid PCI config access at {address} reg {offset:#x}")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PciError {}
+
+/// PCI Express Enhanced Configuration Access Mechanism (ECAM) backend.
+///
+/// The caller supplies a mapped ECAM region for one PCI segment.  This type
+/// does not allocate and can therefore be used from firmware after the MMIO
+/// mapping has been established.
+#[derive(Clone, Copy, Debug)]
+pub struct Ecam {
+    base: *mut u8,
+    segment: u16,
+    bus_start: u8,
+    bus_end: u8,
+}
+
+impl Ecam {
+    /// Creates an ECAM backend.
+    ///
+    /// # Safety
+    ///
+    /// `base` must point to a valid, device-memory ECAM mapping for every bus
+    /// in `bus_start..=bus_end`. The mapping must remain valid for the
+    /// backend's lifetime, and callers must arrange any platform-specific
+    /// synchronization required for configuration writes.
+    pub const unsafe fn new(base: *mut u8, segment: u16, bus_start: u8, bus_end: u8) -> Self {
+        Self {
+            base,
+            segment,
+            bus_start,
+            bus_end,
+        }
+    }
+
+    fn register_address(
+        &self,
+        address: PciAddress,
+        offset: u16,
+        width: usize,
+    ) -> Result<usize, PciError> {
+        if address.segment() != self.segment
+            || address.bus() < self.bus_start
+            || address.bus() > self.bus_end
+            || offset as usize + width > 4096
+            || !(offset as usize).is_multiple_of(width)
+        {
+            return Err(PciError::InvalidAccess { address, offset });
+        }
+
+        Ok(self.base as usize
+            + ((address.bus() - self.bus_start) as usize * 1024 * 1024)
+            + (address.device() as usize * 32 * 1024)
+            + (address.function() as usize * 4 * 1024)
+            + offset as usize)
+    }
+}
+
+impl PciConfigAccess for Ecam {
+    type Error = PciError;
+
+    fn read8(&self, address: PciAddress, offset: u16) -> Result<u8, Self::Error> {
+        let ptr = self.register_address(address, offset, 1)? as *const u8;
+        Ok(unsafe { core::ptr::read_volatile(ptr) })
+    }
+
+    fn read16(&self, address: PciAddress, offset: u16) -> Result<u16, Self::Error> {
+        let ptr = self.register_address(address, offset, 2)? as *const u16;
+        Ok(u16::from_le(unsafe { core::ptr::read_volatile(ptr) }))
+    }
+
+    fn read32(&self, address: PciAddress, offset: u16) -> Result<u32, Self::Error> {
+        let ptr = self.register_address(address, offset, 4)? as *const u32;
+        Ok(u32::from_le(unsafe { core::ptr::read_volatile(ptr) }))
+    }
+
+    fn write8(&self, address: PciAddress, offset: u16, value: u8) -> Result<(), Self::Error> {
+        let ptr = self.register_address(address, offset, 1)? as *mut u8;
+        unsafe { core::ptr::write_volatile(ptr, value) };
+        Ok(())
+    }
+
+    fn write16(&self, address: PciAddress, offset: u16, value: u16) -> Result<(), Self::Error> {
+        let ptr = self.register_address(address, offset, 2)? as *mut u16;
+        unsafe { core::ptr::write_volatile(ptr, value.to_le()) };
+        Ok(())
+    }
+
+    fn write32(&self, address: PciAddress, offset: u16, value: u32) -> Result<(), Self::Error> {
+        let ptr = self.register_address(address, offset, 4)? as *mut u32;
+        unsafe { core::ptr::write_volatile(ptr, value.to_le()) };
+        Ok(())
+    }
+}
+
+impl pci_types::ConfigRegionAccess for Ecam {
+    unsafe fn read(&self, address: PciAddress, offset: u16) -> u32 {
+        self.read32(address, offset)
+            .expect("invalid ECAM read through pci_types")
+    }
+
+    unsafe fn write(&self, address: PciAddress, offset: u16, value: u32) {
+        self.write32(address, offset, value)
+            .expect("invalid ECAM write through pci_types");
+    }
+}
+
+/// Fallible PCI configuration-space access.
+///
+/// The lower-level [`pci_types::ConfigRegionAccess`] trait is intentionally
+/// infallible and unsafe, which is appropriate for firmware ECAM mappings.
+/// This trait is for callers such as Linux userspace where configuration
+/// accesses can fail normally.
+pub trait PciConfigAccess {
+    /// Backend-specific error type.
+    type Error;
+
+    /// Reads an 8-bit configuration register.
+    fn read8(&self, address: PciAddress, offset: u16) -> Result<u8, Self::Error>;
+    /// Reads a 16-bit configuration register.
+    fn read16(&self, address: PciAddress, offset: u16) -> Result<u16, Self::Error>;
+    /// Reads a 32-bit configuration register.
+    fn read32(&self, address: PciAddress, offset: u16) -> Result<u32, Self::Error>;
+    /// Writes an 8-bit configuration register.
+    fn write8(&self, address: PciAddress, offset: u16, value: u8) -> Result<(), Self::Error>;
+    /// Writes a 16-bit configuration register.
+    fn write16(&self, address: PciAddress, offset: u16, value: u16) -> Result<(), Self::Error>;
+    /// Writes a 32-bit configuration register.
+    fn write32(&self, address: PciAddress, offset: u16, value: u32) -> Result<(), Self::Error>;
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+mod linux {
+    use super::{PciAddress, PciConfigAccess, PciDevice, PciError};
+    use std::fs::{self, OpenOptions};
+    use std::io::{Read, Seek, Write};
+    use std::path::{Path, PathBuf};
+
+    /// Linux sysfs PCI backend.
+    #[derive(Clone, Debug)]
+    pub struct SysfsPci {
+        root: PathBuf,
+    }
+
+    impl SysfsPci {
+        /// Creates a backend for the system PCI sysfs tree.
+        pub fn system() -> Self {
+            Self::new("/sys/bus/pci/devices")
+        }
+
+        /// Creates a backend rooted at `root`.
+        ///
+        /// This is primarily useful for tests with a fixture sysfs tree.
+        pub fn new(root: impl Into<PathBuf>) -> Self {
+            Self { root: root.into() }
+        }
+
+        fn device_path(&self, address: PciAddress) -> PathBuf {
+            self.root.join(format!(
+                "{:04x}:{:02x}:{:02x}.{:x}",
+                address.segment(),
+                address.bus(),
+                address.device(),
+                address.function()
+            ))
+        }
+
+        fn config_path(&self, address: PciAddress) -> PathBuf {
+            self.device_path(address).join("config")
+        }
+
+        /// Enumerates PCI functions exposed by Linux sysfs.
+        pub fn enumerate(&self) -> Result<Vec<PciDevice>, PciError> {
+            let entries = fs::read_dir(&self.root).map_err(|_| PciError::Scan)?;
+            let mut devices = Vec::new();
+            for entry in entries {
+                let entry = entry.map_err(|_| PciError::Scan)?;
+                if let Some(device) =
+                    parse_device(&entry.path(), &entry.file_name().to_string_lossy())
+                {
+                    devices.push(device);
+                }
+            }
+            Ok(devices)
+        }
+
+        fn read<const N: usize>(
+            &self,
+            address: PciAddress,
+            offset: u16,
+        ) -> Result<[u8; N], PciError> {
+            let mut file = std::fs::File::open(self.config_path(address))
+                .map_err(|_| PciError::ConfigRead { address, offset })?;
+            file.seek(std::io::SeekFrom::Start(offset.into()))
+                .map_err(|_| PciError::ConfigRead { address, offset })?;
+            let mut bytes = [0; N];
+            file.read_exact(&mut bytes)
+                .map_err(|_| PciError::ConfigRead { address, offset })?;
+            Ok(bytes)
+        }
+
+        fn write(&self, address: PciAddress, offset: u16, bytes: &[u8]) -> Result<(), PciError> {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .open(self.config_path(address))
+                .map_err(|_| PciError::ConfigWrite { address, offset })?;
+            file.seek(std::io::SeekFrom::Start(offset.into()))
+                .map_err(|_| PciError::ConfigWrite { address, offset })?;
+            file.write_all(bytes)
+                .map_err(|_| PciError::ConfigWrite { address, offset })
+        }
+    }
+
+    impl Default for SysfsPci {
+        fn default() -> Self {
+            Self::system()
+        }
+    }
+
+    impl PciConfigAccess for SysfsPci {
+        type Error = PciError;
+
+        fn read8(&self, address: PciAddress, offset: u16) -> Result<u8, Self::Error> {
+            Ok(self.read::<1>(address, offset)?[0])
+        }
+        fn read16(&self, address: PciAddress, offset: u16) -> Result<u16, Self::Error> {
+            Ok(u16::from_le_bytes(self.read::<2>(address, offset)?))
+        }
+        fn read32(&self, address: PciAddress, offset: u16) -> Result<u32, Self::Error> {
+            Ok(u32::from_le_bytes(self.read::<4>(address, offset)?))
+        }
+        fn write8(&self, address: PciAddress, offset: u16, value: u8) -> Result<(), Self::Error> {
+            self.write(address, offset, &[value])
+        }
+        fn write16(&self, address: PciAddress, offset: u16, value: u16) -> Result<(), Self::Error> {
+            self.write(address, offset, &value.to_le_bytes())
+        }
+        fn write32(&self, address: PciAddress, offset: u16, value: u32) -> Result<(), Self::Error> {
+            self.write(address, offset, &value.to_le_bytes())
+        }
+    }
+
+    fn read_hex(path: &Path) -> Option<String> {
+        Some(
+            fs::read_to_string(path)
+                .ok()?
+                .trim()
+                .trim_start_matches("0x")
+                .to_owned(),
+        )
+    }
+
+    fn read_hex_u8(path: &Path) -> Option<u8> {
+        u8::from_str_radix(&read_hex(path)?, 16).ok()
+    }
+
+    fn read_hex_u16(path: &Path) -> Option<u16> {
+        u16::from_str_radix(&read_hex(path)?, 16).ok()
+    }
+
+    fn read_hex_u32(path: &Path) -> Option<u32> {
+        u32::from_str_radix(&read_hex(path)?, 16).ok()
+    }
+
+    fn parse_device(path: &Path, name: &str) -> Option<PciDevice> {
+        let (segment, rest) = name.split_once(':')?;
+        let (bus, rest) = rest.split_once(':')?;
+        let (device, function) = rest.split_once('.')?;
+        let address = PciAddress::new(
+            u16::from_str_radix(segment, 16).ok()?,
+            u8::from_str_radix(bus, 16).ok()?,
+            u8::from_str_radix(device, 16).ok()?,
+            u8::from_str_radix(function, 16).ok()?,
+        );
+        Some(PciDevice {
+            address,
+            vendor_id: read_hex_u16(&path.join("vendor"))?,
+            device_id: read_hex_u16(&path.join("device"))?,
+            revision_id: read_hex_u8(&path.join("revision")).unwrap_or(0),
+            class: read_hex_u32(&path.join("class")).unwrap_or(0),
+        })
+    }
+
+    /// Reads a legacy PCI configuration dword through x86 configuration ports.
+    ///
+    /// This supports only segment zero and offsets below 256. It requires
+    /// `CAP_SYS_RAWIO` (normally root) and serializes the global CF8/CFC pair.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    pub fn read32_direct(address: PciAddress, offset: u16) -> Result<u32, PciError> {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        if address.segment() != 0 || offset > u8::MAX as u16 {
+            return Err(PciError::NotSupported(
+                "legacy PCI config access requires segment 0 and an offset below 256",
+            ));
+        }
+        let _guard = LOCK.lock().expect("PCI configuration lock poisoned");
+        if unsafe { libc::iopl(3) } != 0 {
+            return Err(PciError::ConfigRead { address, offset });
+        }
+        let config_address = 0x8000_0000
+            | ((address.bus() as u32) << 16)
+            | ((address.device() as u32) << 11)
+            | ((address.function() as u32) << 8)
+            | ((offset as u32) & 0xfc);
+        let value: u32;
+        unsafe {
+            core::arch::asm!("out dx, eax", in("dx") 0xcf8_u16, in("eax") config_address, options(nomem, nostack, preserves_flags));
+            core::arch::asm!("in eax, dx", in("dx") 0xcfc_u16, out("eax") value, options(nomem, nostack, preserves_flags));
+        }
+        Ok(value)
+    }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    pub fn read32_direct(_address: PciAddress, _offset: u16) -> Result<u32, PciError> {
+        Err(PciError::NotSupported(
+            "legacy PCI config access is only available on x86 Linux",
+        ))
+    }
+}
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+pub use linux::{SysfsPci, read32_direct};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_matches_ids() {
+        let device = PciDevice {
+            address: PciAddress::new(2, 0, 0x1f, 0),
+            vendor_id: 0x1002,
+            device_id: 0x438d,
+            revision_id: 0,
+            class: 0x010601,
+        };
+        assert!(device.matches(0x1002, 0x438d));
+        assert!(!device.matches(0x1002, 0x438e));
+        assert_eq!(device.base_class(), 0x01);
+        assert_eq!(device.sub_class(), 0x06);
+        assert_eq!(device.interface(), 0x01);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn ecam_access_uses_segment_relative_addresses() {
+        use crate::PciConfigAccess as _;
+
+        let mut memory = alloc::vec![0_u8; 1024 * 1024];
+        let ecam = unsafe { Ecam::new(memory.as_mut_ptr(), 2, 3, 3) };
+        let address = PciAddress::new(2, 3, 1, 2);
+        ecam.write32(address, 0x00, 0x438d_1002).unwrap();
+        ecam.write32(address, 0x10, 0x1234_5678).unwrap();
+
+        assert_eq!(ecam.read32(address, 0x10).unwrap(), 0x1234_5678);
+        assert_eq!(
+            pci_types::PciHeader::new(address).id(ecam),
+            (0x1002, 0x438d)
+        );
+        assert!(matches!(
+            ecam.write32(address, 0x11, 0),
+            Err(PciError::InvalidAccess { .. })
+        ));
+        assert!(matches!(
+            ecam.read32(PciAddress::new(2, 4, 1, 2), 0x10),
+            Err(PciError::InvalidAccess { .. })
+        ));
+    }
+
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    #[test]
+    fn sysfs_backend_enumerates_and_reads_a_fixture() {
+        use crate::PciConfigAccess as _;
+        use std::fs;
+
+        let root = std::env::temp_dir().join(format!("rflasher-pci-test-{}", std::process::id()));
+        let device = root.join("0002:03:1f.4");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&device).unwrap();
+        fs::write(device.join("vendor"), "0x1002\n").unwrap();
+        fs::write(device.join("device"), "0x438d\n").unwrap();
+        fs::write(device.join("revision"), "0x41\n").unwrap();
+        fs::write(device.join("class"), "0x010601\n").unwrap();
+        let mut config = [0_u8; 64];
+        config[0x10..0x12].copy_from_slice(&0x1234_u16.to_le_bytes());
+        fs::write(device.join("config"), config).unwrap();
+
+        let pci = SysfsPci::new(&root);
+        let devices = pci.enumerate().unwrap();
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].address, PciAddress::new(2, 3, 0x1f, 4));
+        assert_eq!(pci.read16(devices[0].address, 0x10).unwrap(), 0x1234);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}


### PR DESCRIPTION
The new `rflasher-pci` crate provides `PciConfigAccess`, `Ecam`, and
`SysfsPci` backends along with shared `PciAddress` and `PciDevice`
types. The old monolithic `pci.rs` in `rflasher-internal` is replaced by
a thin chipset‑detection layer that delegates enumeration and config
access to the new crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable PCI access layer supporting device discovery, configuration reads and writes, ECAM access, and Linux sysfs integration.
  * Added PCI device matching and metadata utilities for chipset detection.
  * Enabled the new PCI functionality across standard workspace builds.
* **Bug Fixes**
  * Improved PCI address handling and validation.
  * Added clearer errors for invalid PCI configuration accesses.
  * Preserved PCI segment information during chipset detection and controller setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->