### PR TITLE
Avoid crossing 4 KiB boundaries in SPI transfers

### DIFF
--- a/crates/rflasher-internal/src/ichspi.rs
+++ b/crates/rflasher-internal/src/ichspi.rs
@@ -2025,9 +2025,13 @@ impl<H: HostAccess> IchSpiController<H> {
         let mut current_addr = addr;
 
         while offset < len {
-            // Max 64 bytes per transfer
+            // Avoid transfers that cross 4 KiB boundaries. The ICH SPI
+            // controller is known to fail on some platforms when a single
+            // transaction spans such a boundary; coreboot applies the same
+            // restriction in its Intel common SPI driver.
             let remaining = len - offset;
-            let block_len = remaining.min(Self::SWSEQ_MAX_DATA);
+            let boundary_remaining = 0x1000 - (current_addr as usize & 0xfff);
+            let block_len = remaining.min(Self::SWSEQ_MAX_DATA).min(boundary_remaining);
 
             // Build write array: opcode + 3-byte address
             let writearr = [
@@ -2277,9 +2281,13 @@ impl<H: HostAccess> IchSpiController<H> {
         let mut current_addr = addr;
 
         while offset < len {
-            // Max 64 bytes per transfer
+            // Avoid transfers that cross 4 KiB boundaries. The ICH SPI
+            // controller is known to fail on some platforms when a single
+            // transaction spans such a boundary; coreboot applies the same
+            // restriction in its Intel common SPI driver.
             let remaining = len - offset;
-            let block_len = remaining.min(Self::SWSEQ_MAX_DATA);
+            let boundary_remaining = 0x1000 - (current_addr as usize & 0xfff);
+            let block_len = remaining.min(Self::SWSEQ_MAX_DATA).min(boundary_remaining);
 
             // Build write array: opcode + 3-byte address
             let writearr = [


### PR DESCRIPTION
Split ICH SPI transactions at 4 KiB boundaries to avoid controller
failures on affected platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flash read reliability on ICH7 and ICH9+ systems by correctly splitting large reads at 4 KiB address boundaries.
  * Preserved the existing 64-byte transfer limit for compatible hardware behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->