### PR TITLE
Fix IFD for non PCH & use zerocopy

### DIFF
--- a/crates/rflasher-core/src/layout/ifd.rs
+++ b/crates/rflasher-core/src/layout/ifd.rs
@@ -7,6 +7,9 @@
 
 use std::string::ToString;
 
+use zerocopy::byteorder::little_endian::U32 as U32LE;
+use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
+
 use super::{Layout, LayoutError, LayoutSource, Region};
 
 /// Intel Flash Descriptor signature.
@@ -18,6 +21,19 @@ const IFD_SIGNATURE: u32 = 0x0FF0_A55A;
 
 /// Maximum number of IFD regions
 const MAX_IFD_REGIONS: usize = 16;
+
+/// Fixed portion of an Intel Flash Descriptor.
+#[repr(C)]
+#[derive(FromBytes, KnownLayout, Immutable, Unaligned)]
+struct IfdHeader {
+    signature: U32LE,
+    flmap0: U32LE,
+}
+
+fn ifd_header_at(data: &[u8], offset: usize) -> Option<&IfdHeader> {
+    let (header, _) = IfdHeader::ref_from_prefix(data.get(offset..)?).ok()?;
+    (header.signature.get() == IFD_SIGNATURE).then_some(header)
+}
 
 /// IFD region names (based on Intel documentation)
 const IFD_REGION_NAMES: [&str; MAX_IFD_REGIONS] = [
@@ -75,21 +91,10 @@ pub fn parse_ifd(data: &[u8]) -> Result<Layout, LayoutError> {
     // flashprog accepts the normal descriptor location (offset 0) and the
     // PCH-bug variant where the descriptor is shifted by one DWORD (offset
     // 0x10). FLMAP0 is immediately after the signature in either form.
-    let descriptor_offset = if data[0..4] == IFD_SIGNATURE.to_le_bytes() {
-        0
-    } else if data[0x10..0x14] == IFD_SIGNATURE.to_le_bytes() {
-        0x10
-    } else {
-        return Err(LayoutError::InvalidIfdSignature);
-    };
-
-    let flmap0_offset = descriptor_offset + 4;
-    let flmap0 = u32::from_le_bytes([
-        data[flmap0_offset],
-        data[flmap0_offset + 1],
-        data[flmap0_offset + 2],
-        data[flmap0_offset + 3],
-    ]);
+    let header = ifd_header_at(data, 0)
+        .or_else(|| ifd_header_at(data, 0x10))
+        .ok_or(LayoutError::InvalidIfdSignature)?;
+    let flmap0 = header.flmap0.get();
 
     // Calculate Flash Region Base Address (FRBA), matching flashprog's
     // getFRBA() macro. FRBA is an absolute descriptor offset, even for the
@@ -101,22 +106,19 @@ pub fn parse_ifd(data: &[u8]) -> Result<Layout, LayoutError> {
     let nr = ((flmap0 >> 24) & 0x7) as usize;
     let num_regions = nr + 1;
 
-    if frba + num_regions * 4 > data.len() {
-        return Err(LayoutError::InvalidIfdSignature);
-    }
+    let (region_registers, _) = <[U32LE]>::ref_from_prefix_with_elems(
+        data.get(frba..)
+            .ok_or(LayoutError::InvalidIfdSignature)?,
+        num_regions,
+    )
+    .map_err(|_| LayoutError::InvalidIfdSignature)?;
 
     let mut layout = Layout::with_source(LayoutSource::Ifd);
     layout.name = Some("Intel Flash Descriptor".to_string());
 
     // Parse each region
-    for (i, &name) in IFD_REGION_NAMES.iter().enumerate().take(num_regions) {
-        let offset = frba + i * 4;
-        let freg = u32::from_le_bytes([
-            data[offset],
-            data[offset + 1],
-            data[offset + 2],
-            data[offset + 3],
-        ]);
+    for (&name, freg) in IFD_REGION_NAMES.iter().zip(region_registers) {
+        let freg = freg.get();
 
         // 0xFFFFFFFF indicates we've hit uninitialized flash memory beyond the
         // actual region table. Stop scanning here.
@@ -146,11 +148,7 @@ pub fn parse_ifd(data: &[u8]) -> Result<Layout, LayoutError> {
 
 /// Check if data appears to contain an Intel Flash Descriptor
 pub fn has_ifd(data: &[u8]) -> bool {
-    if data.len() < 0x14 {
-        return false;
-    }
-    data[0..4] == IFD_SIGNATURE.to_le_bytes()
-        || data[0x10..0x14] == IFD_SIGNATURE.to_le_bytes()
+    ifd_header_at(data, 0).is_some() || ifd_header_at(data, 0x10).is_some()
 }
 
 impl Layout {

--- a/crates/rflasher-core/src/layout/ifd.rs
+++ b/crates/rflasher-core/src/layout/ifd.rs
@@ -9,7 +9,11 @@ use std::string::ToString;
 
 use super::{Layout, LayoutError, LayoutSource, Region};
 
-/// IFD signature at offset 0x10
+/// Intel Flash Descriptor signature.
+///
+/// Normal descriptors store this at offset 0x00. Some PCH generations have
+/// the descriptor shifted by one DWORD, in which case it is at offset 0x10;
+/// flashprog accepts both forms.
 const IFD_SIGNATURE: u32 = 0x0FF0_A55A;
 
 /// Maximum number of IFD regions
@@ -68,24 +72,34 @@ pub fn parse_ifd(data: &[u8]) -> Result<Layout, LayoutError> {
         return Err(LayoutError::InvalidIfdSignature);
     }
 
-    // Check signature at offset 0x10
-    let sig = u32::from_le_bytes([data[0x10], data[0x11], data[0x12], data[0x13]]);
-    if sig != IFD_SIGNATURE {
+    // flashprog accepts the normal descriptor location (offset 0) and the
+    // PCH-bug variant where the descriptor is shifted by one DWORD (offset
+    // 0x10). FLMAP0 is immediately after the signature in either form.
+    let descriptor_offset = if data[0..4] == IFD_SIGNATURE.to_le_bytes() {
+        0
+    } else if data[0x10..0x14] == IFD_SIGNATURE.to_le_bytes() {
+        0x10
+    } else {
         return Err(LayoutError::InvalidIfdSignature);
-    }
+    };
 
-    // Read FLMAP0 at offset 0x14
-    let flmap0 = u32::from_le_bytes([data[0x14], data[0x15], data[0x16], data[0x17]]);
+    let flmap0_offset = descriptor_offset + 4;
+    let flmap0 = u32::from_le_bytes([
+        data[flmap0_offset],
+        data[flmap0_offset + 1],
+        data[flmap0_offset + 2],
+        data[flmap0_offset + 3],
+    ]);
 
-    // Calculate Flash Region Base Address (FRBA)
-    // FRBA is at bits 23:16 of FLMAP0, shifted left by 4
+    // Calculate Flash Region Base Address (FRBA), matching flashprog's
+    // getFRBA() macro. FRBA is an absolute descriptor offset, even for the
+    // PCH-bug variant.
     let frba = ((flmap0 >> 12) & 0xFF0) as usize;
 
-    // Always scan all possible regions (up to 16).
-    // The NR field in FLMAP0 is not reliable for newer chipsets (Skylake+),
-    // where the number of regions is fixed per chipset generation.
-    // Unused regions have limit < base, which we detect below.
-    let num_regions = MAX_IFD_REGIONS;
+    // ICH9 uses NR + 1 region entries. This is flashprog's fallback rule for
+    // pre-PCH100 chipsets.
+    let nr = ((flmap0 >> 24) & 0x7) as usize;
+    let num_regions = nr + 1;
 
     if frba + num_regions * 4 > data.len() {
         return Err(LayoutError::InvalidIfdSignature);
@@ -114,8 +128,8 @@ pub fn parse_ifd(data: &[u8]) -> Result<Layout, LayoutError> {
         let base = freg_base(freg);
         let limit = freg_limit(freg);
 
-        // Region is unused if limit < base
-        if limit < base {
+        // Region is unused if limit <= base
+        if limit <= base {
             continue;
         }
 
@@ -135,8 +149,8 @@ pub fn has_ifd(data: &[u8]) -> bool {
     if data.len() < 0x14 {
         return false;
     }
-    let sig = u32::from_le_bytes([data[0x10], data[0x11], data[0x12], data[0x13]]);
-    sig == IFD_SIGNATURE
+    data[0..4] == IFD_SIGNATURE.to_le_bytes()
+        || data[0x10..0x14] == IFD_SIGNATURE.to_le_bytes()
 }
 
 impl Layout {
@@ -162,21 +176,22 @@ mod tests {
     /// This sets base=0x7FFF (max), limit=0 which makes limit < base.
     const FLREG_UNUSED: u32 = 0x00007FFF;
 
-    fn make_test_ifd() -> Vec<u8> {
+    fn make_test_ifd_at(offset: usize) -> Vec<u8> {
         let mut data = vec![0x00; 0x1000];
 
-        // Signature at 0x10
-        data[0x10..0x14].copy_from_slice(&IFD_SIGNATURE.to_le_bytes());
+        // Signature at the requested descriptor offset
+        data[offset..offset + 4].copy_from_slice(&IFD_SIGNATURE.to_le_bytes());
 
         // FLMAP0: NR=2 (3 regions), FRBA=0x40 (0x40 >> 4 = 0x04 in field)
         // bits 26:24 = NR, bits 23:16 = FRBA >> 4
         let flmap0: u32 = (2 << 24) | (0x04 << 16);
-        data[0x14..0x18].copy_from_slice(&flmap0.to_le_bytes());
+        data[offset + 4..offset + 8].copy_from_slice(&flmap0.to_le_bytes());
 
-        // FRBA at 0x40 - initialize all 16 regions as unused first
-        for i in 0..MAX_IFD_REGIONS {
-            let offset = 0x40 + i * 4;
-            data[offset..offset + 4].copy_from_slice(&FLREG_UNUSED.to_le_bytes());
+        // FRBA at absolute offset 0x40 - initialize all reported regions as unused first
+        for i in 0..3 {
+            let region_offset = 0x40 + i * 4;
+            data[region_offset..region_offset + 4]
+                .copy_from_slice(&FLREG_UNUSED.to_le_bytes());
         }
 
         // Region 0 (descriptor): 0x000000 - 0x000FFF
@@ -192,6 +207,10 @@ mod tests {
         data[0x48..0x4C].copy_from_slice(&freg2.to_le_bytes());
 
         data
+    }
+
+    fn make_test_ifd() -> Vec<u8> {
+        make_test_ifd_at(0x10)
     }
 
     #[test]
@@ -221,5 +240,12 @@ mod tests {
         assert_eq!(layout.regions[2].start, 0x800000);
         assert_eq!(layout.regions[2].end, 0xFFFFFF);
         assert!(layout.regions[2].dangerous);
+    }
+
+    #[test]
+    fn test_parse_standard_ifd_location() {
+        let data = make_test_ifd_at(0);
+        assert!(has_ifd(&data));
+        assert_eq!(parse_ifd(&data).unwrap().regions.len(), 3);
     }
 }

--- a/crates/rflasher-core/src/layout/ifd.rs
+++ b/crates/rflasher-core/src/layout/ifd.rs
@@ -107,8 +107,7 @@ pub fn parse_ifd(data: &[u8]) -> Result<Layout, LayoutError> {
     let num_regions = nr + 1;
 
     let (region_registers, _) = <[U32LE]>::ref_from_prefix_with_elems(
-        data.get(frba..)
-            .ok_or(LayoutError::InvalidIfdSignature)?,
+        data.get(frba..).ok_or(LayoutError::InvalidIfdSignature)?,
         num_regions,
     )
     .map_err(|_| LayoutError::InvalidIfdSignature)?;
@@ -188,8 +187,7 @@ mod tests {
         // FRBA at absolute offset 0x40 - initialize all reported regions as unused first
         for i in 0..3 {
             let region_offset = 0x40 + i * 4;
-            data[region_offset..region_offset + 4]
-                .copy_from_slice(&FLREG_UNUSED.to_le_bytes());
+            data[region_offset..region_offset + 4].copy_from_slice(&FLREG_UNUSED.to_le_bytes());
         }
 
         // Region 0 (descriptor): 0x000000 - 0x000FFF


### PR DESCRIPTION
Code changes:
- Updated Intel Flash Descriptor detection to support both standard offset `0x00` and the PCH-shifted offset `0x10`.
- Added zerocopy-based parsing for the IFD header and region registers with bounds-safe validation.
- Read the region count from the `NR` field in `FLMAP0`, following the ICH9 fallback behavior.
- Treat regions with `limit <= base` as unused.
- Added tests covering standard and shifted descriptor locations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Intel Flash Descriptor detection and parsing for both standard (offset 0) and PCH-shifted layouts.
  * Derives the descriptor region table location and reads the declared number of region entries instead of stopping early.
  * Adjusted unused/empty region handling for correct boundary behavior.
* **Tests**
  * Added coverage to validate parsing when the IFD signature is located at the standard offset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->