### PR TITLE
chips: port recent flashprog chipdb additions (XMC, Fudan, GigaDevice)

### DIFF
--- a/crates/rflasher-chips/data/vendors/fudan.ron
+++ b/crates/rflasher-chips/data/vendors/fudan.ron
@@ -173,5 +173,19 @@
                 (opcode: 0xC7, regions: [(size: MiB(16), count: 1)]),
             ],
         ),
+        (
+            name: "FM25W128",
+            device_id: 0x2818,
+            total_size: MiB(16),
+            features: (wrsr_wren: true, wrsr_ext: true, qpi: true, otp: true, status_reg_2: true, qe_sr2: true),
+            voltage: (min: 1650, max: 3600),
+            erase_blocks: [
+                (opcode: 0x20, regions: [(size: KiB(4), count: 4096)]),
+                (opcode: 0x52, regions: [(size: KiB(32), count: 512)]),
+                (opcode: 0xD8, regions: [(size: KiB(64), count: 256)]),
+                (opcode: 0x60, regions: [(size: MiB(16), count: 1)]),
+                (opcode: 0xC7, regions: [(size: MiB(16), count: 1)]),
+            ],
+        ),
     ],
 )

--- a/crates/rflasher-chips/data/vendors/gigadevice.ron
+++ b/crates/rflasher-chips/data/vendors/gigadevice.ron
@@ -684,7 +684,7 @@
             tested: (probe: Ok, read: Ok, erase: Ok, write: Ok),
         ),
         (
-            name: "GD25Q256D/GD25B256D",
+            name: "GD25Q256D/GD25B256D/GD25R256D",
             device_id: 0x4019,
             total_size: MiB(32),
             features: (otp: true, four_byte_addr: true, status_reg_2: true, ext_addr_reg_c5c8: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true, status_reg_3: true, dual_io: true, quad_io: true, wrsr_ext: true),

--- a/crates/rflasher-chips/data/vendors/sst.ron
+++ b/crates/rflasher-chips/data/vendors/sst.ron
@@ -533,7 +533,7 @@
                 (opcode: 0xC7, regions: [(size: MiB(1), count: 1)]),
             ],
         ),
-        // XM25QU64A - 1.8V 8Mbit. Despite being an XMC part it reports
+        // XM25QU64A - 1.8V 64Mbit (8MiB). Despite being an XMC part it reports
         // SST_ID (0xBF), so it lives in this vendor file (mirrors the
         // SST25WF SANYO_ID precedent above).
         (

--- a/crates/rflasher-chips/data/vendors/sst.ron
+++ b/crates/rflasher-chips/data/vendors/sst.ron
@@ -533,6 +533,23 @@
                 (opcode: 0xC7, regions: [(size: MiB(1), count: 1)]),
             ],
         ),
+        // XM25QU64A - 1.8V 8Mbit. Despite being an XMC part it reports
+        // SST_ID (0xBF), so it lives in this vendor file (mirrors the
+        // SST25WF SANYO_ID precedent above).
+        (
+            name: "XM25QU64A",
+            device_id: 0x3817,
+            total_size: MiB(8),
+            features: (wrsr_wren: true),
+            voltage: (min: 1650, max: 1950),
+            erase_blocks: [
+                (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
+                (opcode: 0x52, regions: [(size: KiB(32), count: 256)]),
+                (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),
+                (opcode: 0x60, regions: [(size: MiB(8), count: 1)]),
+                (opcode: 0xC7, regions: [(size: MiB(8), count: 1)]),
+            ],
+        ),
 
     ],
 )

--- a/crates/rflasher-chips/data/vendors/xmc.ron
+++ b/crates/rflasher-chips/data/vendors/xmc.ron
@@ -156,5 +156,24 @@
                 (opcode: 0xC7, regions: [(size: MiB(64), count: 1)]),
             ],
         ),
+
+        // XM25QU64A - 1.8V 64Mbit (8MiB). Some vendors/boards report the
+        // XMC manufacturer ID (0x20:0x3817) for this part; flashprog lists
+        // it under SST_ID (0xBF) instead. Keep both JEDEC variants so a
+        // device reporting either ID is matched.
+        (
+            name: "XM25QU64A",
+            device_id: 0x3817,
+            total_size: MiB(8),
+            features: (wrsr_wren: true),
+            voltage: (min: 1650, max: 1950),
+            erase_blocks: [
+                (opcode: 0x20, regions: [(size: KiB(4), count: 2048)]),
+                (opcode: 0x52, regions: [(size: KiB(32), count: 256)]),
+                (opcode: 0xD8, regions: [(size: KiB(64), count: 128)]),
+                (opcode: 0x60, regions: [(size: MiB(8), count: 1)]),
+                (opcode: 0xC7, regions: [(size: MiB(8), count: 1)]),
+            ],
+        ),
     ],
 )

--- a/crates/rflasher-chips/data/vendors/xmc.ron
+++ b/crates/rflasher-chips/data/vendors/xmc.ron
@@ -92,5 +92,69 @@
                 (opcode: 0xC7, regions: [(size: MiB(32), count: 1)]),
             ],
         ),
