### PR TITLE
Package rflasher with Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /man
+/completions
 /crates/rflasher-wasm/dist
 /firmware
 opencode.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,6 +3007,7 @@ name = "rflasher"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "clap_mangen",
  "env_logger",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ env_logger = "0.11"
 tokio = { version = "1", features = ["full"] }
 nusb = "0.2.6"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 indicatif = "0.17"
 
 # Build/codegen
@@ -130,6 +131,7 @@ env_logger.workspace = true
 log.workspace = true
 indicatif.workspace = true
 thiserror.workspace = true
+clap_complete.workspace = true
 
 [dev-dependencies]
 nusb = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,9 @@ all-programmers-native = ["dummy", "ch341a", "ch347", "dediprog", "serprog", "ft
 # Cross-platform desktop programmers: nusb-backed USB programmers plus serprog and dummy.
 # Excludes Linux-only devices and the Linux userspace internal chipset backend.
 portable-programmers = ["dummy", "ch341a", "ch347", "dediprog", "serprog", "ftdi-native", "ft4222", "raiden", "sunxi-fel"]
+# Static Linux (musl) builds: portable programmers plus Linux-only backends that
+# are pure libc syscalls and need no C libraries (internal chipset, spidev, mtd).
+static-linux-programmers = ["portable-programmers", "linux-spi", "linux-mtd", "internal"]
 
 [dependencies]
 rflasher-core = { workspace = true, features = ["std", "is_sync"] }

--- a/flake.nix
+++ b/flake.nix
@@ -90,8 +90,22 @@
           nativePackage = pkgs.rustPlatform.buildRustPackage (
             packageAttrs
             // {
+              cargoBuildFlags = packageAttrs.cargoBuildFlags ++ [ "--bin=gen-completions" ];
               buildInputs = runtimeBuildInputs pkgs;
-              nativeBuildInputs = [ pkgs.pkg-config ];
+              nativeBuildInputs = [
+                pkgs.installShellFiles
+                pkgs.pkg-config
+              ];
+
+              postInstall = packageAttrs.postInstall + ''
+                completion_dir=$(mktemp -d)
+                "$out/bin/gen-completions" "$completion_dir"
+                installShellCompletion --cmd rflasher \
+                  --bash "$completion_dir/rflasher.bash" \
+                  --zsh "$completion_dir/_rflasher" \
+                  --fish "$completion_dir/rflasher.fish"
+                rm "$out/bin/gen-completions"
+              '';
             }
           );
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,258 +12,223 @@
 
   outputs =
     {
-      self,
       nixpkgs,
       rust-overlay,
       flake-utils,
       ...
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        overlays = [ (import rust-overlay) ];
-        pkgs = import nixpkgs {
-          inherit system overlays;
-        };
-        lib = pkgs.lib;
+    flake-utils.lib.eachSystem
+      [
+        "x86_64-linux"
+        "aarch64-linux"
+      ]
+      (
+        system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          inherit (pkgs) lib;
 
-        # Cross-compilation targets: name -> { config, rustTarget, cargoLinkerEnv }
-        crossTargets = {
-          i686 = {
-            config = "i686-unknown-linux-gnu";
-            rustTarget = "i686-unknown-linux-gnu";
-            cargoLinkerEnv = "CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER";
-          };
-          aarch64 = {
-            config = "aarch64-unknown-linux-gnu";
-            rustTarget = "aarch64-unknown-linux-gnu";
-            cargoLinkerEnv = "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER";
-          };
-          armv7 = {
-            config = "armv7l-unknown-linux-gnueabihf";
-            rustTarget = "armv7-unknown-linux-gnueabihf";
-            cargoLinkerEnv = "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER";
-          };
-          aarch64-musl = {
-            config = "aarch64-unknown-linux-musl";
-            rustTarget = "aarch64-unknown-linux-musl";
-            cargoLinkerEnv = "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER";
-            isMusl = true;
-          };
-        };
+          cargoLock.lockFile = ./Cargo.lock;
 
-        # Generate cross pkgs for each target
-        mkCrossPkgs =
-          target:
-          let
-            basePkgs = import nixpkgs {
+          runtimeBuildInputs = p: [
+            p.udev
+            p.libftdi1
+            p.pciutils
+          ];
+
+          packageAttrs = {
+            pname = "rflasher";
+            version = (lib.importTOML ./Cargo.toml).workspace.package.version;
+            # Only what the build needs; keeps target/ and other local
+            # artifacts out of the store path and the source hash stable.
+            src = lib.fileset.toSource {
+              root = ./.;
+              fileset = lib.fileset.unions [
+                ./Cargo.toml
+                ./Cargo.lock
+                ./build.rs
+                ./src
+                ./crates
+              ];
+            };
+
+            inherit cargoLock;
+            cargoBuildFlags = [
+              "--package=rflasher"
+              "--bin=rflasher"
+            ];
+            # Run the whole workspace's tests; the root package has none.
+            # rflasher-wasm is excluded (needs the wasm32 target).
+            cargoTestFlags = [
+              "--workspace"
+              "--exclude"
+              "rflasher-wasm"
+            ];
+
+            postPatch = ''
+              substituteInPlace src/main.rs \
+                --replace-fail 'PathBuf::from("/usr/share/rflasher/chips"),' \
+                  "PathBuf::from(\"$out/share/rflasher/chips\"),"
+            '';
+
+            postInstall = ''
+              install -Dm644 crates/rflasher-chips/data/vendors/*.ron -t $out/share/rflasher/chips
+            '';
+
+            meta = {
+              description = "A modern Rust port of flashprog for reading, writing, and erasing flash chips";
+              homepage = "https://github.com/ArthurHeymans/rflasher";
+              license = lib.licenses.gpl2Plus;
+              mainProgram = "rflasher";
+              platforms = lib.platforms.linux;
+            };
+          };
+
+          nativePackage = pkgs.rustPlatform.buildRustPackage (
+            packageAttrs
+            // {
+              buildInputs = runtimeBuildInputs pkgs;
+              nativeBuildInputs = [ pkgs.pkg-config ];
+            }
+          );
+
+          crossTargets = {
+            i686 = {
+              config = "i686-unknown-linux-gnu";
+              rustTarget = "i686-unknown-linux-gnu";
+              cargoLinkerEnv = "CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER";
+            };
+            aarch64 = {
+              config = "aarch64-unknown-linux-gnu";
+              rustTarget = "aarch64-unknown-linux-gnu";
+              cargoLinkerEnv = "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER";
+            };
+            armv7 = {
+              config = "armv7l-unknown-linux-gnueabihf";
+              rustTarget = "armv7-unknown-linux-gnueabihf";
+              cargoLinkerEnv = "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER";
+            };
+            aarch64-musl = {
+              config = "aarch64-unknown-linux-musl";
+              rustTarget = "aarch64-unknown-linux-musl";
+              cargoLinkerEnv = "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER";
+              isMusl = true;
+            };
+          };
+
+          crossPkgsFor = lib.mapAttrs (
+            _: target:
+            import nixpkgs {
               inherit system overlays;
               crossSystem.config = target.config;
-            };
-          in
-          if target.isMusl or false then basePkgs.pkgsStatic else basePkgs;
+            }
+          ) crossTargets;
 
-        # Build inputs as a function of pkgs (musl targets skip C system libs)
-        mkBuildInputs =
-          p:
-          if p.stdenv.hostPlatform.isMusl then
-            [ ]
-          else
-            with p;
-            [
-              udev
-              libftdi1
-              pciutils
+          mkCrossPackage =
+            name: target:
+            let
+              crossPkgs = crossPkgsFor.${name};
+              isMusl = target.isMusl or false;
+            in
+            crossPkgs.rustPlatform.buildRustPackage (
+              packageAttrs
+              // {
+                buildInputs = lib.optionals (!isMusl) (runtimeBuildInputs crossPkgs);
+                nativeBuildInputs = [ crossPkgs.buildPackages.pkg-config ];
+              }
+              // lib.optionalAttrs isMusl {
+                buildNoDefaultFeatures = true;
+                buildFeatures = [ "static-linux-programmers" ];
+              }
+            );
+
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "rust-analyzer"
             ];
-
-        # Base rust toolchain with WASM target for web builds
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          extensions = [
-            "rust-src"
-            "rust-analyzer"
-          ];
-          targets = [ "wasm32-unknown-unknown" ];
-        };
-
-        # Rust toolchain with cross targets
-        rustToolchainCross = pkgs.rust-bin.stable.latest.default.override {
-          extensions = [
-            "rust-src"
-            "rust-analyzer"
-          ];
-          targets = lib.mapAttrsToList (_: t: t.rustTarget) crossTargets;
-        };
-
-        # Create a cross-compilation dev shell for a given target
-        mkCrossDevShell =
-          name: target:
-          let
-            crossPkgs = mkCrossPkgs target;
-            crossBuildInputs = mkBuildInputs crossPkgs;
-            isMusl = target.isMusl or false;
-          in
-          pkgs.mkShell (
-            {
-              buildInputs = crossBuildInputs;
-              nativeBuildInputs = [
-                pkgs.pkg-config
-                rustToolchainCross
-              ];
-
-              LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-
-              "${target.cargoLinkerEnv}" = "${crossPkgs.stdenv.cc}/bin/${crossPkgs.stdenv.cc.targetPrefix}cc";
-
-              shellHook = ''
-                echo "rflasher cross-compilation environment (${target.rustTarget})"
-                echo "Rust version: $(rustc --version)"
-                echo ""
-                echo "Build with:"
-                ${
-                  if isMusl then
-                    ''
-                      echo "  cargo build --target ${target.rustTarget} --no-default-features --features dummy,ch341a,ch347,dediprog,serprog,ft4222,ftdi-native,linux-spi,linux-mtd,internal,raiden"
-                      echo ""
-                      echo "Note: This is a musl static build. Uses pure-Rust backends (ftdi-native)"
-                      echo "to avoid C library dependencies. Binaries are fully statically linked."
-                    ''
-                  else
-                    ''
-                      echo "  cargo build --target ${target.rustTarget}"
-                    ''
-                }
-                echo ""
-              '';
-            }
-            // lib.optionalAttrs (!isMusl) {
-              PKG_CONFIG_PATH = lib.makeSearchPath "lib/pkgconfig" crossBuildInputs;
-              PKG_CONFIG_SYSROOT_DIR = "${crossPkgs.stdenv.cc.libc}";
-            }
-            // lib.optionalAttrs isMusl {
-              RUSTFLAGS = "-C target-feature=+crt-static";
-            }
-          );
-
-        # Create a cross-compiled package for a given target
-        mkCrossPackage =
-          name: target:
-          let
-            crossPkgs = mkCrossPkgs target;
-            isMusl = target.isMusl or false;
-          in
-          crossPkgs.rustPlatform.buildRustPackage (
-            {
-              pname = "rflasher";
-              version = "0.1.0";
-              src = ./.;
-
-              cargoLock.lockFile = ./Cargo.lock;
-
-              buildInputs = mkBuildInputs crossPkgs;
-              nativeBuildInputs = [
-                pkgs.pkg-config
-                rustToolchainCross
-              ];
-
-              CARGO_BUILD_TARGET = target.rustTarget;
-
-              meta = with lib; {
-                description = "A modern Rust port of flashprog for reading, writing, and erasing flash chips";
-                homepage = "https://github.com/user/rflasher";
-                license = licenses.gpl2Plus;
-              };
-            }
-            // lib.optionalAttrs isMusl {
-              # For musl static builds, use pure-Rust backends to avoid C library dependencies
-              buildNoDefaultFeatures = true;
-              buildFeatures = [
-                "dummy"
-                "ch341a"
-                "ch347"
-                "dediprog"
-                "serprog"
-                "ft4222"
-                "ftdi-native"
-                "linux-spi"
-                "linux-mtd"
-                "internal"
-                "raiden"
-              ];
-              RUSTFLAGS = "-C target-feature=+crt-static";
-            }
-          );
-
-        # Generate all cross dev shells and packages
-        crossDevShells = lib.mapAttrs' (
-          name: target: lib.nameValuePair "cross-${name}" (mkCrossDevShell name target)
-        ) crossTargets;
-
-        crossPackages = lib.mapAttrs' (
-          name: target: lib.nameValuePair "cross-${name}" (mkCrossPackage name target)
-        ) crossTargets;
-
-      in
-      {
-        devShells = {
-          default = pkgs.mkShell {
-            buildInputs = mkBuildInputs pkgs;
-            nativeBuildInputs = [
-              pkgs.pkg-config
-              rustToolchain
-              pkgs.cargo
-              pkgs.trunk
-            ];
-
-            PKG_CONFIG_PATH = lib.makeSearchPath "lib/pkgconfig" (mkBuildInputs pkgs);
-            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-
-            shellHook = ''
-              echo "rflasher development environment"
-              echo "Rust version: $(rustc --version)"
-              echo ""
-              echo "Available commands:"
-              echo "  cargo build              - Build the project"
-              echo "  cargo test               - Run tests"
-              echo "  cargo run -- --help      - Show CLI help"
-              echo ""
-              echo "Web build (WASM):"
-              echo "  cd crates/rflasher-wasm && trunk serve  - Dev server"
-              echo "  cd crates/rflasher-wasm && trunk build  - Production build"
-              echo ""
-              echo "Cross-compilation shells:"
-              echo "  nix develop .#cross-i686         - i686-unknown-linux-gnu"
-              echo "  nix develop .#cross-aarch64      - aarch64-unknown-linux-gnu"
-              echo "  nix develop .#cross-armv7        - armv7-unknown-linux-gnueabihf"
-              echo "  nix develop .#cross-aarch64-musl - aarch64-unknown-linux-musl (static)"
-              echo ""
-            '';
+            targets = [ "wasm32-unknown-unknown" ];
           };
-        }
-        // crossDevShells;
 
-        packages = {
-          default = pkgs.rustPlatform.buildRustPackage {
-            pname = "rflasher";
-            version = "0.1.0";
-            src = ./.;
-
-            cargoLock.lockFile = ./Cargo.lock;
-
-            buildInputs = mkBuildInputs pkgs;
-            nativeBuildInputs = [
-              pkgs.pkg-config
-              rustToolchain
-              pkgs.cargo
+          rustToolchainCross = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "rust-analyzer"
             ];
-
-            meta = with lib; {
-              description = "A modern Rust port of flashprog for reading, writing, and erasing flash chips";
-              homepage = "https://github.com/user/rflasher";
-              license = licenses.gpl2Plus;
-            };
+            targets = lib.mapAttrsToList (_: target: target.rustTarget) crossTargets;
           };
+
+          mkCrossDevShell =
+            name: target:
+            let
+              crossPkgs = crossPkgsFor.${name};
+              isMusl = target.isMusl or false;
+              crossBuildInputs = lib.optionals (!isMusl) (runtimeBuildInputs crossPkgs);
+            in
+            pkgs.mkShell (
+              {
+                packages = [
+                  pkgs.pkg-config
+                  rustToolchainCross
+                ];
+                buildInputs = crossBuildInputs;
+
+                "${target.cargoLinkerEnv}" = "${crossPkgs.stdenv.cc}/bin/${crossPkgs.stdenv.cc.targetPrefix}cc";
+
+                shellHook = ''
+                  echo "rflasher cross-compilation environment (${target.rustTarget})"
+                  echo "Build with: cargo build --target ${target.rustTarget}${
+                    if isMusl then " --no-default-features --features static-linux-programmers" else ""
+                  }"
+                '';
+              }
+              // lib.optionalAttrs (!isMusl) {
+                PKG_CONFIG_SYSROOT_DIR = "${crossPkgs.stdenv.cc.libc}";
+              }
+            );
+
+          crossPackages = lib.mapAttrs' (
+            name: target: lib.nameValuePair "cross-${name}" (mkCrossPackage name target)
+          ) crossTargets;
+
+          crossDevShells = lib.mapAttrs' (
+            name: target: lib.nameValuePair "cross-${name}" (mkCrossDevShell name target)
+          ) crossTargets;
+
+          linuxCrossOutputs = lib.optionalAttrs (system == "x86_64-linux") {
+            packages = crossPackages;
+            devShells = crossDevShells;
+          };
+        in
+        {
+          packages = {
+            default = nativePackage;
+            rflasher = nativePackage;
+          }
+          // (linuxCrossOutputs.packages or { });
+
+          apps.default = {
+            type = "app";
+            program = "${nativePackage}/bin/rflasher";
+          };
+
+          checks.package = nativePackage;
+          formatter = pkgs.nixfmt-tree;
+
+          devShells = {
+            default = pkgs.mkShell {
+              packages = [
+                pkgs.pkg-config
+                pkgs.trunk
+                rustToolchain
+              ];
+              buildInputs = runtimeBuildInputs pkgs;
+            };
+          }
+          // (linuxCrossOutputs.devShells or { });
         }
-        // crossPackages;
-      }
-    );
+      );
 }

--- a/src/bin/gen-completions.rs
+++ b/src/bin/gen-completions.rs
@@ -1,0 +1,30 @@
+//! Shell completion generator for rflasher
+//!
+//! Usage: cargo run --bin gen-completions -- [output-dir]
+
+use clap::CommandFactory;
+use clap_complete::{Shell, generate_to};
+use std::fs;
+use std::path::PathBuf;
+
+#[path = "../cli.rs"]
+mod cli;
+
+fn main() -> std::io::Result<()> {
+    let output_dir = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("completions"));
+
+    fs::create_dir_all(&output_dir)?;
+
+    const BIN_NAME: &str = "rflasher";
+    let mut command = cli::Cli::command();
+
+    for shell in [Shell::Bash, Shell::Zsh, Shell::Fish] {
+        let path = generate_to(shell, &mut command, BIN_NAME, &output_dir)?;
+        println!("Generated: {}", path.display());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
The existing flake mixed development toolchains with the Nix package toolchain and carried brittle package and cross-compilation configuration (duplicated attributes, hardcoded version, wrong homepage).

This reorganizes the flake around `buildRustPackage` with a shared `packageAttrs` attrset and a table-driven `crossTargets` map. `rust-overlay` only provides dev shell toolchains; packages build with nixpkgs' `rustPlatform`. The version is read from `Cargo.toml`, and the chip database and generated shell completions (bash/zsh/fish, via a `gen-completions` binary) are installed into the package output.

Checks run the full workspace test suite (`rflasher-wasm` excluded, it needs the wasm32 target). Static musl builds use a new `static-linux-programmers` feature: the portable programmers plus the Linux-only backends that are pure libc syscalls (`internal`, `linux-spi`, `linux-mtd`) and need no C libraries.

The flake exposes conventional package, app, check, and formatter outputs on `x86_64-linux` and `aarch64-linux`, with cross packages/shells (i686, aarch64, armv7, aarch64-musl) on `x86_64-linux`.
