### PR TITLE
cli: streamline file arguments and add per-region files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ thiserror = "2"
 env_logger = "0.11"
 tokio = { version = "1", features = ["full"] }
 nusb = "0.2.6"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 indicatif = "0.17"
 

--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ rflasher probe -p ch341a
 rflasher info -p ch341a
 
 # Read flash to a file
-rflasher read -p ch341a -o flash_backup.bin
+rflasher read -p ch341a flash_backup.bin
 
 # Write a file to flash (with automatic erase and verify)
-rflasher write -p ch341a -i firmware.bin
+rflasher write -p ch341a firmware.bin
 
 # Erase entire chip
 rflasher erase -p ch341a
@@ -189,19 +189,23 @@ rflasher erase -p ch341a
 
 ```bash
 # Read entire flash chip
-rflasher read -p ch341a -o backup.bin
+rflasher read -p ch341a backup.bin
 
 # Write and verify (default behavior)
-rflasher write -p ch341a -i firmware.bin
+rflasher write -p ch341a firmware.bin
 
 # Write without verification (faster, but risky)
-rflasher write -p ch341a -i firmware.bin --no-verify
+rflasher write -p ch341a firmware.bin --no-verify
+
+# Short aliases (r/w/v, and E for erase) and the RFLASHER_PROGRAMMER env var also work
+export RFLASHER_PROGRAMMER=ch341a
+rflasher r backup.bin
 
 # Verify flash contents against a file
-rflasher verify -p ch341a -i firmware.bin
+rflasher verify -p ch341a firmware.bin
 
-# Erase specific region (64 KiB starting at 0x10000)
-rflasher erase -p ch341a --start 0x10000 --length 0x10000
+# Erase only a specific layout region
+rflasher erase -p ch341a --ifd -r bios
 ```
 
 ### Programmer-Specific Options
@@ -244,13 +248,13 @@ rflasher probe -p linux_spi:dev=/dev/spidev0.0,spispeed=4000
 rflasher probe -p linux_gpio_spi:gpiochip=0,cs=25,sck=11,mosi=10,miso=9
 
 # Linux GPIO with custom speed
-rflasher read -p linux_gpio_spi:dev=/dev/gpiochip0,cs=25,sck=11,mosi=10,miso=9,spispeed=500 -o flash.bin
+rflasher read -p linux_gpio_spi:dev=/dev/gpiochip0,cs=25,sck=11,mosi=10,miso=9,spispeed=500 flash.bin
 
 # Linux MTD device
 rflasher probe -p linux_mtd:dev=0
 
 # Linux MTD - read from device 0
-rflasher read -p linux_mtd:dev=0 -o flash_backup.bin
+rflasher read -p linux_mtd:dev=0 flash_backup.bin
 ```
 
 ### Internal Programmer and Embedded Reuse
@@ -276,24 +280,32 @@ Firmware code can pass its own PCI scan results to `find_intel_chipset_in_device
 
 Flash layouts allow you to work with specific regions of the flash chip (e.g., BIOS, ME, GbE regions on Intel systems).
 