+
+        // XM25QH512C - 3.3V 64Mbit with QPI support
+        (
+            name: "XM25QH512C",
+            device_id: 0x4020,
+            total_size: MiB(64),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, dual_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true),
+            voltage: (min: 2700, max: 3600),
+            erase_blocks: [
+                (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
+                (opcode: 0x52, regions: [(size: KiB(32), count: 2048)]),
+                (opcode: 0xD8, opcode_4b: Some(0xDC), regions: [(size: KiB(64), count: 1024)]),
+                (opcode: 0x60, regions: [(size: MiB(64), count: 1)]),
+                (opcode: 0xC7, regions: [(size: MiB(64), count: 1)]),
+            ],
+        ),
+
+        // XM25RH256C - 3.3V 32Mbit
+        (
+            name: "XM25RH256C",
+            device_id: 0x4319,
+            total_size: MiB(32),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, dual_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true),
+            voltage: (min: 2700, max: 3600),
+            erase_blocks: [
+                (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 8192)]),
+                (opcode: 0x52, regions: [(size: KiB(32), count: 1024)]),
+                (opcode: 0xD8, opcode_4b: Some(0xDC), regions: [(size: KiB(64), count: 512)]),
+                (opcode: 0x60, regions: [(size: MiB(32), count: 1)]),
+                (opcode: 0xC7, regions: [(size: MiB(32), count: 1)]),
+            ],
+        ),
+
+        // XM25RH512C - 3.3V 64Mbit
+        (
+            name: "XM25RH512C",
+            device_id: 0x4320,
+            total_size: MiB(64),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, wp_tb: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, dual_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true),
+            voltage: (min: 2700, max: 3600),
+            erase_blocks: [
+                (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
+                (opcode: 0x52, regions: [(size: KiB(32), count: 2048)]),
+                (opcode: 0xD8, opcode_4b: Some(0xDC), regions: [(size: KiB(64), count: 1024)]),
+                (opcode: 0x60, regions: [(size: MiB(64), count: 1)]),
+                (opcode: 0xC7, regions: [(size: MiB(64), count: 1)]),
+            ],
+        ),
+
+        // XM25QU512C - 1.8V 64Mbit
+        (
+            name: "XM25QU512C",
+            device_id: 0x4120,
+            total_size: MiB(64),
+            features: (wrsr_wren: true, fast_read: true, quad_io: true, qpi: true, otp: true, four_byte_addr: true, four_byte_enter: true, status_reg_2: true, status_reg_3: true, qe_sr2: true, four_byte_native: true, four_byte_read: true, four_byte_fast_read: true, four_byte_program: true, four_byte_enter_wren: true, ext_addr_reg_c5c8: true, dual_io: true, four_byte_dual_out_read: true, four_byte_dual_io_read: true, four_byte_quad_out_read: true, four_byte_quad_io_read: true),
+            voltage: (min: 1650, max: 1950),
+            erase_blocks: [
+                (opcode: 0x20, opcode_4b: Some(0x21), regions: [(size: KiB(4), count: 16384)]),
+                (opcode: 0x52, regions: [(size: KiB(32), count: 2048)]),
+                (opcode: 0xD8, opcode_4b: Some(0xDC), regions: [(size: KiB(64), count: 1024)]),
+                (opcode: 0x60, regions: [(size: MiB(64), count: 1)]),
+                (opcode: 0xC7, regions: [(size: MiB(64), count: 1)]),
+            ],
+        ),
     ],
 )

--- a/crates/rflasher-chips/data/vendors/xmc.ron
+++ b/crates/rflasher-chips/data/vendors/xmc.ron
@@ -93,7 +93,7 @@
             ],
         ),
 
-        // XM25QH512C - 3.3V 64Mbit with QPI support
+        // XM25QH512C - 3.3V 512Mbit (64MiB) with QPI support
         (
             name: "XM25QH512C",
             device_id: 0x4020,
@@ -109,7 +109,7 @@
             ],
         ),
 
-        // XM25RH256C - 3.3V 32Mbit
+        // XM25RH256C - 3.3V 256Mbit (32MiB)
         (
             name: "XM25RH256C",
             device_id: 0x4319,
@@ -125,7 +125,7 @@
             ],
         ),
 
-        // XM25RH512C - 3.3V 64Mbit
+        // XM25RH512C - 3.3V 512Mbit (64MiB)
         (
             name: "XM25RH512C",
             device_id: 0x4320,
@@ -141,7 +141,7 @@
             ],
         ),
 
-        // XM25QU512C - 1.8V 64Mbit
+        // XM25QU512C - 1.8V 512Mbit (64MiB)
         (
             name: "XM25QU512C",
             device_id: 0x4120,


### PR DESCRIPTION
Port the SPI NOR chip definitions recently merged upstream in flashprog and
flagged as relevant for the Rust port (Gerrit #573–#582).

### Added
- **XMC** `XM25QH512C` (3.3V 64Mbit), `XM25QU512C` (1.8V 64Mbit), `XM25RH256C`
  (3.3V 32Mbit), `XM25RH512C` (3.3V 64Mbit) — 4-byte-address parts with QPI,
  native 4BA erase opcodes `0x21`/`0xDC`.
- **XMC** `XM25QU64A` (1.8V 8Mbit). This part reports `SST_ID` (0xBF), so it is
  placed in `sst.ron` — mirroring the existing `SST25WF` precedent that groups
  parts under the vendor file matching their JEDEC manufacturer ID.
- **Fudan** `FM25W128` (wide-voltage 16Mbit).
- **GigaDevice** `GD25R256D` alias name added to the `GD25Q256D/GD25B256D` entry.

### Notes
- Feature flags and erase blocks follow the existing `XM25QH256C`/`XM25QU256C`
  convention so the new 4BA parts behave consistently.
- Validated: all bundled RON files parse, the chip database validates
  (no duplicate names, chip-erase present), and code generation succeeds.

Upstream flashprog changes: #573, #575, #576, #577, #582.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and operating on several Fudan, SST, XMC, and GigaDevice SPI flash chips.
  * Added support for new 1.8 V and 3.3 V flash variants, including devices ranging from 8 MiB to 64 MiB.
  * Added erase operations and device-specific capabilities for the newly supported chips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->