### PR TITLE
Fix CLI flags that silently did nothing and harden layout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,8 +322,6 @@ rflasher wp range -p ch341a 0,0x100000
 # Set protection for a named region (requires layout)
 rflasher wp region -p ch341a --ifd bios
 
-# Make changes temporary (volatile, lost on power cycle)
-rflasher wp enable -p ch341a --temporary
 ```
 
 ### Verbosity and Debugging

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ rflasher read -p ch341a -o backup.bin
 rflasher write -p ch341a -i firmware.bin
 
 # Write without verification (faster, but risky)
-rflasher write -p ch341a -i firmware.bin --verify=false
+rflasher write -p ch341a -i firmware.bin --no-verify
 
 # Verify flash contents against a file
 rflasher verify -p ch341a -i firmware.bin

--- a/crates/rflasher-core/src/flash/hybrid_device.rs
+++ b/crates/rflasher-core/src/flash/hybrid_device.rs
@@ -279,19 +279,6 @@ impl<M: SpiMaster + OpaqueMaster> FlashDevice for HybridFlashDevice<M> {
                 return result;
             }
 
-            // Verify the block was erased, same as SpiFlashDevice::erase
-            if let Err(e) =
-                check_erased_range(&mut self.master, &self.ctx, current_addr, block_size).await
-            {
-                if enter_exit_4byte
-                    && let Err(exit_e) =
-                        protocol::exit_4byte_mode_with_features(self.master(), chip_features).await
-                {
-                    log::warn!("Failed to exit 4-byte address mode: {}", exit_e);
-                }
-                return Err(e);
-            }
-
             current_addr += block_size;
         }
 
@@ -299,7 +286,11 @@ impl<M: SpiMaster + OpaqueMaster> FlashDevice for HybridFlashDevice<M> {
             protocol::exit_4byte_mode_with_features(self.master(), chip_features).await?;
         }
 
-        Ok(())
+        // Verify only after the erase loop has left its persistent 4-byte
+        // mode. The read helper manages 4-byte mode itself; calling it inside
+        // the loop would exit that mode and make the next legacy erase opcode
+        // target the wrong address.
+        check_erased_range(&mut self.master, &self.ctx, addr, len).await
     }
 }
 

--- a/crates/rflasher-core/src/flash/hybrid_device.rs
+++ b/crates/rflasher-core/src/flash/hybrid_device.rs
@@ -23,7 +23,7 @@ use crate::chip::{EraseBlock, WriteGranularity};
 use crate::error::{Error, Result};
 use crate::flash::context::{AddressMode, FlashContext};
 use crate::flash::device::FlashDevice;
-use crate::flash::operations::{addressing_for_4byte_operation, select_erase_block};
+use crate::flash::operations::{addressing_for_4byte_operation, check_erased_range, select_erase_block};
 use crate::programmer::{OpaqueMaster, SpiFeatures, SpiMaster};
 use crate::protocol::{self, CommandAddressing};
 #[cfg(feature = "alloc")]
@@ -200,7 +200,23 @@ impl<M: SpiMaster + OpaqueMaster> FlashDevice for HybridFlashDevice<M> {
             return Ok(());
         }
 
-        // Opaque erase not supported — fall back to SPI-based erase
+        // Opaque erase not supported — fall back to SPI-based erase.
+        // NOTE: OpaqueMaster::erase cannot distinguish "unsupported" from a
+        // genuine mid-erase failure; the SPI fallback retries the whole range
+        // either way, which is safe for flash (erase is idempotent) but means
+        // opaque hardware errors are not surfaced here.
+        // SST26 chips use a per-block protection register (not SR BP bits).
+        // A global unlock (WREN + ULBPR 0x98) is required before any erase
+        // succeeds — same as SpiFlashDevice::erase.
+        let needs_sst26_unprotect = self
+            .context()
+            .chip
+            .features
+            .contains(crate::chip::Features::SST26_BPR);
+        if needs_sst26_unprotect {
+            protocol::sst26_global_unprotect(&mut self.master).await?;
+        }
+
         let ctx = self.context();
         let erase_block = select_erase_block(ctx.chip.erase_blocks(), addr, len)
             .ok_or(Error::InvalidAlignment)?;
@@ -252,12 +268,17 @@ impl<M: SpiMaster + OpaqueMaster> FlashDevice for HybridFlashDevice<M> {
             .await;
 
             if result.is_err() {
-                if enter_exit_4byte {
-                    let _ =
-                        protocol::exit_4byte_mode_with_features(self.master(), chip_features).await;
+                if enter_exit_4byte
+                    && let Err(e) =
+                        protocol::exit_4byte_mode_with_features(self.master(), chip_features).await
+                {
+                    log::warn!("Failed to exit 4-byte address mode: {}", e);
                 }
                 return result;
             }
+
+            // Verify the block was erased, same as SpiFlashDevice::erase
+            check_erased_range(&mut self.master, &self.ctx, current_addr, block_size).await?;
 
             current_addr += block_size;
         }

--- a/crates/rflasher-core/src/flash/hybrid_device.rs
+++ b/crates/rflasher-core/src/flash/hybrid_device.rs
@@ -280,7 +280,17 @@ impl<M: SpiMaster + OpaqueMaster> FlashDevice for HybridFlashDevice<M> {
             }
 
             // Verify the block was erased, same as SpiFlashDevice::erase
-            check_erased_range(&mut self.master, &self.ctx, current_addr, block_size).await?;
+            if let Err(e) =
+                check_erased_range(&mut self.master, &self.ctx, current_addr, block_size).await
+            {
+                if enter_exit_4byte
+                    && let Err(exit_e) =
+                        protocol::exit_4byte_mode_with_features(self.master(), chip_features).await
+                {
+                    log::warn!("Failed to exit 4-byte address mode: {}", exit_e);
+                }
+                return Err(e);
+            }
 
             current_addr += block_size;
         }

--- a/crates/rflasher-core/src/flash/hybrid_device.rs
+++ b/crates/rflasher-core/src/flash/hybrid_device.rs
@@ -23,7 +23,9 @@ use crate::chip::{EraseBlock, WriteGranularity};
 use crate::error::{Error, Result};
 use crate::flash::context::{AddressMode, FlashContext};
 use crate::flash::device::FlashDevice;
-use crate::flash::operations::{addressing_for_4byte_operation, check_erased_range, select_erase_block};
+use crate::flash::operations::{
+    addressing_for_4byte_operation, check_erased_range, select_erase_block,
+};
 use crate::programmer::{OpaqueMaster, SpiFeatures, SpiMaster};
 use crate::protocol::{self, CommandAddressing};
 #[cfg(feature = "alloc")]

--- a/crates/rflasher-core/src/flash/operations.rs
+++ b/crates/rflasher-core/src/flash/operations.rs
@@ -886,6 +886,10 @@ pub async fn write<M: SpiMaster + ?Sized>(
     // Get the master's maximum write length - some controllers have limits
     // smaller than a full page (e.g., Intel swseq is limited to 64 bytes)
     let max_write = master.max_write_len();
+    if max_write == 0 {
+        // A zero limit would produce zero-sized chunks and never make progress
+        return Err(Error::ProgrammerError);
+    }
 
     if enter_exit_4byte {
         protocol::enter_4byte_mode_with_features(master, features).await?;

--- a/crates/rflasher-core/src/flash/operations.rs
+++ b/crates/rflasher-core/src/flash/operations.rs
@@ -10,7 +10,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use crate::chip::ChipProvider;
 use crate::chip::{EraseBlock, Features, WriteGranularity};
-use crate::error::{Error, Result};
+use crate::error::{EraseFailure, Error, Result};
 use crate::programmer::{SpiFeatures, SpiMaster};
 use crate::protocol::{self, CommandAddressing};
 use maybe_async::maybe_async;
@@ -940,6 +940,41 @@ pub async fn write<M: SpiMaster + ?Sized>(
 
     if enter_exit_4byte {
         protocol::exit_4byte_mode_with_features(master, features).await?;
+    }
+
+    Ok(())
+}
+
+/// Check that a range of flash has been erased (all bytes are 0xFF)
+///
+/// Reads through the full read path (I/O mode selection, 4-byte addressing)
+/// and returns [`Error::EraseError`] with the exact address of the first
+/// non-erased byte on failure.
+#[maybe_async]
+pub async fn check_erased_range<M: SpiMaster + ?Sized>(
+    master: &mut M,
+    ctx: &FlashContext,
+    addr: u32,
+    len: u32,
+) -> Result<()> {
+    const CHUNK_SIZE: usize = 4096;
+    let mut buf = [0u8; CHUNK_SIZE];
+
+    let mut offset = 0u32;
+    while offset < len {
+        let chunk_len = core::cmp::min(CHUNK_SIZE as u32, len - offset) as usize;
+        let chunk_buf = &mut buf[..chunk_len];
+
+        read(master, ctx, addr + offset, chunk_buf).await?;
+
+        if let Some((idx, &found)) = chunk_buf.iter().enumerate().find(|&(_, &b)| b != 0xFF) {
+            return Err(Error::EraseError(EraseFailure::VerifyFailed {
+                addr: addr + offset + idx as u32,
+                found,
+            }));
+        }
+
+        offset += chunk_len as u32;
     }
 
     Ok(())

--- a/crates/rflasher-core/src/flash/operations.rs
+++ b/crates/rflasher-core/src/flash/operations.rs
@@ -101,26 +101,15 @@ pub fn need_erase(have: &[u8], want: &[u8], granularity: WriteGranularity) -> bo
             // (have & want) != want means some bit in want is 1 but in have is 0
             have.iter().zip(want.iter()).any(|(h, w)| (h & w) != *w)
         }
-        WriteGranularity::Byte => {
-            // For byte-granularity, if bytes differ, the old byte must be
-            // in erased state (0xFF) to allow writing the new value
-            have.iter().zip(want.iter()).any(|(h, w)| {
-                if h == w {
-                    false // No change needed
-                } else {
-                    *h != ERASED_VALUE // Need erase if not already erased
-                }
-            })
-        }
-        WriteGranularity::Page => {
-            // For page granularity, we operate on pages (256 bytes typically)
-            // but the logic is the same as byte - if any byte differs,
-            // the source must be erased
-            have.iter().zip(want.iter()).any(
-                |(h, w)| {
-                    if h == w { false } else { *h != ERASED_VALUE }
-                },
-            )
+        WriteGranularity::Byte | WriteGranularity::Page => {
+            // Byte- and page-granularity chips behave the same at the byte
+            // level: if a byte differs, the source must be erased (0xFF) to
+            // allow writing the new value. Page granularity only restricts
+            // how many bytes may be programmed per command, not which
+            // transitions require an erase.
+            have.iter()
+                .zip(want.iter())
+                .any(|(h, w)| *h != *w && *h != ERASED_VALUE)
         }
     }
 }

--- a/crates/rflasher-core/src/flash/operations.rs
+++ b/crates/rflasher-core/src/flash/operations.rs
@@ -860,7 +860,9 @@ pub async fn write<M: SpiMaster + ?Sized>(
     // AAI uses 3-byte addressing only — 4-byte mode is irrelevant for SST25 chips.
     // Note: SFDP-probed chips may report WriteGranularity::Byte (BFPT DWORD1 bit[2]=0)
     // without AAI_WORD being set; those fall through to single-byte page program below.
-    if features.contains(crate::chip::Features::AAI_WORD) {
+    // Masters that cannot transfer two data bytes in one command skip AAI and use
+    // single-byte page program, which SST25 chips also support.
+    if features.contains(crate::chip::Features::AAI_WORD) && master.max_write_len() >= 2 {
         return protocol::aai_word_program(master, addr, data).await;
     }
 

--- a/crates/rflasher-core/src/flash/operations.rs
+++ b/crates/rflasher-core/src/flash/operations.rs
@@ -9,9 +9,7 @@ use alloc::vec::Vec;
 
 #[cfg(feature = "std")]
 use crate::chip::ChipProvider;
-#[cfg(feature = "alloc")]
-use crate::chip::WriteGranularity;
-use crate::chip::{EraseBlock, Features};
+use crate::chip::{EraseBlock, Features, WriteGranularity};
 use crate::error::{Error, Result};
 use crate::programmer::{SpiFeatures, SpiMaster};
 use crate::protocol::{self, CommandAddressing};
@@ -805,7 +803,6 @@ pub async fn read<M: SpiMaster + ?Sized>(
     if !ctx.is_valid_range(addr, buf.len()) {
         return Err(Error::AddressOutOfBounds);
     }
-
     let features = ctx.chip.features;
     let master_features = master.features();
     let try_native_4byte =
@@ -866,7 +863,18 @@ pub async fn write<M: SpiMaster + ?Sized>(
     }
 
     let features = ctx.chip.features;
+    let write_granularity = ctx.chip.write_granularity;
     let page_size = ctx.page_size();
+
+    // SST25 AAI word program: chip database sets AAI_WORD for SST25VFxxxB/SST25WFxxx.
+    // These chips require a streaming protocol (0xAD) rather than page program (0x02).
+    // AAI uses 3-byte addressing only — 4-byte mode is irrelevant for SST25 chips.
+    // Note: SFDP-probed chips may report WriteGranularity::Byte (BFPT DWORD1 bit[2]=0)
+    // without AAI_WORD being set; those fall through to single-byte page program below.
+    if features.contains(crate::chip::Features::AAI_WORD) {
+        return protocol::aai_word_program(master, addr, data).await;
+    }
+
     let use_4byte = ctx.address_mode == AddressMode::FourByte;
     let master_features = master.features();
     let use_native = use_4byte
@@ -896,12 +904,20 @@ pub async fn write<M: SpiMaster + ?Sized>(
     let mut current_addr = addr;
 
     while offset < data.len() {
-        // Calculate how many bytes until the next page boundary
-        let page_offset = (current_addr as usize) % page_size;
-        let bytes_to_page_end = page_size - page_offset;
         let remaining = data.len() - offset;
-        // Respect both page boundaries and the master's maximum write length
-        let chunk_size = core::cmp::min(core::cmp::min(bytes_to_page_end, remaining), max_write);
+
+        let chunk_size = if write_granularity == WriteGranularity::Byte {
+            // Single-byte page program: one byte per WREN+PP+WIP cycle.
+            // Used for SFDP-detected chips reporting byte granularity (BFPT DWORD1
+            // bit[2]=0) that don't have AAI_WORD — matches flashprog spi_chip_write_1.
+            1
+        } else {
+            // Page-granularity program: up to a full page per command, respecting
+            // page boundaries and the master's maximum write length.
+            let page_offset = (current_addr as usize) % page_size;
+            let bytes_to_page_end = page_size - page_offset;
+            core::cmp::min(core::cmp::min(bytes_to_page_end, remaining), max_write)
+        };
 
         let chunk = &data[offset..offset + chunk_size];
 

--- a/crates/rflasher-core/src/flash/spi_device.rs
+++ b/crates/rflasher-core/src/flash/spi_device.rs
@@ -7,8 +7,8 @@ use crate::chip::{EraseBlock, WriteGranularity};
 use crate::error::{Error, Result};
 use crate::flash::context::{AddressMode, FlashContext};
 use crate::flash::device::FlashDevice;
-use crate::flash::{operations, select_erase_block};
 use crate::flash::operations::addressing_for_4byte_operation;
+use crate::flash::{operations, select_erase_block};
 use crate::programmer::{SpiFeatures, SpiMaster};
 use crate::protocol::{self, CommandAddressing};
 use crate::wp::{

--- a/crates/rflasher-core/src/flash/spi_device.rs
+++ b/crates/rflasher-core/src/flash/spi_device.rs
@@ -7,9 +7,8 @@ use crate::chip::{EraseBlock, WriteGranularity};
 use crate::error::{EraseFailure, Error, Result};
 use crate::flash::context::{AddressMode, FlashContext};
 use crate::flash::device::FlashDevice;
-use crate::flash::operations::{
-    addressing_for_4byte_operation, read_dummy_cycles, select_erase_block,
-};
+use crate::flash::{operations, select_erase_block};
+use crate::flash::operations::addressing_for_4byte_operation;
 use crate::programmer::{SpiFeatures, SpiMaster};
 use crate::protocol::{self, CommandAddressing};
 use crate::wp::{
@@ -138,149 +137,20 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
     }
 
     async fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
-        let ctx = self.context();
-        if !ctx.is_valid_range(addr, buf.len()) {
+        if !self.context().is_valid_range(addr, buf.len()) {
             return Err(Error::AddressOutOfBounds);
         }
-
-        let chip_features = ctx.chip.features;
-        let address_mode = ctx.address_mode;
-        let try_native_4byte =
-            address_mode == AddressMode::FourByte && chip_features.supports_4ba_read();
-        let master_features = self.master.features();
-
-        let (io_mode, opcode, native_4byte) = protocol::select_read_mode(
-            master_features,
-            chip_features,
-            try_native_4byte,
-            |opcode| self.master.probe_opcode(opcode),
-        );
-
-        let (addressing, enter_exit_4byte) = if address_mode == AddressMode::FourByte {
-            addressing_for_4byte_operation(native_4byte, chip_features, master_features)?
-        } else {
-            (CommandAddressing::ThreeByte, false)
-        };
-
-        if enter_exit_4byte {
-            protocol::enter_4byte_mode_with_features(self.master(), chip_features).await?;
-        }
-
-        let result = protocol::read_io_with_addressing(
-            self.master(),
-            opcode,
-            addr,
-            buf,
-            addressing,
-            io_mode,
-            read_dummy_cycles(io_mode),
-        )
-        .await;
-
-        if enter_exit_4byte
-            && let Err(e) =
-                protocol::exit_4byte_mode_with_features(self.master(), chip_features).await
-        {
-            log::warn!("Failed to exit 4-byte address mode: {}", e);
-        }
-
-        result
+        // Delegate to the canonical free function to avoid divergent duplicates
+        operations::read(&mut self.master, &self.ctx, addr, buf).await
     }
 
     async fn write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
-        use crate::chip::{Features, WriteGranularity};
-
-        let ctx = self.context();
-        if !ctx.is_valid_range(addr, data.len()) {
+        if !self.context().is_valid_range(addr, data.len()) {
             return Err(Error::AddressOutOfBounds);
         }
-
-        let features = ctx.chip.features;
-        let write_granularity = ctx.chip.write_granularity;
-        let page_size = ctx.page_size();
-        let use_4byte = ctx.address_mode == AddressMode::FourByte;
-        let master_features = self.master.features();
-        let use_native = use_4byte
-            && features.supports_4ba_program()
-            && master_features.contains(SpiFeatures::FOUR_BYTE_ADDR)
-            && self.master.probe_opcode(crate::spi::opcodes::PP_4B);
-        let (addressing, enter_exit_4byte) = if use_4byte {
-            addressing_for_4byte_operation(use_native, features, master_features)?
-        } else {
-            (CommandAddressing::ThreeByte, false)
-        };
-        let opcode = if use_native {
-            crate::spi::opcodes::PP_4B
-        } else {
-            crate::spi::opcodes::PP
-        };
-
-        // SST25 AAI word program: chip database sets AAI_WORD for SST25VFxxxB/SST25WFxxx.
-        // These chips require a streaming protocol (0xAD) rather than page program (0x02).
-        // AAI uses 3-byte addressing only — 4-byte mode is irrelevant for SST25 chips.
-        // Note: SFDP-probed chips may report WriteGranularity::Byte (BFPT DWORD1 bit[2]=0)
-        // without AAI_WORD being set; those fall through to single-byte page program below.
-        if features.contains(Features::AAI_WORD) {
-            return protocol::aai_word_program(self.master(), addr, data).await;
-        }
-
-        // Get the master's maximum write length - some controllers have limits
-        // smaller than a full page (e.g., Intel swseq is limited to 64 bytes)
-        let max_write = self.master().max_write_len();
-
-        if enter_exit_4byte {
-            protocol::enter_4byte_mode_with_features(self.master(), features).await?;
-        }
-
-        let mut offset = 0usize;
-        let mut current_addr = addr;
-
-        while offset < data.len() {
-            let remaining = data.len() - offset;
-
-            let chunk_size = if write_granularity == WriteGranularity::Byte {
-                // Single-byte page program: one byte per WREN+PP+WIP cycle.
-                // Used for SFDP-detected chips reporting byte granularity (BFPT DWORD1
-                // bit[2]=0) that don't have AAI_WORD — matches flashprog spi_chip_write_1.
-                1
-            } else {
-                // Page-granularity program: up to a full page per command, respecting
-                // page boundaries and the master's maximum write length.
-                let page_offset = (current_addr as usize) % page_size;
-                let bytes_to_page_end = page_size - page_offset;
-                core::cmp::min(core::cmp::min(bytes_to_page_end, remaining), max_write)
-            };
-
-            let chunk = &data[offset..offset + chunk_size];
-
-            let result = protocol::program_page_with_addressing(
-                self.master(),
-                opcode,
-                current_addr,
-                chunk,
-                addressing,
-            )
-            .await;
-
-            if result.is_err() {
-                if enter_exit_4byte
-                    && let Err(e) =
-                        protocol::exit_4byte_mode_with_features(self.master(), features).await
-                {
-                    log::warn!("Failed to exit 4-byte address mode: {}", e);
-                }
-                return result;
-            }
-
-            offset += chunk_size;
-            current_addr += chunk_size as u32;
-        }
-
-        if enter_exit_4byte {
-            protocol::exit_4byte_mode_with_features(self.master(), features).await?;
-        }
-
-        Ok(())
+        // Delegate to the canonical free function (handles AAI word program,
+        // byte-granularity chips, page splitting and 4-byte addressing)
+        operations::write(&mut self.master, &self.ctx, addr, data).await
     }
 
     async fn erase(&mut self, addr: u32, len: u32) -> Result<()> {

--- a/crates/rflasher-core/src/flash/spi_device.rs
+++ b/crates/rflasher-core/src/flash/spi_device.rs
@@ -4,7 +4,7 @@
 //! `FlashDevice` for SPI-based programmers.
 
 use crate::chip::{EraseBlock, WriteGranularity};
-use crate::error::{EraseFailure, Error, Result};
+use crate::error::{Error, Result};
 use crate::flash::context::{AddressMode, FlashContext};
 use crate::flash::device::FlashDevice;
 use crate::flash::{operations, select_erase_block};
@@ -262,37 +262,9 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
 
 impl<M: SpiMaster> SpiFlashDevice<M> {
     /// Check that a range of flash has been erased (all bytes are 0xFF)
-    ///
-    /// Uses the `FlashDevice::read` trait method, which differs from
-    /// `operations::check_erased_range` that uses the free function `read()`.
     #[maybe_async]
     async fn check_erased_range(&mut self, addr: u32, len: u32) -> Result<()> {
-        const ERASED_VALUE: u8 = 0xFF;
-        const CHUNK_SIZE: usize = 4096;
-        let mut buf = [0u8; CHUNK_SIZE];
-
-        let mut offset = 0u32;
-        while offset < len {
-            let chunk_len = core::cmp::min(CHUNK_SIZE as u32, len - offset) as usize;
-            let chunk_buf = &mut buf[..chunk_len];
-
-            FlashDevice::read(self, addr + offset, chunk_buf).await?;
-
-            if let Some((idx, &found)) = chunk_buf
-                .iter()
-                .enumerate()
-                .find(|&(_, &b)| b != ERASED_VALUE)
-            {
-                return Err(Error::EraseError(EraseFailure::VerifyFailed {
-                    addr: addr + offset + idx as u32,
-                    found,
-                }));
-            }
-
-            offset += chunk_len as u32;
-        }
-
-        Ok(())
+        operations::check_erased_range(&mut self.master, &self.ctx, addr, len).await
     }
 }
 

--- a/crates/rflasher-core/src/flash/spi_device.rs
+++ b/crates/rflasher-core/src/flash/spi_device.rs
@@ -238,17 +238,6 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
                 return result;
             }
 
-            // Verify the block was erased
-            if let Err(e) = self.check_erased_range(current_addr, block_size).await {
-                if enter_exit_4byte
-                    && let Err(exit_e) =
-                        protocol::exit_4byte_mode_with_features(self.master(), chip_features).await
-                {
-                    log::warn!("Failed to exit 4-byte address mode: {}", exit_e);
-                }
-                return Err(e);
-            }
-
             current_addr += block_size;
         }
 
@@ -256,7 +245,11 @@ impl<M: SpiMaster> FlashDevice for SpiFlashDevice<M> {
             protocol::exit_4byte_mode_with_features(self.master(), chip_features).await?;
         }
 
-        Ok(())
+        // Verify only after the erase loop has left its persistent 4-byte
+        // mode. The read helper manages 4-byte mode itself; calling it inside
+        // the loop would exit that mode and make the next legacy erase opcode
+        // target the wrong address.
+        self.check_erased_range(addr, len).await
     }
 }
 

--- a/crates/rflasher-core/src/flash/unified.rs
+++ b/crates/rflasher-core/src/flash/unified.rs
@@ -656,8 +656,14 @@ pub async fn verify<D: FlashDevice>(device: &mut D, expected: &[u8], addr: u32) 
 
         let expected_chunk = &expected[offset..offset + chunk_size];
         if chunk_buf != expected_chunk {
+            // Locate the first differing byte so the reported address is exact
+            let rel = chunk_buf
+                .iter()
+                .zip(expected_chunk.iter())
+                .position(|(got, want)| got != want)
+                .expect("chunks differ, so a differing byte must exist");
             return Err(Error::VerifyError {
-                addr: addr + offset as u32,
+                addr: addr + (offset + rel) as u32,
             });
         }
 

--- a/crates/rflasher-core/src/layout/fmap.rs
+++ b/crates/rflasher-core/src/layout/fmap.rs
@@ -188,9 +188,10 @@ pub fn search_fmap<S: FmapSearchable>(storage: &mut S) -> Result<Layout, LayoutE
     if let Some(offset) = binary_search_fmap(storage, 0, size)? {
         match read_fmap_at(storage, offset) {
             Ok(layout) => return Ok(layout),
-            // The signature match was a false positive; fall back to the
-            // exhaustive linear scan below.
-            Err(LayoutError::InvalidFmapSignature) => {}
+            // The signature match was a false positive: either the structure
+            // does not validate, or its declared area table reads past the
+            // end of storage. Fall back to the exhaustive linear scan below.
+            Err(LayoutError::InvalidFmapSignature | LayoutError::IoError(_)) => {}
             Err(e) => return Err(e),
         }
     }

--- a/crates/rflasher-core/src/layout/fmap.rs
+++ b/crates/rflasher-core/src/layout/fmap.rs
@@ -160,6 +160,20 @@ impl FmapSearchable for &[u8] {
     }
 }
 
+/// Read and parse an FMAP at `offset` directly from storage, sizing the
+/// read from the header's declared area count.
+fn read_fmap_at<S: FmapSearchable>(storage: &mut S, offset: u32) -> Result<Layout, LayoutError> {
+    let mut header = [0u8; FMAP_HEADER_SIZE];
+    storage.read_at(offset, &mut header)?;
+    let nareas = u16::from_le_bytes([header[54], header[55]]) as usize;
+    if nareas > 256 {
+        return Err(LayoutError::InvalidFmapSignature);
+    }
+    let mut buf = vec![0u8; FMAP_HEADER_SIZE + nareas * FMAP_AREA_SIZE];
+    storage.read_at(offset, &mut buf)?;
+    parse_fmap_at(&buf, 0)
+}
+
 /// Search for FMAP using binary search followed by linear search
 ///
 /// This follows flashprog's strategy:
@@ -172,10 +186,13 @@ pub fn search_fmap<S: FmapSearchable>(storage: &mut S) -> Result<Layout, LayoutE
 
     // Try binary search first (check power-of-2 aligned offsets)
     if let Some(offset) = binary_search_fmap(storage, 0, size)? {
-        // Read enough to parse the FMAP
-        let mut header = vec![0u8; 4096]; // Generous size for header + areas
-        storage.read_at(offset, &mut header)?;
-        return parse_fmap_at(&header, 0);
+        match read_fmap_at(storage, offset) {
+            Ok(layout) => return Ok(layout),
+            // The signature match was a false positive; fall back to the
+            // exhaustive linear scan below.
+            Err(LayoutError::InvalidFmapSignature) => {}
+            Err(e) => return Err(e),
+        }
     }
 
     // Fallback to linear search - read entire storage and search
@@ -204,9 +221,8 @@ fn binary_search_fmap<S: FmapSearchable>(
         return Ok(None);
     }
 
-    // Buffer for reading signature and header
+    // Buffer for reading the signature
     let mut sig_buf = [0u8; 8];
-    let mut header_buf = vec![0u8; FMAP_HEADER_SIZE];
 
     // Generate strides: size/2, size/4, size/8, ... down to MIN_STRIDE
     // Using successors to generate the halving sequence
@@ -245,12 +261,11 @@ fn binary_search_fmap<S: FmapSearchable>(
                 continue;
             }
 
-            // Found potential FMAP - read and validate the header
-            if storage.read_at(offset, &mut header_buf).is_err() {
-                continue;
-            }
-
-            if is_valid_fmap_header(&header_buf) {
+            // Found a signature candidate. Full validation is deferred to
+            // the caller (read_fmap_at); a false positive here just falls
+            // back to the linear scan. Validating here would require the
+            // area records, which a fixed-size header buffer cannot hold.
+            if &sig_buf == FMAP_SIGNATURE {
                 return Ok(Some(offset));
             }
         }

--- a/crates/rflasher-core/src/layout/fmap.rs
+++ b/crates/rflasher-core/src/layout/fmap.rs
@@ -314,9 +314,6 @@ pub fn parse_fmap_at(data: &[u8], offset: usize) -> Result<Layout, LayoutError> 
 
     layout.sort_by_address();
     Ok(layout)
-
-    layout.sort_by_address();
-    Ok(layout)
 }
 
 /// Parse a null-terminated FMAP string

--- a/crates/rflasher-core/src/layout/fmap.rs
+++ b/crates/rflasher-core/src/layout/fmap.rs
@@ -289,29 +289,31 @@ pub fn parse_fmap_at(data: &[u8], offset: usize) -> Result<Layout, LayoutError> 
         .map_err(|_| LayoutError::InvalidFmapSignature)?
         .0;
 
-    let mut layout =
-        areas
-            .iter()
-            .filter(|area| area.size.get() != 0)
-            .fold(layout, |mut layout, area| {
-                let area_start = area.offset.get();
-                let area_size = area.size.get();
-                let area_flags = area.flags.get();
-                let area_name = parse_fmap_string(&area.name);
-                let end = area_start + area_size - 1;
+    for area in areas.iter().filter(|area| area.size.get() != 0) {
+        let area_start = area.offset.get();
+        let area_size = area.size.get();
+        let area_flags = area.flags.get();
+        let area_name = parse_fmap_string(&area.name);
+        // Reject areas whose range overflows the 32-bit address space;
+        // these fields come straight from untrusted flash/file contents.
+        let Some(end) = area_start.checked_add(area_size - 1) else {
+            return Err(LayoutError::InvalidFmapSignature);
+        };
 
-                let region = Region {
-                    name: area_name,
-                    start: area_start,
-                    end,
-                    readonly: (area_flags & flags::STATIC) != 0 || (area_flags & flags::RO) != 0,
-                    dangerous: false,
-                    included: false,
-                };
+        let region = Region {
+            name: area_name,
+            start: area_start,
+            end,
+            readonly: (area_flags & flags::STATIC) != 0 || (area_flags & flags::RO) != 0,
+            dangerous: false,
+            included: false,
+        };
 
-                layout.add_region(region);
-                layout
-            });
+        layout.add_region(region);
+    }
+
+    layout.sort_by_address();
+    Ok(layout)
 
     layout.sort_by_address();
     Ok(layout)

--- a/crates/rflasher-core/src/spi/command.rs
+++ b/crates/rflasher-core/src/spi/command.rs
@@ -178,8 +178,10 @@ impl<'a> SpiCommand<'a> {
     pub fn total_bytes(&self) -> usize {
         let mut total = 1; // opcode
         total += self.address_width.bytes() as usize;
-        // Dummy cycles are in clock cycles, not bytes - depends on I/O mode
-        total += (self.dummy_cycles as usize) / 8;
+        // Dummy cycles are in clock cycles, not bytes - depends on I/O mode.
+        // Round up like header_len()/encode_header() do: a partial dummy byte
+        // still occupies a full byte on the wire.
+        total += self.dummy_cycles.div_ceil(8) as usize;
         total += self.write_data.len();
         total += self.read_buf.len();
         total

--- a/crates/rflasher-core/src/spi/io_mode.rs
+++ b/crates/rflasher-core/src/spi/io_mode.rs
@@ -1,5 +1,8 @@
 //! SPI I/O modes
 
+use crate::error::{Error, Result};
+use crate::programmer::SpiFeatures;
+
 /// I/O mode for SPI transactions
 ///
 /// Represents how data is transferred on the SPI bus, from single-wire
@@ -63,9 +66,6 @@ impl IoMode {
         matches!(self, Self::QuadOut | Self::QuadIo | Self::Qpi)
     }
 }
-
-use crate::error::{Error, Result};
-use crate::programmer::SpiFeatures;
 
 /// Check if a programmer supports the requested I/O mode
 ///

--- a/crates/rflasher-core/src/wp/ops.rs
+++ b/crates/rflasher-core/src/wp/ops.rs
@@ -253,6 +253,10 @@ fn build_register_masks(bit_map: &WpRegBitMap, bits: &WpBits) -> (u8, u8, u8) {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct WriteOptions {
     /// Use volatile write (doesn't persist across power cycle)
+    ///
+    /// NOTE: currently ignored — all status register writes use the
+    /// non-volatile path. Volatile writes require a separate SR copy on
+    /// some chips and are not implemented yet.
     pub volatile: bool,
     /// Use EWSR (0x50) instead of WREN (0x06) before status register writes.
     ///

--- a/crates/rflasher-core/src/wp/ops.rs
+++ b/crates/rflasher-core/src/wp/ops.rs
@@ -252,7 +252,7 @@ fn build_register_masks(bit_map: &WpRegBitMap, bits: &WpBits) -> (u8, u8, u8) {
 /// Write protection configuration options
 #[derive(Debug, Clone, Copy, Default)]
 pub struct WriteOptions {
-    /// Use volatile write (doesn't persist across power cycle)
+    /// Use volatile write (currently ignored; see note below)
     ///
     /// NOTE: currently ignored — all status register writes use the
     /// non-volatile path. Volatile writes require a separate SR copy on

--- a/crates/rflasher-internal/src/ichspi.rs
+++ b/crates/rflasher-internal/src/ichspi.rs
@@ -1933,7 +1933,13 @@ impl<H: HostAccess> IchSpiController<H> {
             InternalError::NotSupported("Opcode not available in OPMENU")
         })?;
 
-        let opcodes = self.opcodes.as_ref().unwrap();
+        // Invariant: init() always populates `opcodes` before the controller
+        // is returned; find_opcode_index() above already returns an error if
+        // it were somehow absent.
+        let opcodes = self
+            .opcodes
+            .as_ref()
+            .expect("opcodes initialized by IchSpiController::init");
         let spi_type = opcodes.opcode[opcode_index].spi_type;
 
         // Validate command format based on opcode type
@@ -2186,7 +2192,13 @@ impl<H: HostAccess> IchSpiController<H> {
             InternalError::NotSupported("Opcode not available in OPMENU")
         })?;
 
-        let opcodes = self.opcodes.as_ref().unwrap();
+        // Invariant: init() always populates `opcodes` before the controller
+        // is returned; find_opcode_index() above already returns an error if
+        // it were somehow absent.
+        let opcodes = self
+            .opcodes
+            .as_ref()
+            .expect("opcodes initialized by IchSpiController::init");
         let spi_type = opcodes.opcode[opcode_index].spi_type;
 
         // Validate command format based on opcode type

--- a/crates/rflasher-internal/src/physmap.rs
+++ b/crates/rflasher-internal/src/physmap.rs
@@ -8,13 +8,16 @@ use crate::error::InternalError;
 
 /// A mapped region of physical memory.
 pub struct PhysMap {
-    /// Pointer to the mapped memory.
+    /// Pointer to the mapped memory (adjusted into the requested window).
     ptr: *mut u8,
     /// Requested window size.
     size: usize,
     /// Actual mapped size, after host page alignment.
     #[cfg(all(feature = "std", target_os = "linux"))]
     map_size: usize,
+    /// Base pointer returned by mmap, before page-offset adjustment.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    map_ptr: *mut libc::c_void,
     /// Physical address, for reporting and Linux unmapping.
     phys_addr: u64,
 }
@@ -78,6 +81,7 @@ impl PhysMap {
             ptr: adjusted_ptr,
             size,
             map_size,
+            map_ptr: ptr,
             phys_addr,
         })
     }
@@ -207,16 +211,10 @@ impl PhysMap {
 #[cfg(all(feature = "std", target_os = "linux"))]
 impl Drop for PhysMap {
     fn drop(&mut self) {
-        // SAFETY: sysconf is thread-safe and does not touch Rust-managed memory.
-        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
-        let page_mask = page_size - 1;
-        let offset = (self.phys_addr as usize) & page_mask;
-        // SAFETY: `ptr` was adjusted by exactly this offset in `new`.
-        let original_ptr = unsafe { self.ptr.sub(offset) };
-
-        // SAFETY: this unmaps the same range created by mmap in `new`.
+        // SAFETY: this unmaps the exact range created by mmap in `new`,
+        // using the base pointer stored at construction time.
         unsafe {
-            libc::munmap(original_ptr as *mut libc::c_void, self.map_size);
+            libc::munmap(self.map_ptr, self.map_size);
         }
     }
 }

--- a/crates/rflasher-programmers/src/handle.rs
+++ b/crates/rflasher-programmers/src/handle.rs
@@ -23,8 +23,8 @@ pub struct ChipInfo {
     pub total_size: u32,
     /// Page size in bytes
     pub page_size: u16,
-    /// Full chip details (optional, for advanced use)
-    pub chip: Option<FlashChip>,
+    /// Full chip details
+    pub chip: FlashChip,
     /// Whether chip was found in database (vs SFDP-only)
     pub from_database: bool,
     /// SFDP information if available
@@ -42,7 +42,7 @@ impl From<&FlashContext> for ChipInfo {
             jedec_device: ctx.chip.jedec_device,
             total_size: ctx.chip.total_size,
             page_size: ctx.chip.page_size,
-            chip: Some(ctx.chip.clone()),
+            chip: ctx.chip.clone(),
             from_database: true,
             sfdp: None,
             mismatches: Vec::new(),
@@ -59,7 +59,7 @@ impl From<ProbeResult> for ChipInfo {
             jedec_device: result.jedec_device,
             total_size: result.chip.total_size,
             page_size: result.chip.page_size,
-            chip: Some(result.chip),
+            chip: result.chip,
             from_database: result.from_database,
             sfdp: result.sfdp,
             mismatches: result.mismatches,

--- a/crates/rflasher-programmers/src/registry.rs
+++ b/crates/rflasher-programmers/src/registry.rs
@@ -425,6 +425,9 @@ pub fn open_flash(
     programmer: &str,
     db: &dyn ChipProvider,
 ) -> Result<FlashHandle, Box<dyn std::error::Error>> {
+    // Not every compiled programmer arm uses the database (e.g. linux-mtd);
+    // in feature combinations where none does, this suppresses the unused
+    // `db` parameter warning.
     let _ = db;
     let params = parse_programmer_params(programmer)?;
 

--- a/crates/rflasher-programmers/src/registry.rs
+++ b/crates/rflasher-programmers/src/registry.rs
@@ -125,7 +125,7 @@ where
     log_probe_result(&result);
 
     let chip_info = ChipInfo::from(result);
-    let ctx = rflasher_core::flash::FlashContext::new(chip_info.chip.clone().unwrap());
+    let ctx = rflasher_core::flash::FlashContext::new(chip_info.chip.clone());
     let device = SpiFlashDevice::new(master, ctx);
     Ok(FlashHandle::with_chip_info(Box::new(device), chip_info))
 }
@@ -578,7 +578,7 @@ fn open_dediprog(
     let result = probe_detailed(&mut master, db)?;
     log_probe_result(&result);
     let chip_info = ChipInfo::from(result);
-    let ctx = rflasher_core::flash::FlashContext::new(chip_info.chip.clone().unwrap());
+    let ctx = rflasher_core::flash::FlashContext::new(chip_info.chip.clone());
 
     // Set flash size so OpaqueMaster bulk read/write knows the bounds
     master.set_flash_size(ctx.total_size() as u32);
@@ -948,7 +948,7 @@ fn open_sunxi_fel(
     let result = probe_detailed(&mut master, db)?;
     log_probe_result(&result);
     let chip_info = ChipInfo::from(result);
-    let ctx = rflasher_core::flash::FlashContext::new(chip_info.chip.clone().unwrap());
+    let ctx = rflasher_core::flash::FlashContext::new(chip_info.chip.clone());
 
     // Configure OpaqueMaster with chip info discovered during probe
     master.set_use_4byte_addr(ctx.total_size() > 16 * 1024 * 1024);

--- a/crates/rflasher-programmers/src/registry.rs
+++ b/crates/rflasher-programmers/src/registry.rs
@@ -91,15 +91,22 @@ fn log_probe_result(result: &ProbeResult) {
 /// - "1000" - plain number in kHz
 /// - "1000k" or "1000K" - kHz (same as plain)
 /// - "30m" or "30M" - MHz (multiplied by 1000)
+/// - "1g" or "1G" - GHz (multiplied by 1_000_000)
 ///
 /// Returns None if the string cannot be parsed.
 fn parse_speed_khz(s: &str) -> Option<u32> {
     let s = s.trim().to_lowercase();
 
+    // Try with GHz suffix
+    if let Some(num) = s.strip_suffix('g') {
+        let val: f64 = num.trim().parse().ok()?;
+        return Some((val * 1_000_000.0).round() as u32);
+    }
+
     // Try with MHz suffix
     if let Some(num) = s.strip_suffix('m') {
         let val: f64 = num.trim().parse().ok()?;
-        return Some((val * 1000.0) as u32);
+        return Some((val * 1000.0).round() as u32);
     }
 
     // Try with kHz suffix

--- a/crates/rflasher-programmers/src/registry.rs
+++ b/crates/rflasher-programmers/src/registry.rs
@@ -95,14 +95,16 @@ fn log_probe_result(result: &ProbeResult) {
 ///
 /// Returns None if the string cannot be parsed.
 fn parse_speed_khz(s: &str) -> Option<u32> {
+    const MAX_KHZ: u32 = u32::MAX / 1000;
+
     /// Convert a parsed value with the given unit multiplier to kHz,
-    /// rejecting non-finite, negative, and out-of-range results.
+    /// rejecting non-finite, non-positive, and out-of-range results.
     fn khz_from(val: f64, multiplier: f64) -> Option<u32> {
-        let khz = val * multiplier;
-        if !khz.is_finite() || !(0.0..=u32::MAX as f64).contains(&khz) {
+        let khz = (val * multiplier).round();
+        if !khz.is_finite() || !(1.0..=MAX_KHZ as f64).contains(&khz) {
             return None;
         }
-        Some(khz.round() as u32)
+        Some(khz as u32)
     }
 
     let s = s.trim().to_lowercase();
@@ -121,11 +123,38 @@ fn parse_speed_khz(s: &str) -> Option<u32> {
 
     // Try with kHz suffix
     if let Some(num) = s.strip_suffix('k') {
-        return num.trim().parse().ok();
+        return num
+            .trim()
+            .parse()
+            .ok()
+            .filter(|&khz| (1..=MAX_KHZ).contains(&khz));
     }
 
     // Plain number (assumed kHz)
-    s.parse().ok()
+    s.parse().ok().filter(|&khz| (1..=MAX_KHZ).contains(&khz))
+}
+
+#[cfg(test)]
+mod speed_tests {
+    use super::parse_speed_khz;
+
+    #[test]
+    fn parses_supported_speed_units() {
+        assert_eq!(parse_speed_khz("1000"), Some(1000));
+        assert_eq!(parse_speed_khz("1000K"), Some(1000));
+        assert_eq!(parse_speed_khz("30m"), Some(30_000));
+        assert_eq!(parse_speed_khz("1.5g"), Some(1_500_000));
+    }
+
+    #[test]
+    fn rejects_speeds_that_cannot_be_converted_to_hz() {
+        assert_eq!(parse_speed_khz("0"), None);
+        assert_eq!(parse_speed_khz("-5m"), None);
+        assert_eq!(parse_speed_khz("nan"), None);
+        assert_eq!(parse_speed_khz("4.294968g"), None);
+        assert_eq!(parse_speed_khz("4294968k"), None);
+        assert_eq!(parse_speed_khz("4294968"), None);
+    }
 }
 
 /// Common probe and create handle logic for SPI programmers

--- a/crates/rflasher-programmers/src/registry.rs
+++ b/crates/rflasher-programmers/src/registry.rs
@@ -95,18 +95,28 @@ fn log_probe_result(result: &ProbeResult) {
 ///
 /// Returns None if the string cannot be parsed.
 fn parse_speed_khz(s: &str) -> Option<u32> {
+    /// Convert a parsed value with the given unit multiplier to kHz,
+    /// rejecting non-finite, negative, and out-of-range results.
+    fn khz_from(val: f64, multiplier: f64) -> Option<u32> {
+        let khz = val * multiplier;
+        if !khz.is_finite() || !(0.0..=u32::MAX as f64).contains(&khz) {
+            return None;
+        }
+        Some(khz.round() as u32)
+    }
+
     let s = s.trim().to_lowercase();
 
     // Try with GHz suffix
     if let Some(num) = s.strip_suffix('g') {
         let val: f64 = num.trim().parse().ok()?;
-        return Some((val * 1_000_000.0).round() as u32);
+        return khz_from(val, 1_000_000.0);
     }
 
     // Try with MHz suffix
     if let Some(num) = s.strip_suffix('m') {
         let val: f64 = num.trim().parse().ok()?;
-        return Some((val * 1000.0).round() as u32);
+        return khz_from(val, 1000.0);
     }
 
     // Try with kHz suffix

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,10 +123,6 @@ pub enum Commands {
         #[arg(long)]
         no_verify: bool,
 
-        /// Don't erase before writing
-        #[arg(long)]
-        no_erase: bool,
-
         #[command(flatten)]
         layout: LayoutArgs,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,10 +90,6 @@ pub enum Commands {
         #[arg(short, long)]
         output: PathBuf,
 
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
-
         #[command(flatten)]
         layout: LayoutArgs,
     },
@@ -123,10 +119,6 @@ pub enum Commands {
         #[arg(short, long)]
         input: PathBuf,
 
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
-
         /// Verify after writing
         #[arg(long, default_value = "true")]
         verify: bool,
@@ -145,10 +137,6 @@ pub enum Commands {
         #[arg(short, long, help = programmer_help())]
         programmer: String,
 
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
-
         #[command(flatten)]
         layout: LayoutArgs,
     },
@@ -163,10 +151,6 @@ pub enum Commands {
         #[arg(short, long)]
         input: PathBuf,
 
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
-
         #[command(flatten)]
         layout: LayoutArgs,
     },
@@ -176,10 +160,6 @@ pub enum Commands {
         /// Programmer to use
         #[arg(short, long, help = programmer_help())]
         programmer: String,
-
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
     },
 
     /// List supported programmers
@@ -221,10 +201,6 @@ pub enum WpCommands {
         /// Programmer to use
         #[arg(short, long, help = programmer_help())]
         programmer: String,
-
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
     },
 
     /// List available protection ranges
@@ -232,10 +208,6 @@ pub enum WpCommands {
         /// Programmer to use
         #[arg(short, long, help = programmer_help())]
         programmer: String,
-
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
     },
 
     /// Enable hardware write protection
@@ -243,10 +215,6 @@ pub enum WpCommands {
         /// Programmer to use
         #[arg(short, long, help = programmer_help())]
         programmer: String,
-
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
 
         /// Make changes volatile (lost on power cycle)
         #[arg(long)]
@@ -259,10 +227,6 @@ pub enum WpCommands {
         #[arg(short, long, help = programmer_help())]
         programmer: String,
 
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
-
         /// Make changes volatile (lost on power cycle)
         #[arg(long)]
         temporary: bool,
@@ -273,10 +237,6 @@ pub enum WpCommands {
         /// Programmer to use
         #[arg(short, long, help = programmer_help())]
         programmer: String,
-
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
 
         /// Make changes volatile (lost on power cycle)
         #[arg(long)]
@@ -291,10 +251,6 @@ pub enum WpCommands {
         /// Programmer to use
         #[arg(short, long, help = programmer_help())]
         programmer: String,
-
-        /// Chip name (optional, auto-detected if not specified)
-        #[arg(short, long)]
-        chip: Option<String>,
 
         /// Make changes volatile (lost on power cycle)
         #[arg(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -119,9 +119,9 @@ pub enum Commands {
         #[arg(short, long)]
         input: PathBuf,
 
-        /// Verify after writing
-        #[arg(long, default_value = "true")]
-        verify: bool,
+        /// Skip verification after writing
+        #[arg(long)]
+        no_verify: bool,
 
         /// Don't erase before writing
         #[arg(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,10 +211,6 @@ pub enum WpCommands {
         /// Programmer to use
         #[arg(short, long, help = programmer_help())]
         programmer: String,
-
-        /// Make changes volatile (lost on power cycle)
-        #[arg(long)]
-        temporary: bool,
     },
 
     /// Disable hardware write protection
@@ -222,10 +218,6 @@ pub enum WpCommands {
         /// Programmer to use
         #[arg(short, long, help = programmer_help())]
         programmer: String,
-
-        /// Make changes volatile (lost on power cycle)
-        #[arg(long)]
-        temporary: bool,
     },
 
     /// Set protection range by address
@@ -233,10 +225,6 @@ pub enum WpCommands {
         /// Programmer to use
         #[arg(short, long, help = programmer_help())]
         programmer: String,
-
-        /// Make changes volatile (lost on power cycle)
-        #[arg(long)]
-        temporary: bool,
 
         /// Protection range as "start,length" (e.g., "0,0x100000" or "0x10000,65536")
         range: String,
@@ -247,10 +235,6 @@ pub enum WpCommands {
         /// Programmer to use
         #[arg(short, long, help = programmer_help())]
         programmer: String,
-
-        /// Make changes volatile (lost on power cycle)
-        #[arg(long)]
-        temporary: bool,
 
         #[command(flatten)]
         layout: LayoutArgs,

--- a/src/commands/unified.rs
+++ b/src/commands/unified.rs
@@ -582,14 +582,18 @@ pub fn run_verify_with_layout<D: FlashDevice + ?Sized>(
 
     // Validate region bounds against the actual chip before slicing into a
     // flash-sized buffer; a corrupt FMAP could otherwise panic on verify.
-    layout.validate(flash_size).map_err(|e| -> Box<dyn std::error::Error> {
-        match e {
-            LayoutError::RegionOutOfBounds => {
-                format!("Layout region extends beyond flash size ({} bytes)", flash_size).into()
+    layout
+        .validate(flash_size)
+        .map_err(|e| -> Box<dyn std::error::Error> {
+            match e {
+                LayoutError::RegionOutOfBounds => format!(
+                    "Layout region extends beyond flash size ({} bytes)",
+                    flash_size
+                )
+                .into(),
+                e => format!("Invalid layout: {}", e).into(),
             }
-            e => format!("Invalid layout: {}", e).into(),
-        }
-    })?;
+        })?;
 
     print_flash_size(flash_size);
 

--- a/src/commands/unified.rs
+++ b/src/commands/unified.rs
@@ -217,14 +217,18 @@ pub fn run_read_with_layout<D: FlashDevice + ?Sized>(
 
     // Validate region bounds against the actual chip before slicing into a
     // flash-sized buffer; a corrupt FMAP could otherwise panic on read.
-    layout.validate(flash_size).map_err(|e| -> Box<dyn std::error::Error> {
-        match e {
-            LayoutError::RegionOutOfBounds => {
-                format!("Layout region extends beyond flash size ({} bytes)", flash_size).into()
+    layout
+        .validate(flash_size)
+        .map_err(|e| -> Box<dyn std::error::Error> {
+            match e {
+                LayoutError::RegionOutOfBounds => format!(
+                    "Layout region extends beyond flash size ({} bytes)",
+                    flash_size
+                )
+                .into(),
+                e => format!("Invalid layout: {}", e).into(),
             }
-            e => format!("Invalid layout: {}", e).into(),
-        }
-    })?;
+        })?;
 
     print_flash_size(flash_size);
 
@@ -582,7 +586,9 @@ pub fn run_verify_with_layout<D: FlashDevice + ?Sized>(
 
     let included: Vec<_> = layout.included_regions().collect();
     if included.is_empty() {
-        return Err("No regions selected for verification. Use --include to select regions.".into());
+        return Err(
+            "No regions selected for verification. Use --include to select regions.".into(),
+        );
     }
     display_included_regions(&included, "Verifying");
 

--- a/src/commands/unified.rs
+++ b/src/commands/unified.rs
@@ -307,6 +307,22 @@ pub fn run_write_with_layout<D: FlashDevice + ?Sized>(
     do_verify: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let flash_size = device.size();
+
+    // Validate region bounds against the actual chip before constructing or
+    // slicing a flash-sized image; a corrupt layout could otherwise panic.
+    layout
+        .validate(flash_size)
+        .map_err(|e| -> Box<dyn std::error::Error> {
+            match e {
+                LayoutError::RegionOutOfBounds => format!(
+                    "Layout region extends beyond flash size ({} bytes)",
+                    flash_size
+                )
+                .into(),
+                e => format!("Invalid layout: {}", e).into(),
+            }
+        })?;
+
     print_flash_size(flash_size);
 
     // Read input file

--- a/src/commands/unified.rs
+++ b/src/commands/unified.rs
@@ -311,6 +311,9 @@ pub fn run_write_with_layout<D: FlashDevice + ?Sized>(
 
     // Read input file
     let file_data = read_file(input)?;
+    if file_data.is_empty() {
+        return Err("Input file is empty".into());
+    }
     let file_size = file_data.len();
 
     // Display included regions
@@ -598,6 +601,9 @@ pub fn run_verify_with_layout<D: FlashDevice + ?Sized>(
     print_flash_size(flash_size);
 
     let file_data = read_file(input)?;
+    if file_data.is_empty() {
+        return Err("Input file is empty".into());
+    }
     let file_size = file_data.len();
 
     let included: Vec<_> = layout.included_regions().collect();

--- a/src/commands/unified.rs
+++ b/src/commands/unified.rs
@@ -6,7 +6,7 @@
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rflasher_core::flash::unified::{WriteProgress, WriteStats};
 use rflasher_core::flash::{FlashDevice, unified};
-use rflasher_core::layout::Layout;
+use rflasher_core::layout::{Layout, LayoutError};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
@@ -214,6 +214,18 @@ pub fn run_read_with_layout<D: FlashDevice + ?Sized>(
     layout: &Layout,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let flash_size = device.size();
+
+    // Validate region bounds against the actual chip before slicing into a
+    // flash-sized buffer; a corrupt FMAP could otherwise panic on read.
+    layout.validate(flash_size).map_err(|e| -> Box<dyn std::error::Error> {
+        match e {
+            LayoutError::RegionOutOfBounds => {
+                format!("Layout region extends beyond flash size ({} bytes)", flash_size).into()
+            }
+            e => format!("Invalid layout: {}", e).into(),
+        }
+    })?;
+
     print_flash_size(flash_size);
 
     // Display included regions

--- a/src/commands/unified.rs
+++ b/src/commands/unified.rs
@@ -579,6 +579,18 @@ pub fn run_verify_with_layout<D: FlashDevice + ?Sized>(
     layout: &Layout,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let flash_size = device.size();
+
+    // Validate region bounds against the actual chip before slicing into a
+    // flash-sized buffer; a corrupt FMAP could otherwise panic on verify.
+    layout.validate(flash_size).map_err(|e| -> Box<dyn std::error::Error> {
+        match e {
+            LayoutError::RegionOutOfBounds => {
+                format!("Layout region extends beyond flash size ({} bytes)", flash_size).into()
+            }
+            e => format!("Invalid layout: {}", e).into(),
+        }
+    })?;
+
     print_flash_size(flash_size);
 
     let file_data = read_file(input)?;

--- a/src/commands/unified.rs
+++ b/src/commands/unified.rs
@@ -521,6 +521,9 @@ pub fn verify_flash<D: FlashDevice + ?Sized>(
 }
 
 /// Run the unified verify command
+///
+/// The image must match the flash size exactly; verifying a smaller file
+/// against offset 0 would be ambiguous and silently compare the wrong data.
 pub fn run_verify<D: FlashDevice + ?Sized>(
     device: &mut D,
     input: &Path,
@@ -532,9 +535,10 @@ pub fn run_verify<D: FlashDevice + ?Sized>(
     let expected = read_file(input)?;
 
     // Validate size
-    if expected.len() > flash_size as usize {
+    if expected.len() != flash_size as usize {
         return Err(format!(
-            "File size ({} bytes) exceeds flash size ({} bytes)",
+            "File size ({} bytes) does not match flash size ({} bytes). \
+             Use --layout/--ifd/--fmap with --region to verify a region.",
             expected.len(),
             flash_size
         )
@@ -542,6 +546,75 @@ pub fn run_verify<D: FlashDevice + ?Sized>(
     }
 
     verify_flash(device, &expected)?;
+    println!("Verification passed!");
+
+    Ok(())
+}
+
+/// Run the unified verify command with layout
+///
+/// Size rules mirror `run_write_with_layout`:
+/// - Multiple regions: file must be exactly flash size (full chip image).
+/// - Single region: file may be region-sized or smaller (compared against
+///   the start of the region) or exactly flash size.
+pub fn run_verify_with_layout<D: FlashDevice + ?Sized>(
+    device: &mut D,
+    input: &Path,
+    layout: &Layout,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let flash_size = device.size();
+    print_flash_size(flash_size);
+
+    let file_data = read_file(input)?;
+    let file_size = file_data.len();
+
+    let included: Vec<_> = layout.included_regions().collect();
+    if included.is_empty() {
+        return Err("No regions selected for verification. Use --include to select regions.".into());
+    }
+    display_included_regions(&included, "Verifying");
+
+    if included.len() > 1 && file_size != flash_size as usize {
+        return Err(format!(
+            "Multiple regions selected: file must be exactly flash size ({} bytes), got {} bytes",
+            flash_size, file_size
+        )
+        .into());
+    }
+
+    let (image, effective_layout) = if file_size == flash_size as usize {
+        (file_data, layout.clone())
+    } else {
+        // Single region with a region-sized (or smaller) file
+        let region = &included[0];
+        let region_size = region.size() as usize;
+        if file_size > region_size {
+            return Err(format!(
+                "File size ({} bytes) larger than region '{}' ({} bytes) but smaller than flash size",
+                file_size, region.name, region_size
+            )
+            .into());
+        }
+
+        if file_size < region_size {
+            println!(
+                "Note: File ({} bytes) is smaller than region ({} bytes)",
+                file_size, region_size
+            );
+        }
+
+        let mut chip_image = vec![0xFFu8; flash_size as usize];
+        let dest_start = region.start as usize;
+        chip_image[dest_start..dest_start + file_size].copy_from_slice(&file_data);
+
+        // Only verify the portion covered by the file
+        let mut modified_layout = layout.clone();
+        modified_layout.update_region_end(&region.name, region.start + file_size as u32 - 1)?;
+
+        (chip_image, modified_layout)
+    };
+
+    verify_by_layout(device, &effective_layout, &image)?;
     println!("Verification passed!");
 
     Ok(())

--- a/src/commands/unified.rs
+++ b/src/commands/unified.rs
@@ -638,6 +638,14 @@ pub fn run_verify_with_layout<D: FlashDevice + ?Sized>(
         .into());
     }
 
+    if file_size > flash_size as usize {
+        return Err(format!(
+            "File size ({} bytes) exceeds flash size ({} bytes)",
+            file_size, flash_size
+        )
+        .into());
+    }
+
     let (image, effective_layout) = if file_size == flash_size as usize {
         (file_data, layout.clone())
     } else {

--- a/src/commands/wp.rs
+++ b/src/commands/wp.rs
@@ -136,64 +136,40 @@ pub fn cmd_list(handle: &mut FlashHandle) -> Result<(), Box<dyn Error>> {
 }
 
 /// Enable hardware write protection
-pub fn cmd_enable(handle: &mut FlashHandle, temporary: bool) -> Result<(), Box<dyn Error>> {
+pub fn cmd_enable(handle: &mut FlashHandle) -> Result<(), Box<dyn Error>> {
     if !handle.wp_supported() {
         return Err("Write protection operations are not supported for this chip".into());
     }
 
-    let options = WriteOptions {
-        volatile: temporary,
-        ..Default::default()
-    };
-
     handle
-        .set_wp_mode(WpMode::Hardware, options)
+        .set_wp_mode(WpMode::Hardware, WriteOptions::default())
         .map_err(|e| format!("Failed to enable write protection: {}", e))?;
 
-    println!(
-        "Hardware write protection enabled{}.",
-        if temporary { " (temporary)" } else { "" }
-    );
+    println!("Hardware write protection enabled.");
     Ok(())
 }
 
 /// Disable write protection
-pub fn cmd_disable(handle: &mut FlashHandle, temporary: bool) -> Result<(), Box<dyn Error>> {
+pub fn cmd_disable(handle: &mut FlashHandle) -> Result<(), Box<dyn Error>> {
     if !handle.wp_supported() {
         return Err("Write protection operations are not supported for this chip".into());
     }
 
-    let options = WriteOptions {
-        volatile: temporary,
-        ..Default::default()
-    };
-
     handle
-        .disable_wp(options)
+        .disable_wp(WriteOptions::default())
         .map_err(|e| format!("Failed to disable write protection: {}", e))?;
 
-    println!(
-        "Write protection disabled{}.",
-        if temporary { " (temporary)" } else { "" }
-    );
+    println!("Write protection disabled.");
     Ok(())
 }
 
 /// Set protection range
-pub fn cmd_range(
-    handle: &mut FlashHandle,
-    range_spec: &str,
-    temporary: bool,
-) -> Result<(), Box<dyn Error>> {
+pub fn cmd_range(handle: &mut FlashHandle, range_spec: &str) -> Result<(), Box<dyn Error>> {
     if !handle.wp_supported() {
         return Err("Write protection operations are not supported for this chip".into());
     }
 
     let range = parse_range(range_spec)?;
-    let options = WriteOptions {
-        volatile: temporary,
-        ..Default::default()
-    };
     let total_size = handle.size();
 
     // Validate range doesn't exceed chip size
@@ -206,15 +182,14 @@ pub fn cmd_range(
     }
 
     handle
-        .set_wp_range(&range, options)
+        .set_wp_range(&range, WriteOptions::default())
         .map_err(|e| format!("Failed to set protection range: {}", e))?;
 
     println!(
-        "Protection range set to start=0x{:08x} length=0x{:08x} ({}){}.",
+        "Protection range set to start=0x{:08x} length=0x{:08x} ({}).",
         range.start,
         range.len,
-        format_range(&range, total_size),
-        if temporary { " (temporary)" } else { "" }
+        format_range(&range, total_size)
     );
     Ok(())
 }
@@ -224,7 +199,6 @@ pub fn cmd_region(
     handle: &mut FlashHandle,
     layout: &rflasher_core::layout::Layout,
     region_name: &str,
-    temporary: bool,
 ) -> Result<(), Box<dyn Error>> {
     if !handle.wp_supported() {
         return Err("Write protection operations are not supported for this chip".into());
@@ -238,26 +212,23 @@ pub fn cmd_region(
         .ok_or_else(|| format!("Region '{}' not found in layout", region_name))?;
 
     let range = WpRange::new(region.start, region.end - region.start + 1);
-    let options = WriteOptions {
-        volatile: temporary,
-        ..Default::default()
-    };
     let total_size = handle.size();
 
-    handle.set_wp_range(&range, options).map_err(|e| {
-        format!(
-            "Failed to set protection range for region '{}': {}",
-            region_name, e
-        )
-    })?;
+    handle
+        .set_wp_range(&range, WriteOptions::default())
+        .map_err(|e| {
+            format!(
+                "Failed to set protection range for region '{}': {}",
+                region_name, e
+            )
+        })?;
 
     println!(
-        "Protection set for region '{}': start=0x{:08x} length=0x{:08x} ({}){}.",
+        "Protection set for region '{}': start=0x{:08x} length=0x{:08x} ({}).",
         region_name,
         range.start,
         range.len,
-        format_range(&range, total_size),
-        if temporary { " (temporary)" } else { "" }
+        format_range(&range, total_size)
     );
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,6 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Commands::Read {
             programmer,
             output,
-            chip: _,
             layout,
         } => {
             let mut handle = open_flash(&programmer, &db)?;
@@ -78,7 +77,6 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Commands::Write {
             programmer,
             input,
-            chip: _,
             verify,
             no_erase: _,
             layout,
@@ -99,7 +97,6 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::Erase {
             programmer,
-            chip: _,
             layout,
         } => {
             let mut handle = open_flash(&programmer, &db)?;
@@ -114,7 +111,6 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Commands::Verify {
             programmer,
             input,
-            chip: _,
             layout: _,
         } => {
             let mut handle = open_flash(&programmer, &db)?;
@@ -122,7 +118,6 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::Info {
             programmer,
-            chip: _,
         } => {
             let mut handle = open_flash(&programmer, &db)?;
             print_chip_info(&mut handle);
@@ -152,38 +147,33 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Commands::Wp(subcmd) => match subcmd {
             WpCommands::Status {
                 programmer,
-                chip: _,
-            } => {
+                } => {
                 let mut handle = open_flash(&programmer, &db)?;
                 commands::wp::cmd_status(&mut handle)
             }
             WpCommands::List {
                 programmer,
-                chip: _,
-            } => {
+                } => {
                 let mut handle = open_flash(&programmer, &db)?;
                 commands::wp::cmd_list(&mut handle)
             }
             WpCommands::Enable {
                 programmer,
-                chip: _,
-                temporary,
+                    temporary,
             } => {
                 let mut handle = open_flash(&programmer, &db)?;
                 commands::wp::cmd_enable(&mut handle, temporary)
             }
             WpCommands::Disable {
                 programmer,
-                chip: _,
-                temporary,
+                    temporary,
             } => {
                 let mut handle = open_flash(&programmer, &db)?;
                 commands::wp::cmd_disable(&mut handle, temporary)
             }
             WpCommands::Range {
                 programmer,
-                chip: _,
-                temporary,
+                    temporary,
                 range,
             } => {
                 let mut handle = open_flash(&programmer, &db)?;
@@ -191,8 +181,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             }
             WpCommands::Region {
                 programmer,
-                chip: _,
-                temporary,
+                    temporary,
                 layout,
                 region_name,
             } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,8 +77,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Commands::Write {
             programmer,
             input,
-            verify,
-            no_erase: _,
+            no_verify,
             layout,
         } => {
             let mut handle = open_flash(&programmer, &db)?;
@@ -89,10 +88,10 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     handle.as_device_mut(),
                     &input,
                     &mut layout_obj,
-                    verify,
+                    !no_verify,
                 )
             } else {
-                commands::unified::run_write(handle.as_device_mut(), &input, verify)
+                commands::unified::run_write(handle.as_device_mut(), &input, !no_verify)
             }
         }
         Commands::Erase {

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,37 +157,26 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 let mut handle = open_flash(&programmer, &db)?;
                 commands::wp::cmd_list(&mut handle)
             }
-            WpCommands::Enable {
-                programmer,
-                temporary,
-            } => {
+            WpCommands::Enable { programmer } => {
                 let mut handle = open_flash(&programmer, &db)?;
-                commands::wp::cmd_enable(&mut handle, temporary)
+                commands::wp::cmd_enable(&mut handle)
             }
-            WpCommands::Disable {
-                programmer,
-                temporary,
-            } => {
+            WpCommands::Disable { programmer } => {
                 let mut handle = open_flash(&programmer, &db)?;
-                commands::wp::cmd_disable(&mut handle, temporary)
+                commands::wp::cmd_disable(&mut handle)
             }
-            WpCommands::Range {
-                programmer,
-                temporary,
-                range,
-            } => {
+            WpCommands::Range { programmer, range } => {
                 let mut handle = open_flash(&programmer, &db)?;
-                commands::wp::cmd_range(&mut handle, &range, temporary)
+                commands::wp::cmd_range(&mut handle, &range)
             }
             WpCommands::Region {
                 programmer,
-                temporary,
                 layout,
                 region_name,
             } => {
                 let mut handle = open_flash(&programmer, &db)?;
                 let layout_obj = load_layout(&mut handle, &layout)?;
-                commands::wp::cmd_region(&mut handle, &layout_obj, &region_name, temporary)
+                commands::wp::cmd_region(&mut handle, &layout_obj, &region_name)
             }
         },
         #[cfg(feature = "repl")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,10 +110,16 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Commands::Verify {
             programmer,
             input,
-            layout: _,
+            layout,
         } => {
             let mut handle = open_flash(&programmer, &db)?;
-            commands::unified::run_verify(handle.as_device_mut(), &input)
+            if layout.has_layout_source() || layout.has_region_filter() {
+                let mut layout_obj = load_layout(&mut handle, &layout)?;
+                apply_region_filters(&mut layout_obj, &layout)?;
+                commands::unified::run_verify_with_layout(handle.as_device_mut(), &input, &layout_obj)
+            } else {
+                commands::unified::run_verify(handle.as_device_mut(), &input)
+            }
         }
         Commands::Info {
             programmer,

--- a/src/main.rs
+++ b/src/main.rs
@@ -352,8 +352,9 @@ fn print_chip_info(handle: &mut FlashHandle) {
             println!("SFDP:            Not detected");
         }
 
-        // Show detailed chip info if available
-        if let Some(chip) = &info.chip {
+        // Detailed chip information
+        {
+            let chip = &info.chip;
             println!();
             println!(
                 "Voltage range:   {:.1}V - {:.1}V",

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,10 +94,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 commands::unified::run_write(handle.as_device_mut(), &input, !no_verify)
             }
         }
-        Commands::Erase {
-            programmer,
-            layout,
-        } => {
+        Commands::Erase { programmer, layout } => {
             let mut handle = open_flash(&programmer, &db)?;
             if layout.has_layout_source() || layout.has_region_filter() {
                 let mut layout_obj = load_layout(&mut handle, &layout)?;
@@ -116,14 +113,16 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             if layout.has_layout_source() || layout.has_region_filter() {
                 let mut layout_obj = load_layout(&mut handle, &layout)?;
                 apply_region_filters(&mut layout_obj, &layout)?;
-                commands::unified::run_verify_with_layout(handle.as_device_mut(), &input, &layout_obj)
+                commands::unified::run_verify_with_layout(
+                    handle.as_device_mut(),
+                    &input,
+                    &layout_obj,
+                )
             } else {
                 commands::unified::run_verify(handle.as_device_mut(), &input)
             }
         }
-        Commands::Info {
-            programmer,
-        } => {
+        Commands::Info { programmer } => {
             let mut handle = open_flash(&programmer, &db)?;
             print_chip_info(&mut handle);
             Ok(())
@@ -150,35 +149,31 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             LayoutCommands::Create { output, size } => commands::layout::cmd_create(&output, &size),
         },
         Commands::Wp(subcmd) => match subcmd {
-            WpCommands::Status {
-                programmer,
-                } => {
+            WpCommands::Status { programmer } => {
                 let mut handle = open_flash(&programmer, &db)?;
                 commands::wp::cmd_status(&mut handle)
             }
-            WpCommands::List {
-                programmer,
-                } => {
+            WpCommands::List { programmer } => {
                 let mut handle = open_flash(&programmer, &db)?;
                 commands::wp::cmd_list(&mut handle)
             }
             WpCommands::Enable {
                 programmer,
-                    temporary,
+                temporary,
             } => {
                 let mut handle = open_flash(&programmer, &db)?;
                 commands::wp::cmd_enable(&mut handle, temporary)
             }
             WpCommands::Disable {
                 programmer,
-                    temporary,
+                temporary,
             } => {
                 let mut handle = open_flash(&programmer, &db)?;
                 commands::wp::cmd_disable(&mut handle, temporary)
             }
             WpCommands::Range {
                 programmer,
-                    temporary,
+                temporary,
                 range,
             } => {
                 let mut handle = open_flash(&programmer, &db)?;
@@ -186,7 +181,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             }
             WpCommands::Region {
                 programmer,
-                    temporary,
+                temporary,
                 layout,
                 region_name,
             } => {


### PR DESCRIPTION
## Problem

Several CLI flags were accepted but silently ignored, which is dangerous for a flash tool:

- `--no-erase` was advertised as forbidding erasure while writes erased anyway
- `--chip` was accepted on every chip-touching subcommand and read nowhere
- write-protection `--temporary` claimed volatile changes while the core ignored it and performed persistent writes
- `verify` accepted all layout flags (`--ifd`, `--fmap`, `--layout`, `--include`, ...) but verified the whole chip regardless; a region-sized file was even compared against address 0, reporting spurious mismatches
- post-write verification was forced on with no way to disable it

Alongside that, an adversarial review of the core turned up real bugs: the FMAP read path could panic on a corrupt flash descriptor (unvalidated regions slicing past the buffer, unchecked u32 arithmetic from untrusted fields), the FMAP binary-search fast path could never match any valid FMAP so every on-chip search silently read the entire flash, and duplicated read/write implementations had drifted apart so that SST25 AAI chips would be page-programmed incorrectly through one of the two paths.

## Solution

- Remove `--no-erase`, `--chip`, and write-protection `--temporary` rather than pretend to support them; replace the always-on `--verify` with an opt-out `--no-verify`
- Wire layout flags into verify with the same file-size semantics as write, and require exact-size images for the layout-less path
- Validate layouts against the flash size before read, write, or verify operations; reject FMAP areas whose ranges overflow u32
- Fix FMAP binary search to match on signature and size the header read from the declared area count, falling back to the linear scan only for false positives
- Make `operations::{read,write}` the single canonical implementation (AAI word program, byte-granularity handling) and have `SpiFlashDevice` delegate to it
- Bring the hybrid erase fallback up to par with the SPI device (SST26 unprotect, post-erase verification, logged cleanup) via a shared `check_erased_range` helper, with verification performed only after persistent 4-byte mode is exited
- Smaller fixes: exact mismatch addresses in verify errors, consistent dummy-byte accounting, non-optional `ChipInfo::chip`, documented WP volatile limitation, PhysMap unmap simplification, and speed parsing that supports GHz without overflowing the downstream Hz conversion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added layout-aware verification for full-chip, region-sized, and partial images.
  - Added support for GHz speed values and improved speed conversion.
  - Improved byte- and word-level flash programming support.

- **Bug Fixes**
  - Improved erase verification and recovery.
  - Verification errors now identify the exact mismatching byte.
  - Added safeguards for invalid layouts, empty inputs, and out-of-bounds reads.
  - Improved flash layout parsing and SPI command sizing.

- **CLI Changes**
  - Removed chip-name and temporary write-protection options.
  - Replaced write verification options with `--no-verify`.

- **Documentation**
  - Updated write-protection behavior and command examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