+`--region`/`--include` accept `NAME[:FILE]`. With a `FILE`, each region reads to / writes from its own file instead of a full chip image; the positional file can then be omitted. Per-region files must not exceed their region's size, and a smaller file covers only the start of the region. When a positional file is combined with per-region files, it must be a full chip image and supplies the data for regions without their own file.
+
 ```bash
 # Extract Intel Flash Descriptor from a flash image
-rflasher layout ifd -i flash.bin -o layout.toml
+rflasher layout ifd flash.bin -o layout.toml
 
 # Extract FMAP from a Chromebook flash image
-rflasher layout fmap -i chromebook.bin -o layout.toml
+rflasher layout fmap chromebook.bin -o layout.toml
 
 # Show layout from a file
-rflasher layout show -f layout.toml
+rflasher layout show layout.toml
 
 # Create a new layout template
-rflasher layout create -o custom.toml --size "16 MiB"
+rflasher layout create custom.toml --size "16 MiB"
 
-# Read only the BIOS region (using IFD from chip)
-rflasher read -p ch341a --ifd --region bios -o bios.bin
+# Read only the BIOS region into its own file (using IFD from chip)
+rflasher read -p ch341a --ifd -r bios:bios.bin
 
-# Write to a specific region from a layout file
-rflasher write -p ch341a --layout layout.toml --region bios -i bios_update.bin
+# Read several regions, each to its own file
+rflasher read -p ch341a --ifd --include bios:bios.bin,me:me.bin
+
+# Write a region from its own file (per-region NAME:FILE)
+rflasher write -p ch341a --layout layout.toml -r bios:bios_update.bin
+
+# Read/write a region out of a full chip image instead
+rflasher write -p ch341a --ifd -r bios full_image.bin
 
 # Erase multiple regions
 rflasher erase -p ch341a --ifd --include bios,descriptor

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,16 @@ pub struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     pub verbose: u8,
 
+    /// Programmer to use
+    #[arg(
+        short,
+        long,
+        global = true,
+        env = "RFLASHER_PROGRAMMER",
+        help = programmer_help()
+    )]
+    pub programmer: Option<String>,
+
     /// Path to chip database directory (contains .ron files)
     /// Defaults to the bundled development database and system data directories.
     #[arg(long, global = true)]
@@ -29,11 +39,41 @@ pub struct Cli {
     pub command: Commands,
 }
 
+/// A region selector, optionally paired with a per-region file
+/// (`name` or `name:file`).
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // gen-manpage includes this module but never reads the fields
+pub struct RegionSpec {
+    pub name: String,
+    pub file: Option<PathBuf>,
+}
+
+impl std::str::FromStr for RegionSpec {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (name, file) = match s.split_once(':') {
+            Some((name, file)) => (name, Some(PathBuf::from(file))),
+            None => (s, None),
+        };
+        if name.is_empty() {
+            return Err(format!("Empty region name in '{}'", s));
+        }
+        if file.as_ref().is_some_and(|f| f.as_os_str().is_empty()) {
+            return Err(format!("Empty file path in '{}'", s));
+        }
+        Ok(RegionSpec {
+            name: name.to_string(),
+            file,
+        })
+    }
+}
+
 /// Layout options shared across commands
 #[derive(clap::Args, Debug, Clone, Default)]
 pub struct LayoutArgs {
     /// Layout file (TOML format)
-    #[arg(long, conflicts_with_all = ["ifd", "fmap"])]
+    #[arg(short, long, conflicts_with_all = ["ifd", "fmap"])]
     pub layout: Option<PathBuf>,
 
     /// Read layout from Intel Flash Descriptor (IFD) in flash
@@ -44,17 +84,18 @@ pub struct LayoutArgs {
     #[arg(long, conflicts_with_all = ["layout", "ifd"])]
     pub fmap: bool,
 
-    /// Include only these regions (comma-separated, requires layout)
-    #[arg(long, value_delimiter = ',')]
-    pub include: Vec<String>,
+    /// Include only these regions (comma-separated NAME[:FILE], requires layout)
+    #[arg(long, value_delimiter = ',', value_name = "NAME[:FILE]")]
+    pub include: Vec<RegionSpec>,
 
     /// Exclude these regions (comma-separated, requires layout)
     #[arg(long, value_delimiter = ',')]
     pub exclude: Vec<String>,
 
-    /// Operate on a single region (shorthand for --include with one region)
-    #[arg(long)]
-    pub region: Option<String>,
+    /// Operate on a single region, optionally with its own file
+    /// (shorthand for --include with one region)
+    #[arg(short, long, value_name = "NAME[:FILE]")]
+    pub region: Option<RegionSpec>,
 }
 
 impl LayoutArgs {
@@ -74,21 +115,18 @@ impl LayoutArgs {
 #[derive(Subcommand)]
 pub enum Commands {
     /// Probe for flash chip
-    Probe {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-    },
+    Probe,
 
     /// Read flash contents to file
+    ///
+    /// Reads the whole chip (or the selected regions) into FILE. With
+    /// --region/--include NAME:FILE, each named region is additionally
+    /// written to its own file; FILE may then be omitted.
+    #[command(visible_alias = "r")]
     Read {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-
-        /// Output file path (or directory if using --layout with multiple regions)
-        #[arg(short, long)]
-        output: PathBuf,
+        /// Output file for the (0xFF-padded) full image. Optional when every
+        /// selected region has its own NAME:FILE.
+        file: Option<PathBuf>,
 
         #[command(flatten)]
         layout: LayoutArgs,
@@ -96,31 +134,35 @@ pub enum Commands {
 
     /// Write file to flash
     ///
-    /// When writing with a layout (--ifd, --fmap, or --layout), the input file
-    /// is interpreted based on its size:
+    /// When writing with a layout (--ifd, --fmap, or --layout), region data
+    /// can come from per-region files (--region/--include NAME:FILE) and/or
+    /// from FILE:
     ///
-    /// - Multiple regions: File must be full chip size. Data is extracted from
-    ///   the file at each region's offset.
+    /// - Per-region files: each file is written starting at its region's base
+    ///   address and must not exceed the region size. FILE may be omitted if
+    ///   every selected region has its own file; if FILE is also given it must
+    ///   be a full chip image providing data for the remaining regions.
     ///
-    /// - Single region with file == chip size: Full chip image, region data
-    ///   extracted from file at region offset.
+    /// - FILE only, multiple regions: FILE must be full chip size. Data is
+    ///   extracted from the file at each region's offset.
     ///
-    /// - Single region with file <= region size: Region file, written starting
-    ///   at the region's base address. If smaller than the region, only that
-    ///   portion is written.
+    /// - FILE only, single region with file == chip size: full chip image,
+    ///   region data extracted from file at region offset.
     ///
-    /// - Single region with region size < file < chip size: Error (ambiguous).
+    /// - FILE only, single region with file <= region size: region file,
+    ///   written starting at the region's base address. If smaller than the
+    ///   region, only that portion is written.
+    ///
+    /// - FILE only, single region with region size < file < chip size:
+    ///   Error (ambiguous).
+    #[command(visible_alias = "w")]
     Write {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-
-        /// Input file path (see command help for size requirements with layouts)
-        #[arg(short, long)]
-        input: PathBuf,
+        /// Input file (see command help for size requirements with layouts).
+        /// Optional when every selected region has its own NAME:FILE.
+        file: Option<PathBuf>,
 
         /// Skip verification after writing
-        #[arg(long)]
+        #[arg(short, long)]
         no_verify: bool,
 
         #[command(flatten)]
@@ -128,40 +170,35 @@ pub enum Commands {
     },
 
     /// Erase flash chip
+    #[command(visible_alias = "E")]
     Erase {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-
         #[command(flatten)]
         layout: LayoutArgs,
     },
 
     /// Verify flash contents against file
+    ///
+    /// Size rules mirror `write`, including per-region files via
+    /// --region/--include NAME:FILE.
+    #[command(visible_alias = "v")]
     Verify {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-
-        /// Input file path to verify against
-        #[arg(short, long)]
-        input: PathBuf,
+        /// Input file to verify against. Optional when every selected region
+        /// has its own NAME:FILE.
+        file: Option<PathBuf>,
 
         #[command(flatten)]
         layout: LayoutArgs,
     },
 
     /// Show chip information
-    Info {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-    },
+    Info,
 
     /// List supported programmers
+    #[command(visible_alias = "programmers")]
     ListProgrammers,
 
     /// List supported chips
+    #[command(visible_alias = "chips")]
     ListChips {
         /// Filter by vendor
         #[arg(long)]
@@ -179,10 +216,6 @@ pub enum Commands {
     /// Start Scheme REPL for scripting SPI commands
     #[cfg(feature = "repl")]
     Repl {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-
         /// Script file to run instead of interactive REPL
         #[arg(short, long)]
         script: Option<std::path::PathBuf>,
@@ -193,49 +226,25 @@ pub enum Commands {
 #[derive(Subcommand)]
 pub enum WpCommands {
     /// Show current write protection status (default if no subcommand specified)
-    Status {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-    },
+    Status,
 
     /// List available protection ranges
-    List {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-    },
+    List,
 
     /// Enable hardware write protection
-    Enable {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-    },
+    Enable,
 
     /// Disable hardware write protection
-    Disable {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-    },
+    Disable,
 
     /// Set protection range by address
     Range {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-
         /// Protection range as "start,length" (e.g., "0,0x100000" or "0x10000,65536")
         range: String,
     },
 
     /// Set protection range by region name (requires layout)
     Region {
-        /// Programmer to use
-        #[arg(short, long, help = programmer_help())]
-        programmer: String,
-
         #[command(flatten)]
         layout: LayoutArgs,
 
@@ -250,14 +259,12 @@ pub enum LayoutCommands {
     /// Show layout from a file
     Show {
         /// Layout file (TOML format)
-        #[arg(short, long)]
         file: PathBuf,
     },
 
     /// Extract layout from flash image (IFD or FMAP)
     Extract {
         /// Input file (flash image)
-        #[arg(short, long)]
         input: PathBuf,
 
         /// Output layout file (TOML format)
@@ -268,7 +275,6 @@ pub enum LayoutCommands {
     /// Extract Intel Flash Descriptor layout from image
     Ifd {
         /// Input file (flash image)
-        #[arg(short, long)]
         input: PathBuf,
 
         /// Output layout file (TOML format, optional - prints to stdout if not specified)
@@ -279,7 +285,6 @@ pub enum LayoutCommands {
     /// Extract FMAP layout from image
     Fmap {
         /// Input file (flash image)
-        #[arg(short, long)]
         input: PathBuf,
 
         /// Output layout file (TOML format, optional - prints to stdout if not specified)
@@ -290,7 +295,6 @@ pub enum LayoutCommands {
     /// Create a new layout file template
     Create {
         /// Output layout file
-        #[arg(short, long)]
         output: PathBuf,
 
         /// Chip size (e.g., "16 MiB", "0x1000000")

--- a/src/commands/unified.rs
+++ b/src/commands/unified.rs
@@ -7,9 +7,13 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rflasher_core::flash::unified::{WriteProgress, WriteStats};
 use rflasher_core::flash::{FlashDevice, unified};
 use rflasher_core::layout::{Layout, LayoutError};
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// Per-region file assignments: (region name, file path)
+pub type RegionFiles = [(String, PathBuf)];
 use std::time::Duration;
 
 // =============================================================================
@@ -75,6 +79,223 @@ fn display_included_regions(included: &[&rflasher_core::layout::Region], action:
             region.size()
         );
     });
+}
+
+/// Validate a layout against the flash size with a friendly error message
+fn validate_layout(layout: &Layout, flash_size: u32) -> Result<(), Box<dyn std::error::Error>> {
+    layout.validate(flash_size).map_err(|e| match e {
+        LayoutError::RegionOutOfBounds => format!(
+            "Layout region extends beyond flash size ({} bytes)",
+            flash_size
+        )
+        .into(),
+        e => format!("Invalid layout: {}", e).into(),
+    })
+}
+
+/// Validate per-region file assignments against the final filtered layout.
+pub(crate) fn validate_region_files(
+    layout: &Layout,
+    region_files: &RegionFiles,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut seen = HashSet::new();
+
+    for (name, _) in region_files {
+        if !seen.insert(name.as_str()) {
+            return Err(format!("Region '{}' was given more than one file", name).into());
+        }
+
+        let region = layout
+            .find_region(name)
+            .ok_or_else(|| format!("Region '{}' not found in layout", name))?;
+        if !region.included {
+            return Err(format!("Region '{}' has a file assignment but is excluded", name).into());
+        }
+    }
+
+    Ok(())
+}
+
+/// Ensure every included region has a per-region file assigned.
+///
+/// Used when no whole-image file was given, so regions without their own
+/// file would have no data source (write/verify) or destination (read).
+fn require_full_region_file_coverage(
+    included: &[&rflasher_core::layout::Region],
+    region_files: &RegionFiles,
+    what: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let missing: Vec<_> = included
+        .iter()
+        .filter(|r| !region_files.iter().any(|(name, _)| *name == r.name))
+        .map(|r| r.name.as_str())
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "No {} file given and no NAME:FILE for region(s): {}",
+            what,
+            missing.join(", ")
+        )
+        .into())
+    }
+}
+
+/// Overlay per-region files onto a full-chip image.
+///
+/// Each file is copied to its region's base address and must not exceed the
+/// region size. Returns an adjusted layout where regions covered by a file
+/// smaller than the region are shrunk to the file's extent.
+fn apply_region_files(
+    layout: &Layout,
+    image: &mut [u8],
+    region_files: &RegionFiles,
+) -> Result<Layout, Box<dyn std::error::Error>> {
+    validate_region_files(layout, region_files)?;
+
+    let mut effective = layout.clone();
+
+    for (name, path) in region_files {
+        let region = layout
+            .find_region(name)
+            .ok_or_else(|| format!("Region '{}' not found in layout", name))?;
+        let data = read_file(path)?;
+        if data.is_empty() {
+            return Err(format!("Region file {:?} is empty", path).into());
+        }
+
+        let region_size = region.size() as usize;
+        if data.len() > region_size {
+            return Err(format!(
+                "File {:?} ({} bytes) larger than region '{}' ({} bytes)",
+                path,
+                data.len(),
+                name,
+                region_size
+            )
+            .into());
+        }
+
+        let start = region.start as usize;
+        image[start..start + data.len()].copy_from_slice(&data);
+
+        if data.len() < region_size {
+            println!(
+                "Note: File {:?} ({} bytes) is smaller than region '{}' ({} bytes)",
+                path,
+                data.len(),
+                name,
+                region_size
+            );
+            effective.update_region_end(name, region.start + data.len() as u32 - 1)?;
+        }
+    }
+
+    Ok(effective)
+}
+
+/// Build the full-chip image to write/verify from an optional whole-image
+/// file plus per-region files.
+///
+/// Returns the image, the effective layout (regions shrunk to partial file
+/// extents), and the effective number of bytes covered.
+fn build_image(
+    input: Option<&Path>,
+    layout: &Layout,
+    region_files: &RegionFiles,
+    included: &[&rflasher_core::layout::Region],
+    flash_size: u32,
+) -> Result<(Vec<u8>, Layout, usize), Box<dyn std::error::Error>> {
+    if !region_files.is_empty() {
+        // Per-region files, optionally on top of a full chip image
+        let mut image = match input {
+            Some(path) => {
+                let data = read_file(path)?;
+                if data.len() != flash_size as usize {
+                    return Err(format!(
+                        "With per-region files, FILE must be a full chip image ({} bytes), got {} bytes",
+                        flash_size,
+                        data.len()
+                    )
+                    .into());
+                }
+                data
+            }
+            None => {
+                require_full_region_file_coverage(included, region_files, "input")?;
+                vec![0xFFu8; flash_size as usize]
+            }
+        };
+
+        let effective_layout = apply_region_files(layout, &mut image, region_files)?;
+        let covered = effective_layout
+            .included_regions()
+            .map(|r| r.size() as usize)
+            .sum();
+        return Ok((image, effective_layout, covered));
+    }
+
+    // Single whole-image file; interpretation depends on its size
+    let input = input.ok_or("Input file required (no per-region NAME:FILE given)")?;
+    let file_data = read_file(input)?;
+    if file_data.is_empty() {
+        return Err("Input file is empty".into());
+    }
+    let file_size = file_data.len();
+
+    if file_size > flash_size as usize {
+        return Err(format!(
+            "File size ({} bytes) exceeds flash size ({} bytes)",
+            file_size, flash_size
+        )
+        .into());
+    }
+
+    if included.len() > 1 && file_size != flash_size as usize {
+        return Err(format!(
+            "Multiple regions selected: file must be exactly flash size ({} bytes), got {} bytes",
+            flash_size, file_size
+        )
+        .into());
+    }
+
+    if file_size == flash_size as usize {
+        // Full flash image
+        let covered = included.iter().map(|r| r.size() as usize).sum();
+        return Ok((file_data, layout.clone(), covered));
+    }
+
+    // Single region, file <= region size
+    let region = &included[0];
+    let region_size = region.size() as usize;
+
+    if file_size > region_size {
+        return Err(format!(
+            "File size ({} bytes) larger than region '{}' ({} bytes) but smaller than flash size",
+            file_size, region.name, region_size
+        )
+        .into());
+    }
+
+    let mut chip_image = vec![0xFFu8; flash_size as usize];
+    let dest_start = region.start as usize;
+    chip_image[dest_start..dest_start + file_size].copy_from_slice(&file_data);
+
+    // Shrink the region to the portion covered by the file
+    let effective_layout = if file_size < region_size {
+        println!(
+            "Note: File ({} bytes) is smaller than region ({} bytes)",
+            file_size, region_size
+        );
+        let mut modified_layout = layout.clone();
+        modified_layout.update_region_end(&region.name, region.start + file_size as u32 - 1)?;
+        modified_layout
+    } else {
+        layout.clone()
+    };
+
+    Ok((chip_image, effective_layout, file_size))
 }
 
 /// Create a layout covering the entire flash
@@ -204,31 +425,26 @@ pub fn run_read<D: FlashDevice + ?Sized>(
     output: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let layout = full_flash_layout(device.size());
-    run_read_with_layout(device, output, &layout)
+    run_read_with_layout(device, Some(output), &layout, &[])
 }
 
 /// Run the unified read command with layout
+///
+/// `output` receives the full (0xFF-padded) image when given. Each entry in
+/// `region_files` additionally gets that region's data written to its own
+/// file. At least one destination must cover every included region.
 pub fn run_read_with_layout<D: FlashDevice + ?Sized>(
     device: &mut D,
-    output: &Path,
+    output: Option<&Path>,
     layout: &Layout,
+    region_files: &RegionFiles,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let flash_size = device.size();
 
     // Validate region bounds against the actual chip before slicing into a
     // flash-sized buffer; a corrupt FMAP could otherwise panic on read.
-    layout
-        .validate(flash_size)
-        .map_err(|e| -> Box<dyn std::error::Error> {
-            match e {
-                LayoutError::RegionOutOfBounds => format!(
-                    "Layout region extends beyond flash size ({} bytes)",
-                    flash_size
-                )
-                .into(),
-                e => format!("Invalid layout: {}", e).into(),
-            }
-        })?;
+    validate_layout(layout, flash_size)?;
+    validate_region_files(layout, region_files)?;
 
     print_flash_size(flash_size);
 
@@ -236,6 +452,10 @@ pub fn run_read_with_layout<D: FlashDevice + ?Sized>(
     let included: Vec<_> = layout.included_regions().collect();
     if included.is_empty() {
         return Err("No regions selected for reading. Use --include to select regions.".into());
+    }
+
+    if output.is_none() {
+        require_full_region_file_coverage(&included, region_files, "output")?;
     }
 
     display_included_regions(&included, "Reading");
@@ -272,15 +492,32 @@ pub fn run_read_with_layout<D: FlashDevice + ?Sized>(
 
     pb.finish_with_message("Read complete");
 
-    // Write to file
-    let mut file = File::create(output)?;
-    file.write_all(&data)?;
+    // Write per-region files
+    for (name, path) in region_files {
+        let region = layout
+            .find_region(name)
+            .ok_or_else(|| format!("Region '{}' not found in layout", name))?;
+        let region_data = &data[region.start as usize..=region.end as usize];
+        std::fs::write(path, region_data)?;
+        println!(
+            "Wrote region '{}' ({} bytes) to {:?}",
+            name,
+            region_data.len(),
+            path
+        );
+    }
 
-    println!("Wrote {} bytes to {:?}", data.len(), output);
-    println!(
-        "  ({} bytes from included regions, rest filled with 0xFF)",
-        bytes_read
-    );
+    // Write full image
+    if let Some(output) = output {
+        let mut file = File::create(output)?;
+        file.write_all(&data)?;
+
+        println!("Wrote {} bytes to {:?}", data.len(), output);
+        println!(
+            "  ({} bytes from included regions, rest filled with 0xFF)",
+            bytes_read
+        );
+    }
 
     Ok(())
 }
@@ -296,41 +533,29 @@ pub fn run_write<D: FlashDevice + ?Sized>(
     do_verify: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut layout = full_flash_layout(device.size());
-    run_write_with_layout(device, input, &mut layout, do_verify)
+    run_write_with_layout(device, Some(input), &mut layout, &[], do_verify)
 }
 
 /// Run the unified write command with layout
+///
+/// `region_files` provide per-region data (each file written at its region's
+/// base address). `input`, when given alongside region files, must be a full
+/// chip image and supplies data for the remaining regions; without region
+/// files the size-based rules documented on the CLI apply.
 pub fn run_write_with_layout<D: FlashDevice + ?Sized>(
     device: &mut D,
-    input: &Path,
+    input: Option<&Path>,
     layout: &mut Layout,
+    region_files: &RegionFiles,
     do_verify: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let flash_size = device.size();
 
     // Validate region bounds against the actual chip before constructing or
     // slicing a flash-sized image; a corrupt layout could otherwise panic.
-    layout
-        .validate(flash_size)
-        .map_err(|e| -> Box<dyn std::error::Error> {
-            match e {
-                LayoutError::RegionOutOfBounds => format!(
-                    "Layout region extends beyond flash size ({} bytes)",
-                    flash_size
-                )
-                .into(),
-                e => format!("Invalid layout: {}", e).into(),
-            }
-        })?;
+    validate_layout(layout, flash_size)?;
 
     print_flash_size(flash_size);
-
-    // Read input file
-    let file_data = read_file(input)?;
-    if file_data.is_empty() {
-        return Err("Input file is empty".into());
-    }
-    let file_size = file_data.len();
 
     // Display included regions
     let included: Vec<_> = layout.included_regions().collect();
@@ -347,63 +572,8 @@ pub fn run_write_with_layout<D: FlashDevice + ?Sized>(
         return Err(format!("Cannot write to readonly region(s): {}", names.join(", ")).into());
     }
 
-    // Validate file size
-    if file_size > flash_size as usize {
-        return Err(format!(
-            "File size ({} bytes) exceeds flash size ({} bytes)",
-            file_size, flash_size
-        )
-        .into());
-    }
-
-    if included.len() > 1 && file_size != flash_size as usize {
-        return Err(format!(
-            "Multiple regions selected: file must be exactly flash size ({} bytes), got {} bytes",
-            flash_size, file_size
-        )
-        .into());
-    }
-
-    let (image, effective_write_size) = if file_size == flash_size as usize {
-        // Full flash image
-        (file_data, included.iter().map(|r| r.size() as usize).sum())
-    } else {
-        // Single region, file <= region size
-        let region = &included[0];
-        let region_size = region.size() as usize;
-
-        if file_size > region_size {
-            return Err(format!(
-                "File size ({} bytes) larger than region '{}' ({} bytes) but smaller than flash size",
-                file_size, region.name, region_size
-            )
-            .into());
-        }
-
-        let mut chip_image = vec![0xFFu8; flash_size as usize];
-        let dest_start = region.start as usize;
-        chip_image[dest_start..dest_start + file_size].copy_from_slice(&file_data);
-
-        if file_size < region_size {
-            println!(
-                "Note: File ({} bytes) is smaller than region ({} bytes)",
-                file_size, region_size
-            );
-        }
-
-        (chip_image, file_size)
-    };
-
-    // Adjust layout if file is smaller than region
-    let effective_layout = if included.len() == 1 && file_size < included[0].size() as usize {
-        let region = &included[0];
-        let mut modified_layout = layout.clone();
-        let actual_end = region.start + file_size as u32 - 1;
-        modified_layout.update_region_end(&region.name, actual_end)?;
-        modified_layout
-    } else {
-        layout.clone()
-    };
+    let (image, effective_layout, effective_write_size) =
+        build_image(input, layout, region_files, &included, flash_size)?;
 
     // Smart write using layout
     let mut progress = IndicatifProgress::new();
@@ -588,39 +758,20 @@ pub fn run_verify<D: FlashDevice + ?Sized>(
 
 /// Run the unified verify command with layout
 ///
-/// Size rules mirror `run_write_with_layout`:
-/// - Multiple regions: file must be exactly flash size (full chip image).
-/// - Single region: file may be region-sized or smaller (compared against
-///   the start of the region) or exactly flash size.
+/// Size rules mirror `run_write_with_layout`, including per-region files.
 pub fn run_verify_with_layout<D: FlashDevice + ?Sized>(
     device: &mut D,
-    input: &Path,
+    input: Option<&Path>,
     layout: &Layout,
+    region_files: &RegionFiles,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let flash_size = device.size();
 
     // Validate region bounds against the actual chip before slicing into a
     // flash-sized buffer; a corrupt FMAP could otherwise panic on verify.
-    layout
-        .validate(flash_size)
-        .map_err(|e| -> Box<dyn std::error::Error> {
-            match e {
-                LayoutError::RegionOutOfBounds => format!(
-                    "Layout region extends beyond flash size ({} bytes)",
-                    flash_size
-                )
-                .into(),
-                e => format!("Invalid layout: {}", e).into(),
-            }
-        })?;
+    validate_layout(layout, flash_size)?;
 
     print_flash_size(flash_size);
-
-    let file_data = read_file(input)?;
-    if file_data.is_empty() {
-        return Err("Input file is empty".into());
-    }
-    let file_size = file_data.len();
 
     let included: Vec<_> = layout.included_regions().collect();
     if included.is_empty() {
@@ -630,53 +781,8 @@ pub fn run_verify_with_layout<D: FlashDevice + ?Sized>(
     }
     display_included_regions(&included, "Verifying");
 
-    if included.len() > 1 && file_size != flash_size as usize {
-        return Err(format!(
-            "Multiple regions selected: file must be exactly flash size ({} bytes), got {} bytes",
-            flash_size, file_size
-        )
-        .into());
-    }
-
-    if file_size > flash_size as usize {
-        return Err(format!(
-            "File size ({} bytes) exceeds flash size ({} bytes)",
-            file_size, flash_size
-        )
-        .into());
-    }
-
-    let (image, effective_layout) = if file_size == flash_size as usize {
-        (file_data, layout.clone())
-    } else {
-        // Single region with a region-sized (or smaller) file
-        let region = &included[0];
-        let region_size = region.size() as usize;
-        if file_size > region_size {
-            return Err(format!(
-                "File size ({} bytes) larger than region '{}' ({} bytes) but smaller than flash size",
-                file_size, region.name, region_size
-            )
-            .into());
-        }
-
-        if file_size < region_size {
-            println!(
-                "Note: File ({} bytes) is smaller than region ({} bytes)",
-                file_size, region_size
-            );
-        }
-
-        let mut chip_image = vec![0xFFu8; flash_size as usize];
-        let dest_start = region.start as usize;
-        chip_image[dest_start..dest_start + file_size].copy_from_slice(&file_data);
-
-        // Only verify the portion covered by the file
-        let mut modified_layout = layout.clone();
-        modified_layout.update_region_end(&region.name, region.start + file_size as u32 - 1)?;
-
-        (chip_image, modified_layout)
-    };
+    let (image, effective_layout, _) =
+        build_image(input, layout, region_files, &included, flash_size)?;
 
     verify_by_layout(device, &effective_layout, &image)?;
     println!("Verification passed!");
@@ -728,5 +834,145 @@ pub fn verify_by_layout<D: FlashDevice + ?Sized>(
             pb.abandon_with_message("Verification failed!");
             Err(e)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rflasher_core::layout::{LayoutSource, Region};
+
+    const FLASH_SIZE: u32 = 0x1000;
+
+    /// Layout with two included regions: a (0x000-0x7FF), b (0x800-0xFFF)
+    fn two_region_layout() -> Layout {
+        let mut layout = Layout::with_source(LayoutSource::Manual);
+        for (name, start, end) in [("a", 0x000, 0x7FF), ("b", 0x800, 0xFFF)] {
+            let mut region = Region::new(name, start, end);
+            region.included = true;
+            layout.add_region(region);
+        }
+        layout
+    }
+
+    fn temp_file(name: &str, data: &[u8]) -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("rflasher-test-{}-{}", std::process::id(), name));
+        std::fs::write(&path, data).unwrap();
+        path
+    }
+
+    #[test]
+    fn region_files_without_image_file() {
+        let layout = two_region_layout();
+        let included: Vec<_> = layout.included_regions().collect();
+        let files = vec![
+            ("a".to_string(), temp_file("a.bin", &[0xAA; 0x800])),
+            ("b".to_string(), temp_file("b.bin", &[0xBB; 0x800])),
+        ];
+
+        let (image, effective, covered) =
+            build_image(None, &layout, &files, &included, FLASH_SIZE).unwrap();
+
+        assert_eq!(covered, 0x1000);
+        assert!(image[..0x800].iter().all(|&b| b == 0xAA));
+        assert!(image[0x800..].iter().all(|&b| b == 0xBB));
+        assert_eq!(effective.included_regions().count(), 2);
+    }
+
+    #[test]
+    fn partial_region_file_shrinks_region() {
+        let layout = two_region_layout();
+        let included: Vec<_> = layout.included_regions().collect();
+        let files = vec![
+            ("a".to_string(), temp_file("a-part.bin", &[0xAA; 0x100])),
+            ("b".to_string(), temp_file("b-full.bin", &[0xBB; 0x800])),
+        ];
+
+        let (image, effective, covered) =
+            build_image(None, &layout, &files, &included, FLASH_SIZE).unwrap();
+
+        assert_eq!(covered, 0x100 + 0x800);
+        assert!(image[..0x100].iter().all(|&b| b == 0xAA));
+        assert!(image[0x100..0x800].iter().all(|&b| b == 0xFF));
+        assert_eq!(effective.find_region("a").unwrap().end, 0x0FF);
+    }
+
+    #[test]
+    fn missing_region_file_without_image_errors() {
+        let layout = two_region_layout();
+        let included: Vec<_> = layout.included_regions().collect();
+        let files = vec![("a".to_string(), temp_file("a-only.bin", &[0xAA; 0x800]))];
+
+        let err = build_image(None, &layout, &files, &included, FLASH_SIZE).unwrap_err();
+        assert!(err.to_string().contains("b"), "unexpected error: {}", err);
+    }
+
+    #[test]
+    fn region_file_plus_full_image_fills_rest() {
+        let layout = two_region_layout();
+        let included: Vec<_> = layout.included_regions().collect();
+        let full = temp_file("full.bin", &[0x11; 0x1000]);
+        let files = vec![("b".to_string(), temp_file("b2.bin", &[0xBB; 0x800]))];
+
+        let (image, _, covered) =
+            build_image(Some(&full), &layout, &files, &included, FLASH_SIZE).unwrap();
+
+        assert_eq!(covered, 0x1000);
+        assert!(image[..0x800].iter().all(|&b| b == 0x11));
+        assert!(image[0x800..].iter().all(|&b| b == 0xBB));
+    }
+
+    #[test]
+    fn region_file_plus_partial_image_errors() {
+        let layout = two_region_layout();
+        let included: Vec<_> = layout.included_regions().collect();
+        let small = temp_file("small.bin", &[0x11; 0x800]);
+        let files = vec![("b".to_string(), temp_file("b3.bin", &[0xBB; 0x800]))];
+
+        assert!(build_image(Some(&small), &layout, &files, &included, FLASH_SIZE).is_err());
+    }
+
+    #[test]
+    fn oversized_region_file_errors() {
+        let layout = two_region_layout();
+        let included: Vec<_> = layout.included_regions().collect();
+        let files = vec![("a".to_string(), temp_file("a-big.bin", &[0xAA; 0x900]))];
+
+        assert!(build_image(None, &layout, &files, &included, FLASH_SIZE).is_err());
+    }
+
+    #[test]
+    fn duplicate_region_files_error() {
+        let layout = two_region_layout();
+        let included: Vec<_> = layout.included_regions().collect();
+        let full = temp_file("duplicate-full.bin", &[0x11; FLASH_SIZE as usize]);
+        let files = vec![
+            ("a".to_string(), temp_file("a-first.bin", &[0xAA; 0x100])),
+            ("a".to_string(), temp_file("a-second.bin", &[0xBB; 0x800])),
+        ];
+
+        let err = build_image(Some(&full), &layout, &files, &included, FLASH_SIZE).unwrap_err();
+        assert!(
+            err.to_string().contains("more than one file"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn excluded_region_file_errors() {
+        let mut layout = two_region_layout();
+        layout.exclude_region("a").unwrap();
+        let included: Vec<_> = layout.included_regions().collect();
+        let full = temp_file("excluded-full.bin", &[0x11; FLASH_SIZE as usize]);
+        let files = vec![("a".to_string(), temp_file("a-excluded.bin", &[0xAA; 0x800]))];
+
+        let err = build_image(Some(&full), &layout, &files, &included, FLASH_SIZE).unwrap_err();
+        assert!(
+            err.to_string().contains("excluded"),
+            "unexpected error: {}",
+            err
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,80 +50,82 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     log::info!("Loaded {} chip definitions", db.len());
 
+    let programmer = cli.programmer;
+
     match cli.command {
-        Commands::Probe { programmer } => {
+        Commands::Probe => {
             // Probe doesn't use the device, just shows info
-            let _handle = open_flash(&programmer, &db)?;
+            let _handle = open_flash(require_programmer(&programmer)?, &db)?;
             Ok(())
         }
-        Commands::Read {
-            programmer,
-            output,
-            layout,
-        } => {
-            let mut handle = open_flash(&programmer, &db)?;
+        Commands::Read { file, layout } => {
+            let mut handle = open_flash(require_programmer(&programmer)?, &db)?;
             if layout.has_layout_source() || layout.has_region_filter() {
                 let mut layout_obj = load_layout(&mut handle, &layout)?;
-                apply_region_filters(&mut layout_obj, &layout)?;
+                let region_files = apply_region_filters(&mut layout_obj, &layout)?;
                 commands::unified::run_read_with_layout(
                     handle.as_device_mut(),
-                    &output,
+                    file.as_deref(),
                     &layout_obj,
+                    &region_files,
                 )
             } else {
-                commands::unified::run_read(handle.as_device_mut(), &output)
+                let file = file.ok_or("Output file required")?;
+                commands::unified::run_read(handle.as_device_mut(), &file)
             }
         }
         Commands::Write {
-            programmer,
-            input,
+            file,
             no_verify,
             layout,
         } => {
-            let mut handle = open_flash(&programmer, &db)?;
+            let mut handle = open_flash(require_programmer(&programmer)?, &db)?;
             if layout.has_layout_source() || layout.has_region_filter() {
                 let mut layout_obj = load_layout(&mut handle, &layout)?;
-                apply_region_filters(&mut layout_obj, &layout)?;
+                let region_files = apply_region_filters(&mut layout_obj, &layout)?;
                 commands::unified::run_write_with_layout(
                     handle.as_device_mut(),
-                    &input,
+                    file.as_deref(),
                     &mut layout_obj,
+                    &region_files,
                     !no_verify,
                 )
             } else {
-                commands::unified::run_write(handle.as_device_mut(), &input, !no_verify)
+                let file = file.ok_or("Input file required")?;
+                commands::unified::run_write(handle.as_device_mut(), &file, !no_verify)
             }
         }
-        Commands::Erase { programmer, layout } => {
-            let mut handle = open_flash(&programmer, &db)?;
+        Commands::Erase { layout } => {
+            let mut handle = open_flash(require_programmer(&programmer)?, &db)?;
             if layout.has_layout_source() || layout.has_region_filter() {
                 let mut layout_obj = load_layout(&mut handle, &layout)?;
-                apply_region_filters(&mut layout_obj, &layout)?;
+                let region_files = apply_region_filters(&mut layout_obj, &layout)?;
+                if !region_files.is_empty() {
+                    return Err("Per-region files (NAME:FILE) make no sense for erase".into());
+                }
                 commands::unified::run_erase_with_layout(handle.as_device_mut(), &layout_obj)
             } else {
                 commands::unified::run_erase(handle.as_device_mut())
             }
         }
-        Commands::Verify {
-            programmer,
-            input,
-            layout,
-        } => {
-            let mut handle = open_flash(&programmer, &db)?;
+        Commands::Verify { file, layout } => {
+            let mut handle = open_flash(require_programmer(&programmer)?, &db)?;
             if layout.has_layout_source() || layout.has_region_filter() {
                 let mut layout_obj = load_layout(&mut handle, &layout)?;
-                apply_region_filters(&mut layout_obj, &layout)?;
+                let region_files = apply_region_filters(&mut layout_obj, &layout)?;
                 commands::unified::run_verify_with_layout(
                     handle.as_device_mut(),
-                    &input,
+                    file.as_deref(),
                     &layout_obj,
+                    &region_files,
                 )
             } else {
-                commands::unified::run_verify(handle.as_device_mut(), &input)
+                let file = file.ok_or("Input file required")?;
+                commands::unified::run_verify(handle.as_device_mut(), &file)
             }
         }
-        Commands::Info { programmer } => {
-            let mut handle = open_flash(&programmer, &db)?;
+        Commands::Info => {
+            let mut handle = open_flash(require_programmer(&programmer)?, &db)?;
             print_chip_info(&mut handle);
             Ok(())
         }
@@ -148,42 +150,35 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             }
             LayoutCommands::Create { output, size } => commands::layout::cmd_create(&output, &size),
         },
-        Commands::Wp(subcmd) => match subcmd {
-            WpCommands::Status { programmer } => {
-                let mut handle = open_flash(&programmer, &db)?;
-                commands::wp::cmd_status(&mut handle)
+        Commands::Wp(subcmd) => {
+            let mut handle = open_flash(require_programmer(&programmer)?, &db)?;
+            match subcmd {
+                WpCommands::Status => commands::wp::cmd_status(&mut handle),
+                WpCommands::List => commands::wp::cmd_list(&mut handle),
+                WpCommands::Enable => commands::wp::cmd_enable(&mut handle),
+                WpCommands::Disable => commands::wp::cmd_disable(&mut handle),
+                WpCommands::Range { range } => commands::wp::cmd_range(&mut handle, &range),
+                WpCommands::Region {
+                    layout,
+                    region_name,
+                } => {
+                    let layout_obj = load_layout(&mut handle, &layout)?;
+                    commands::wp::cmd_region(&mut handle, &layout_obj, &region_name)
+                }
             }
-            WpCommands::List { programmer } => {
-                let mut handle = open_flash(&programmer, &db)?;
-                commands::wp::cmd_list(&mut handle)
-            }
-            WpCommands::Enable { programmer } => {
-                let mut handle = open_flash(&programmer, &db)?;
-                commands::wp::cmd_enable(&mut handle)
-            }
-            WpCommands::Disable { programmer } => {
-                let mut handle = open_flash(&programmer, &db)?;
-                commands::wp::cmd_disable(&mut handle)
-            }
-            WpCommands::Range { programmer, range } => {
-                let mut handle = open_flash(&programmer, &db)?;
-                commands::wp::cmd_range(&mut handle, &range)
-            }
-            WpCommands::Region {
-                programmer,
-                layout,
-                region_name,
-            } => {
-                let mut handle = open_flash(&programmer, &db)?;
-                let layout_obj = load_layout(&mut handle, &layout)?;
-                commands::wp::cmd_region(&mut handle, &layout_obj, &region_name)
-            }
-        },
+        }
         #[cfg(feature = "repl")]
-        Commands::Repl { programmer, script } => {
-            commands::repl::cmd_repl(&programmer, script.as_deref())
+        Commands::Repl { script } => {
+            commands::repl::cmd_repl(require_programmer(&programmer)?, script.as_deref())
         }
     }
+}
+
+/// Require a programmer to be specified via -p/--programmer or RFLASHER_PROGRAMMER
+fn require_programmer(programmer: &Option<String>) -> Result<&str, Box<dyn std::error::Error>> {
+    programmer.as_deref().ok_or_else(|| {
+        "No programmer specified. Use -p/--programmer or set RFLASHER_PROGRAMMER.".into()
+    })
 }
 
 /// Load the chip database from the specified path or default locations
@@ -272,20 +267,28 @@ fn load_layout(
     }
 }
 
-/// Apply region filters (--include, --exclude, --region) to a layout
+/// Apply region filters (--include, --exclude, --region) to a layout.
+///
+/// Returns the per-region file assignments collected from NAME:FILE specs.
 fn apply_region_filters(
     layout: &mut Layout,
     args: &LayoutArgs,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // Handle --region shorthand (equivalent to --include with one region)
-    if let Some(region_name) = &args.region {
-        layout.include_region(region_name)?;
-    }
+) -> Result<Vec<(String, std::path::PathBuf)>, Box<dyn std::error::Error>> {
+    // --region is shorthand for --include with one region
+    let specs = args.region.iter().chain(args.include.iter());
 
-    // Handle --include
-    for name in &args.include {
-        layout.include_region(name)?;
-    }
+    let region_files: Vec<_> = specs
+        .map(|spec| {
+            layout.include_region(&spec.name)?;
+            Ok(spec
+                .file
+                .as_ref()
+                .map(|file| (spec.name.clone(), file.clone())))
+        })
+        .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?
+        .into_iter()
+        .flatten()
+        .collect();
 
     // Handle --exclude (only applies if some regions are already included)
     for name in &args.exclude {
@@ -297,7 +300,9 @@ fn apply_region_filters(
         layout.include_all();
     }
 
-    Ok(())
+    commands::unified::validate_region_files(layout, &region_files)?;
+
+    Ok(region_files)
 }
 
 fn print_chip_info(handle: &mut FlashHandle) {


### PR DESCRIPTION
The CLI was heavier than it needed to be: `read`/`write`/`verify` required `-o`/`-i` for their single obvious file argument, `-p/--programmer` had to be repeated on every subcommand, and working with layout regions always went through a full padded chip image.

This makes the file argument positional, promotes `--programmer` to a global flag with an `RFLASHER_PROGRAMMER` env fallback, and adds flashrom-style per-region files: `--region`/`--include` accept `NAME:FILE`, so each region reads to / writes from its own file, no full image needed.

```
export RFLASHER_PROGRAMMER=ch341a
rflasher r backup.bin
rflasher r --ifd --include bios:bios.bin,me:me.bin
rflasher w --ifd -r bios:new_bios.bin
```

Per-region files must fit their region; a smaller file covers only the region's start. Combined with a positional file, that file must be a full chip image and supplies the remaining regions.

Also adds short flags (`-l`, `-r`, `-n`), command aliases (`r`/`w`/`v`, `E` for erase, `programmers`/`chips`), positional inputs for the `layout` subcommands, and fixes stale docs (output-directory help text, nonexistent `erase --start/--length` example).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select the programmer once with `-p`/`--programmer` or `RFLASHER_PROGRAMMER`.
  * Use shorter command aliases for common operations.
  * Read, write, and verify complete images or individual regions using `NAME:FILE` assignments.
  * Support partial region files and region-specific output files.
  * Use positional input and output filenames with expanded layout options.
  * Provide validation for missing, oversized, empty, or incompatible region files.
* **Documentation**
  * Added examples for region erasing, Linux MTD reads, programmer selection, and multi-region layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
