### PR TITLE
Add Micron IDs and reject duplicate names

### DIFF
--- a/crates/rflasher-chips-codegen/src/lib.rs
+++ b/crates/rflasher-chips-codegen/src/lib.rs
@@ -7,6 +7,7 @@ use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 use serde::Deserialize;
 
+use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -483,7 +484,16 @@ impl ChipDatabase {
     /// Validate the chip database
     pub fn validate(&self) -> Result<(), Error> {
         for vendor in &self.vendors {
+            let mut chip_names = HashSet::new();
+
             for chip in &vendor.chips {
+                if !chip_names.insert(chip.name.as_str()) {
+                    return Err(Error::Validation(format!(
+                        "Vendor {} defines chip name {} more than once",
+                        vendor.vendor, chip.name
+                    )));
+                }
+
                 // Validate erase blocks
                 if chip.erase_blocks.is_empty() {
                     return Err(Error::Validation(format!(

--- a/crates/rflasher-chips/data/vendors/atmel.ron
+++ b/crates/rflasher-chips/data/vendors/atmel.ron
@@ -1,5 +1,9 @@
 // Atmel/Adesto SPI Flash Chips
 // Ported from flashprog/flashchips.c
+//
+// AT45 DataFlash parts are intentionally excluded: although transported over
+// SPI, they require the DataFlash page-buffer protocol, which rflasher's
+// ordinary SPI-NOR chip model does not represent.
 
 (
     vendor: "Atmel",

--- a/crates/rflasher-chips/data/vendors/eon.ron
+++ b/crates/rflasher-chips/data/vendors/eon.ron
@@ -19,19 +19,7 @@
                 (opcode: 0xC7, regions: [(size: KiB(512), count: 1)]),
             ],
         ),
-        (
-            name: "EN25Q80",
-            device_id: 0x3014,
-            total_size: MiB(1),
-            features: (wrsr_wren: true, otp: true),
-            voltage: (min: 2700, max: 3600),
-            erase_blocks: [
-                (opcode: 0x20, regions: [(size: KiB(4), count: 256)]),
-                (opcode: 0xD8, regions: [(size: KiB(64), count: 16)]),
-                (opcode: 0x60, regions: [(size: MiB(1), count: 1)]),
-                (opcode: 0xC7, regions: [(size: MiB(1), count: 1)]),
-            ],
-        ),
+
         (
             name: "EN25Q16",
             device_id: 0x3015,
@@ -104,36 +92,7 @@
             ],
             tested: (probe: Ok, read: Ok, erase: Ok, write: Ok),
         ),
-        (
-            name: "EN25QH32",
-            device_id: 0x7016,
-            total_size: MiB(4),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true),
-            voltage: (min: 2700, max: 3600),
-            erase_blocks: [
-                (opcode: 0x20, regions: [(size: KiB(4), count: 1024)]),
-                (opcode: 0x52, regions: [(size: KiB(32), count: 128)]),
-                (opcode: 0xD8, regions: [(size: KiB(64), count: 64)]),
-                (opcode: 0x60, regions: [(size: MiB(4), count: 1)]),
-                (opcode: 0xC7, regions: [(size: MiB(4), count: 1)]),
-            ],
-            tested: (probe: Ok, read: Ok, erase: Ok, write: Ok),
-        ),
-        (
-            name: "EN25QH64",
-            device_id: 0x7017,
-            total_size: MiB(8),
-            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, status_reg_2: true),
-            voltage: (min: 2700, max: 3600),
-            erase_blocks: [
-                (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
-                (opcode: 0x52, regions: [(size: KiB(32), count: 256)]),
-                (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),
-                (opcode: 0x60, regions: [(size: MiB(8), count: 1)]),
-                (opcode: 0xC7, regions: [(size: MiB(8), count: 1)]),
-            ],
-            tested: (probe: Ok, read: Ok, erase: Ok, write: Ok),
-        ),
+
         (
             name: "EN25QH128",
             device_id: 0x7018,

--- a/crates/rflasher-chips/data/vendors/esmt.ron
+++ b/crates/rflasher-chips/data/vendors/esmt.ron
@@ -89,6 +89,8 @@
         ),
         (
             name: "F25L32PA",
+            // F25L032A uses the same RDID. Keep both names because their
+            // status-register/OTP capabilities differ and probing is ambiguous.
             device_id: 0x2016,
             total_size: MiB(4),
             features: (wrsr_wren: true, wrsr_ewsr: true, otp: true),

--- a/crates/rflasher-chips/data/vendors/macronix.ron
+++ b/crates/rflasher-chips/data/vendors/macronix.ron
@@ -1,5 +1,9 @@
 // Macronix SPI Flash Chips
 // Ported from flashprog/flashchips.c
+//
+// MX23L1654/3254/6454/12854 are mask ROMs and are intentionally excluded.
+// The current chip model requires writable erase geometry and cannot represent
+// read-only SPI devices safely.
 
 (
     vendor: "Macronix",

--- a/crates/rflasher-chips/data/vendors/micron.ron
+++ b/crates/rflasher-chips/data/vendors/micron.ron
@@ -550,5 +550,33 @@
             tested: (probe: Ok, read: Ok, erase: Ok, write: Ok),
         ),
 
+        // One-gigabit N25Q00A variants. These IDs are also used by MT25QU01G/MT25QL01G. Keep these
+        // aliases after the MT25 entries so JEDEC-only probing preserves the
+        // active MT25 erase profile.
+        (
+            name: "N25Q00A..1G",
+            device_id: 0xBB21,
+            total_size: MiB(128),
+            features: (wrsr_wren: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            voltage: (min: 1700, max: 2000),
+            erase_blocks: [
+                (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 32768)]),
+                (opcode: 0xD8, opcode_4b: Some(0xDC), regions: [(size: KiB(64), count: 2048)]),
+                (opcode: 0xC4, regions: [(size: MiB(32), count: 4)]),
+            ],
+        ),
+        (
+            name: "N25Q00A..3G",
+            device_id: 0xBA21,
+            total_size: MiB(128),
+            features: (wrsr_wren: true, quad_io: true, otp: true, four_byte_addr: true, four_byte_native: true, four_byte_enter_wren: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true),
+            voltage: (min: 2700, max: 3600),
+            erase_blocks: [
+                (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 32768)]),
+                (opcode: 0xD8, opcode_4b: Some(0xDC), regions: [(size: KiB(64), count: 2048)]),
+                (opcode: 0xC4, regions: [(size: MiB(32), count: 4)]),
+            ],
+        ),
+
     ],
 )

--- a/crates/rflasher-chips/src/lib.rs
+++ b/crates/rflasher-chips/src/lib.rs
@@ -513,6 +513,19 @@ mod tests {
 
         assert!(!db.is_empty());
         assert!(db.find_by_jedec_id(0xEF, 0x4018).is_some());
+
+        // N25Q00A and MT25Q01G share JEDEC IDs but have different erase
+        // profiles. Keep the tested MT25 definitions as the active matches.
+        assert_eq!(
+            db.find_by_jedec_id(0x20, 0xBA21)
+                .map(|chip| chip.name.as_str()),
+            Some("MT25QL01G")
+        );
+        assert_eq!(
+            db.find_by_jedec_id(0x20, 0xBB21)
+                .map(|chip| chip.name.as_str()),
+            Some("MT25QU01G")
+        );
     }
 
     #[cfg(feature = "static-chips")]


### PR DESCRIPTION
Register the 1-Gbit N25Q00A voltage variants with native 4-byte
operations. Remove unsupported EON entries and document exclusions for
DataFlash and Macronix mask ROMs while preserving the ambiguous ESMT
alias.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Micron N25Q00A 1 Gbit flash variants at 1.8 V and 3.3 V, including OTP, four-byte addressing, and erase operations.
  * Improved identification of MT25 1 Gbit variants sharing JEDEC IDs.
* **Bug Fixes**
  * Removed duplicate Eon chip catalog entries.
  * Added validation to detect duplicate chip names within a vendor.
* **Documentation**
  * Documented unsupported device families and clarified probing limitations for similar ESMT parts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->