### PR TITLE
Update Raiden V2 packet serialization to use variable-length USB transfers and zerocopy wire-format parsing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,6 +3144,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ prettyplease = "0.2"
 heapless = "0.8"
 once_cell = { version = "1.21", default-features = false }
 maybe-async = "0.2"
+zerocopy = { version = "0.8", features = ["derive"] }
 
 [package]
 name = "rflasher"

--- a/crates/rflasher-raiden/Cargo.toml
+++ b/crates/rflasher-raiden/Cargo.toml
@@ -17,6 +17,7 @@ nusb = { workspace = true, optional = true }
 futures-lite = { version = "2", optional = true }
 maybe-async.workspace = true
 log.workspace = true
+zerocopy.workspace = true
 
 web-sys = { version = "0.3", optional = true, features = [
     "Navigator",

--- a/crates/rflasher-raiden/src/protocol.rs
+++ b/crates/rflasher-raiden/src/protocol.rs
@@ -365,6 +365,8 @@ pub struct CommandV2Start {
     pub write_count: u16,
     /// Total number of bytes to read (0xFFFF = full duplex)
     pub read_count: u16,
+    /// Number of valid bytes in `data`
+    pub data_len: usize,
     /// First chunk of write data (up to 58 bytes)
     pub data: [u8; V2_START_PAYLOAD],
 }
@@ -375,6 +377,7 @@ impl Default for CommandV2Start {
             packet_id: PacketId::CmdTransferStart as u16,
             write_count: 0,
             read_count: 0,
+            data_len: 0,
             data: [0; V2_START_PAYLOAD],
         }
     }
@@ -389,17 +392,21 @@ impl CommandV2Start {
             ..Default::default()
         };
         let len = std::cmp::min(first_data.len(), V2_START_PAYLOAD);
+        cmd.data_len = len;
         cmd.data[..len].copy_from_slice(&first_data[..len]);
         cmd
     }
 
-    /// Serialize to a 64-byte packet
-    pub fn to_bytes(&self) -> [u8; USB_PACKET_SIZE] {
-        let mut buf = [0u8; USB_PACKET_SIZE];
+    /// Serialize to a variable-length packet.
+    ///
+    /// The device uses the USB transfer length to determine how much write
+    /// payload is present, so the final packet must not be padded to 64 bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![0u8; 6 + self.data_len];
         buf[0..2].copy_from_slice(&self.packet_id.to_le_bytes());
         buf[2..4].copy_from_slice(&self.write_count.to_le_bytes());
         buf[4..6].copy_from_slice(&self.read_count.to_le_bytes());
-        buf[6..64].copy_from_slice(&self.data);
+        buf[6..].copy_from_slice(&self.data[..self.data_len]);
         buf
     }
 }
@@ -411,6 +418,8 @@ pub struct CommandV2Continue {
     pub packet_id: u16,
     /// Byte offset for validation
     pub data_index: u16,
+    /// Number of valid bytes in `data`
+    pub data_len: usize,
     /// Additional write data (up to 60 bytes)
     pub data: [u8; V2_CONTINUE_PAYLOAD],
 }
@@ -420,6 +429,7 @@ impl Default for CommandV2Continue {
         Self {
             packet_id: PacketId::CmdTransferContinue as u16,
             data_index: 0,
+            data_len: 0,
             data: [0; V2_CONTINUE_PAYLOAD],
         }
     }
@@ -433,16 +443,17 @@ impl CommandV2Continue {
             ..Default::default()
         };
         let len = std::cmp::min(data.len(), V2_CONTINUE_PAYLOAD);
+        cmd.data_len = len;
         cmd.data[..len].copy_from_slice(&data[..len]);
         cmd
     }
 
-    /// Serialize to a 64-byte packet
-    pub fn to_bytes(&self) -> [u8; USB_PACKET_SIZE] {
-        let mut buf = [0u8; USB_PACKET_SIZE];
+    /// Serialize to a variable-length packet.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![0u8; 4 + self.data_len];
         buf[0..2].copy_from_slice(&self.packet_id.to_le_bytes());
         buf[2..4].copy_from_slice(&self.data_index.to_le_bytes());
-        buf[4..64].copy_from_slice(&self.data);
+        buf[4..].copy_from_slice(&self.data[..self.data_len]);
         buf
     }
 }
@@ -463,11 +474,9 @@ impl Default for CommandV2Restart {
 }
 
 impl CommandV2Restart {
-    /// Serialize to a 64-byte packet
-    pub fn to_bytes(&self) -> [u8; USB_PACKET_SIZE] {
-        let mut buf = [0u8; USB_PACKET_SIZE];
-        buf[0..2].copy_from_slice(&self.packet_id.to_le_bytes());
-        buf
+    /// Serialize the two-byte command header.
+    pub fn to_bytes(&self) -> [u8; 2] {
+        self.packet_id.to_le_bytes()
     }
 }
 
@@ -487,11 +496,9 @@ impl Default for CommandV2GetConfig {
 }
 
 impl CommandV2GetConfig {
-    /// Serialize to a 64-byte packet
-    pub fn to_bytes(&self) -> [u8; USB_PACKET_SIZE] {
-        let mut buf = [0u8; USB_PACKET_SIZE];
-        buf[0..2].copy_from_slice(&self.packet_id.to_le_bytes());
-        buf
+    /// Serialize the two-byte command header.
+    pub fn to_bytes(&self) -> [u8; 2] {
+        self.packet_id.to_le_bytes()
     }
 }
 
@@ -605,5 +612,28 @@ impl ResponseV2Config {
     /// Check if full duplex is supported
     pub fn supports_full_duplex(&self) -> bool {
         self.feature_bitmap & features::FULL_DUPLEX != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn v2_header_only_commands_are_two_bytes() {
+        assert_eq!(CommandV2GetConfig::default().to_bytes(), [0, 0]);
+        assert_eq!(CommandV2Restart::default().to_bytes(), [4, 0]);
+    }
+
+    #[test]
+    fn v2_start_packet_contains_only_valid_payload() {
+        let cmd = CommandV2Start::new(3, 2, &[0x9f, 0xaa, 0x55]);
+        assert_eq!(cmd.to_bytes(), vec![2, 0, 3, 0, 2, 0, 0x9f, 0xaa, 0x55]);
+    }
+
+    #[test]
+    fn v2_continue_packet_contains_only_valid_payload() {
+        let cmd = CommandV2Continue::new(58, &[0xde, 0xad]);
+        assert_eq!(cmd.to_bytes(), vec![3, 0, 58, 0, 0xde, 0xad]);
     }
 }

--- a/crates/rflasher-raiden/src/protocol.rs
+++ b/crates/rflasher-raiden/src/protocol.rs
@@ -9,6 +9,9 @@
 
 #![allow(dead_code)]
 
+use zerocopy::byteorder::little_endian::U16 as U16Le;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
 // ===========================================================================
 // USB Device Identifiers
 // ===========================================================================
@@ -109,6 +112,43 @@ impl PacketId {
             _ => None,
         }
     }
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct PacketV2Header {
+    packet_id: U16Le,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct CommandV2StartHeader {
+    packet_id: U16Le,
+    write_count: U16Le,
+    read_count: U16Le,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct PacketV2ContinueHeader {
+    packet_id: U16Le,
+    data_index: U16Le,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct ResponseV2StartHeader {
+    packet_id: U16Le,
+    status_code: U16Le,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct ResponseV2ConfigWire {
+    packet_id: U16Le,
+    max_write_count: U16Le,
+    max_read_count: U16Le,
+    feature_bitmap: U16Le,
 }
 
 // ===========================================================================
@@ -402,12 +442,15 @@ impl CommandV2Start {
     /// The device uses the USB transfer length to determine how much write
     /// payload is present, so the final packet must not be padded to 64 bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut buf = vec![0u8; 6 + self.data_len];
-        buf[0..2].copy_from_slice(&self.packet_id.to_le_bytes());
-        buf[2..4].copy_from_slice(&self.write_count.to_le_bytes());
-        buf[4..6].copy_from_slice(&self.read_count.to_le_bytes());
-        buf[6..].copy_from_slice(&self.data[..self.data_len]);
-        buf
+        let header = CommandV2StartHeader {
+            packet_id: U16Le::new(self.packet_id),
+            write_count: U16Le::new(self.write_count),
+            read_count: U16Le::new(self.read_count),
+        };
+        let mut packet = Vec::with_capacity(size_of::<CommandV2StartHeader>() + self.data_len);
+        packet.extend_from_slice(header.as_bytes());
+        packet.extend_from_slice(&self.data[..self.data_len]);
+        packet
     }
 }
 
@@ -450,11 +493,14 @@ impl CommandV2Continue {
 
     /// Serialize to a variable-length packet.
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut buf = vec![0u8; 4 + self.data_len];
-        buf[0..2].copy_from_slice(&self.packet_id.to_le_bytes());
-        buf[2..4].copy_from_slice(&self.data_index.to_le_bytes());
-        buf[4..].copy_from_slice(&self.data[..self.data_len]);
-        buf
+        let header = PacketV2ContinueHeader {
+            packet_id: U16Le::new(self.packet_id),
+            data_index: U16Le::new(self.data_index),
+        };
+        let mut packet = Vec::with_capacity(size_of::<PacketV2ContinueHeader>() + self.data_len);
+        packet.extend_from_slice(header.as_bytes());
+        packet.extend_from_slice(&self.data[..self.data_len]);
+        packet
     }
 }
 
@@ -475,8 +521,12 @@ impl Default for CommandV2Restart {
 
 impl CommandV2Restart {
     /// Serialize the two-byte command header.
-    pub fn to_bytes(&self) -> [u8; 2] {
-        self.packet_id.to_le_bytes()
+    pub fn to_bytes(&self) -> Vec<u8> {
+        PacketV2Header {
+            packet_id: U16Le::new(self.packet_id),
+        }
+        .as_bytes()
+        .to_vec()
     }
 }
 
@@ -497,8 +547,12 @@ impl Default for CommandV2GetConfig {
 
 impl CommandV2GetConfig {
     /// Serialize the two-byte command header.
-    pub fn to_bytes(&self) -> [u8; 2] {
-        self.packet_id.to_le_bytes()
+    pub fn to_bytes(&self) -> Vec<u8> {
+        PacketV2Header {
+            packet_id: U16Le::new(self.packet_id),
+        }
+        .as_bytes()
+        .to_vec()
     }
 }
 
@@ -526,16 +580,16 @@ impl Default for ResponseV2Start {
 impl ResponseV2Start {
     /// Parse from a 64-byte packet
     pub fn from_bytes(buf: &[u8]) -> Self {
-        let mut rsp = Self::default();
-        if buf.len() >= 4 {
-            rsp.packet_id = u16::from_le_bytes([buf[0], buf[1]]);
-            rsp.status_code = u16::from_le_bytes([buf[2], buf[3]]);
-        }
-        if buf.len() >= 64 {
-            rsp.data.copy_from_slice(&buf[4..64]);
-        } else if buf.len() > 4 {
-            rsp.data[..buf.len() - 4].copy_from_slice(&buf[4..]);
-        }
+        let Ok((header, payload)) = ResponseV2StartHeader::ref_from_prefix(buf) else {
+            return Self::default();
+        };
+        let mut rsp = Self {
+            packet_id: header.packet_id.get(),
+            status_code: header.status_code.get(),
+            ..Default::default()
+        };
+        let data_len = payload.len().min(V2_CONTINUE_PAYLOAD);
+        rsp.data[..data_len].copy_from_slice(&payload[..data_len]);
         rsp
     }
 
@@ -569,16 +623,16 @@ impl Default for ResponseV2Continue {
 impl ResponseV2Continue {
     /// Parse from a 64-byte packet
     pub fn from_bytes(buf: &[u8]) -> Self {
-        let mut rsp = Self::default();
-        if buf.len() >= 4 {
-            rsp.packet_id = u16::from_le_bytes([buf[0], buf[1]]);
-            rsp.data_index = u16::from_le_bytes([buf[2], buf[3]]);
-        }
-        if buf.len() >= 64 {
-            rsp.data.copy_from_slice(&buf[4..64]);
-        } else if buf.len() > 4 {
-            rsp.data[..buf.len() - 4].copy_from_slice(&buf[4..]);
-        }
+        let Ok((header, payload)) = PacketV2ContinueHeader::ref_from_prefix(buf) else {
+            return Self::default();
+        };
+        let mut rsp = Self {
+            packet_id: header.packet_id.get(),
+            data_index: header.data_index.get(),
+            ..Default::default()
+        };
+        let data_len = payload.len().min(V2_CONTINUE_PAYLOAD);
+        rsp.data[..data_len].copy_from_slice(&payload[..data_len]);
         rsp
     }
 }
@@ -599,14 +653,15 @@ pub struct ResponseV2Config {
 impl ResponseV2Config {
     /// Parse from a 64-byte packet
     pub fn from_bytes(buf: &[u8]) -> Self {
-        let mut rsp = Self::default();
-        if buf.len() >= 8 {
-            rsp.packet_id = u16::from_le_bytes([buf[0], buf[1]]);
-            rsp.max_write_count = u16::from_le_bytes([buf[2], buf[3]]);
-            rsp.max_read_count = u16::from_le_bytes([buf[4], buf[5]]);
-            rsp.feature_bitmap = u16::from_le_bytes([buf[6], buf[7]]);
+        let Ok((wire, _)) = ResponseV2ConfigWire::ref_from_prefix(buf) else {
+            return Self::default();
+        };
+        Self {
+            packet_id: wire.packet_id.get(),
+            max_write_count: wire.max_write_count.get(),
+            max_read_count: wire.max_read_count.get(),
+            feature_bitmap: wire.feature_bitmap.get(),
         }
-        rsp
     }
 
     /// Check if full duplex is supported


### PR DESCRIPTION
- Stop padding V2 command packets to 64 bytes; send only the header and valid payload.
- Track valid payload lengths for start and continuation commands.
- Add zerocopy packet header types for safe little-endian serialization and parsing.
- Improve response parsing for short or malformed buffers.
- Add tests covering header-only and variable-length command packets.