### PR TITLE
internal: report permission denied with typed resource context

### DIFF
--- a/crates/rflasher-internal/src/amd_spi100.rs
+++ b/crates/rflasher-internal/src/amd_spi100.rs
@@ -753,7 +753,7 @@ impl<H: HostAccess> Spi100Controller<H> {
         }
 
         self.send_command(&writearr[..write_len], cmd.read_buf)
-            .map_err(map_amd_error)
+            .map_err(InternalError::to_core_error)
     }
 }
 
@@ -789,21 +789,8 @@ impl<H: HostAccess> Controller for Spi100Controller<H> {
         } else {
             16 * 1024 * 1024 // Default to 16MB if not yet probed
         };
-        self.read(chip_size_u64, addr, buf).map_err(|e| match e {
-            InternalError::NoChipset
-            | InternalError::UnsupportedChipset { .. }
-            | InternalError::MultipleChipsets => CoreError::ProgrammerNotReady,
-            InternalError::PciAccess(_) | InternalError::MemoryMap { .. } => {
-                CoreError::ProgrammerError
-            }
-            InternalError::AccessDenied { .. } => CoreError::RegionProtected,
-            InternalError::Io(_) => CoreError::IoError,
-            InternalError::ChipsetEnable(_) | InternalError::SpiInit(_) => {
-                CoreError::ProgrammerError
-            }
-            InternalError::InvalidDescriptor => CoreError::ProgrammerError,
-            InternalError::NotSupported(_) => CoreError::OpcodeNotSupported,
-        })
+        self.read(chip_size_u64, addr, buf)
+            .map_err(InternalError::to_core_error)
     }
 
     fn controller_write(&mut self, addr: u32, data: &[u8]) -> CoreResult<()> {
@@ -923,20 +910,5 @@ impl<H: HostAccess> SpiMaster for Spi100Controller<H> {
 
     fn delay_us(&mut self, us: u32) {
         self.host.delay_us(us);
-    }
-}
-
-/// Convert AMD internal error to core error
-fn map_amd_error(e: InternalError) -> CoreError {
-    match e {
-        InternalError::NoChipset
-        | InternalError::UnsupportedChipset { .. }
-        | InternalError::MultipleChipsets => CoreError::ProgrammerNotReady,
-        InternalError::PciAccess(_) | InternalError::MemoryMap { .. } => CoreError::ProgrammerError,
-        InternalError::AccessDenied { .. } => CoreError::RegionProtected,
-        InternalError::Io(_) => CoreError::IoError,
-        InternalError::ChipsetEnable(_) | InternalError::SpiInit(_) => CoreError::ProgrammerError,
-        InternalError::InvalidDescriptor => CoreError::ProgrammerError,
-        InternalError::NotSupported(_) => CoreError::OpcodeNotSupported,
     }
 }

--- a/crates/rflasher-internal/src/error.rs
+++ b/crates/rflasher-internal/src/error.rs
@@ -2,6 +2,8 @@
 
 use core::fmt;
 
+use rflasher_core::error::Error as CoreError;
+
 /// Error type for the internal programmer
 #[derive(Debug)]
 pub enum InternalError {
@@ -17,6 +19,12 @@ pub enum InternalError {
     MultipleChipsets,
     /// Failed to access PCI device
     PciAccess(PciAccessError),
+    /// Permission was denied while accessing a required system resource.
+    ///
+    /// The `resource` variant carries context such as the physical address
+    /// that could not be mapped, so failures remain diagnosable even though
+    /// the OS error code itself is not preserved here.
+    PermissionDenied { resource: RestrictedResource },
     /// Failed to map memory
     MemoryMap { address: u64, size: usize },
     /// Chipset enable failed
@@ -31,6 +39,31 @@ pub enum InternalError {
     NotSupported(&'static str),
     /// I/O error
     Io(&'static str),
+}
+
+/// A system resource whose access was denied.
+#[derive(Debug)]
+pub enum RestrictedResource {
+    /// Physical memory accessed through `/dev/mem` while mapping `address`.
+    ///
+    /// With `CONFIG_STRICT_DEVMEM`, `mmap()` fails with `EPERM` for ranges
+    /// the kernel considers reserved, so the intended address matters when
+    /// interpreting this failure.
+    DevMem { address: u64 },
+}
+
+impl fmt::Display for RestrictedResource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DevMem { address } => {
+                write!(
+                    f,
+                    "physical memory through /dev/mem (address {:#x})",
+                    address
+                )
+            }
+        }
+    }
 }
 
 /// PCI access error details
@@ -115,6 +148,9 @@ impl fmt::Display for InternalError {
             }
             Self::MultipleChipsets => write!(f, "multiple supported chipsets found"),
             Self::PciAccess(e) => write!(f, "PCI access error: {}", e),
+            Self::PermissionDenied { resource } => {
+                write!(f, "permission denied while accessing {resource}")
+            }
             Self::MemoryMap { address, size } => {
                 write!(f, "failed to map memory at {:#x} (size {})", address, size)
             }
@@ -166,6 +202,29 @@ impl fmt::Display for PciAccessError {
                 bus, device, function, register
             ),
             Self::InvalidBar(bar) => write!(f, "BAR{} not available or invalid", bar),
+        }
+    }
+}
+
+impl InternalError {
+    /// Classifies this internal error as a [`CoreError`].
+    ///
+    /// Centralizing the mapping keeps every conversion site in sync; new
+    /// `InternalError` variants cannot silently diverge between call sites.
+    pub fn to_core_error(self) -> CoreError {
+        match self {
+            Self::NoChipset | Self::UnsupportedChipset { .. } | Self::MultipleChipsets => {
+                CoreError::ProgrammerNotReady
+            }
+            Self::PciAccess(_)
+            | Self::PermissionDenied { .. }
+            | Self::MemoryMap { .. }
+            | Self::ChipsetEnable(_)
+            | Self::SpiInit(_)
+            | Self::InvalidDescriptor => CoreError::ProgrammerError,
+            Self::AccessDenied { .. } => CoreError::RegionProtected,
+            Self::Io(_) => CoreError::IoError,
+            Self::NotSupported(_) => CoreError::OpcodeNotSupported,
         }
     }
 }

--- a/crates/rflasher-internal/src/error.rs
+++ b/crates/rflasher-internal/src/error.rs
@@ -44,22 +44,21 @@ pub enum InternalError {
 /// A system resource whose access was denied.
 #[derive(Debug)]
 pub enum RestrictedResource {
-    /// Physical memory accessed through `/dev/mem` while mapping `address`.
+    /// Physical memory accessed through `/dev/mem` while mapping a range.
     ///
     /// With `CONFIG_STRICT_DEVMEM`, `mmap()` fails with `EPERM` for ranges
-    /// the kernel considers reserved, so the intended address matters when
-    /// interpreting this failure.
-    DevMem { address: u64 },
+    /// the kernel considers reserved, so both the intended address and size
+    /// matter when interpreting this failure.
+    DevMem { address: u64, size: usize },
 }
 
 impl fmt::Display for RestrictedResource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::DevMem { address } => {
+            Self::DevMem { address, size } => {
                 write!(
                     f,
-                    "physical memory through /dev/mem (address {:#x})",
-                    address
+                    "physical memory through /dev/mem (address {address:#x}, size {size})"
                 )
             }
         }

--- a/crates/rflasher-internal/src/ichspi.rs
+++ b/crates/rflasher-internal/src/ichspi.rs
@@ -2451,7 +2451,7 @@ impl<H: HostAccess> Controller for IchSpiController<H> {
         } else {
             self.swseq_read(addr, buf)
         };
-        result.map_err(Self::map_internal_error)
+        result.map_err(InternalError::to_core_error)
     }
 
     fn controller_write(&mut self, addr: u32, data: &[u8]) -> CoreResult<()> {
@@ -2462,7 +2462,7 @@ impl<H: HostAccess> Controller for IchSpiController<H> {
         } else {
             self.swseq_write(addr, data)
         };
-        result.map_err(Self::map_internal_error)
+        result.map_err(InternalError::to_core_error)
     }
 
     fn controller_erase(&mut self, addr: u32, len: u32) -> CoreResult<()> {
@@ -2473,7 +2473,7 @@ impl<H: HostAccess> Controller for IchSpiController<H> {
         } else {
             self.swseq_erase(addr, len)
         };
-        result.map_err(Self::map_internal_error)
+        result.map_err(InternalError::to_core_error)
     }
 
     fn controller_name(&self) -> &'static str {
@@ -2583,7 +2583,7 @@ impl<H: HostAccess> Controller for IchSpiController<H> {
         } else {
             self.swseq_send_command(&writearr[..write_len], cmd.read_buf)
         };
-        result.map_err(Self::map_internal_error)
+        result.map_err(InternalError::to_core_error)
     }
 
     fn probe_opcode(&self, opcode: u8) -> bool {
@@ -2594,28 +2594,6 @@ impl<H: HostAccess> Controller for IchSpiController<H> {
 
         // Check if the opcode is in the OPMENU table
         self.has_opcode(opcode)
-    }
-}
-
-#[cfg(any(all(feature = "std", target_os = "linux"), not(feature = "std")))]
-impl<H: HostAccess> IchSpiController<H> {
-    /// Map InternalError to CoreError
-    fn map_internal_error(e: InternalError) -> CoreError {
-        match e {
-            InternalError::NoChipset
-            | InternalError::UnsupportedChipset { .. }
-            | InternalError::MultipleChipsets => CoreError::ProgrammerNotReady,
-            InternalError::PciAccess(_) | InternalError::MemoryMap { .. } => {
-                CoreError::ProgrammerError
-            }
-            InternalError::AccessDenied { .. } => CoreError::RegionProtected,
-            InternalError::Io(_) => CoreError::IoError,
-            InternalError::ChipsetEnable(_) | InternalError::SpiInit(_) => {
-                CoreError::ProgrammerError
-            }
-            InternalError::InvalidDescriptor => CoreError::ProgrammerError,
-            InternalError::NotSupported(_) => CoreError::OpcodeNotSupported,
-        }
     }
 }
 

--- a/crates/rflasher-internal/src/lib.rs
+++ b/crates/rflasher-internal/src/lib.rs
@@ -60,7 +60,7 @@ pub use amd_enable::{AmdSpi100Info, enable_amd_spi100, enable_amd_spi100_with_ho
 pub use amd_pci::{AMD_CHIPSETS, AMD_VID, AmdChipset, AmdChipsetEnable};
 pub use amd_spi100::Spi100Controller;
 pub use chipset::{BusType, ChipsetEnable, IchChipset, TestStatus};
-pub use error::{InternalError, PciAccessError};
+pub use error::{InternalError, PciAccessError, RestrictedResource};
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub use host::LinuxHost;
 pub use host::{DefaultPciAccess, HostAccess, MmioAccess, PciAddress, PciConfigAccess};

--- a/crates/rflasher-internal/src/physmap.rs
+++ b/crates/rflasher-internal/src/physmap.rs
@@ -4,7 +4,7 @@
 //! builds use direct physical-address MMIO and rely on the caller/platform to
 //! have installed suitable mappings and memory attributes.
 
-use crate::error::InternalError;
+use crate::error::{InternalError, RestrictedResource};
 
 /// A mapped region of physical memory.
 pub struct PhysMap {
@@ -41,9 +41,17 @@ impl PhysMap {
             .write(true)
             .custom_flags(libc::O_SYNC)
             .open("/dev/mem")
-            .map_err(|_| InternalError::MemoryMap {
-                address: phys_addr,
-                size,
+            .map_err(|error| {
+                if error.kind() == std::io::ErrorKind::PermissionDenied {
+                    InternalError::PermissionDenied {
+                        resource: RestrictedResource::DevMem { address: phys_addr },
+                    }
+                } else {
+                    InternalError::MemoryMap {
+                        address: phys_addr,
+                        size,
+                    }
+                }
             })?;
 
         // SAFETY: sysconf is thread-safe and does not touch Rust-managed memory.
@@ -68,9 +76,16 @@ impl PhysMap {
         };
 
         if ptr == libc::MAP_FAILED {
-            return Err(InternalError::MemoryMap {
-                address: phys_addr,
-                size,
+            let error = std::io::Error::last_os_error();
+            return Err(if error.kind() == std::io::ErrorKind::PermissionDenied {
+                InternalError::PermissionDenied {
+                    resource: RestrictedResource::DevMem { address: phys_addr },
+                }
+            } else {
+                InternalError::MemoryMap {
+                    address: phys_addr,
+                    size,
+                }
             });
         }
 

--- a/crates/rflasher-internal/src/physmap.rs
+++ b/crates/rflasher-internal/src/physmap.rs
@@ -4,7 +4,20 @@
 //! builds use direct physical-address MMIO and rely on the caller/platform to
 //! have installed suitable mappings and memory attributes.
 
-use crate::error::{InternalError, RestrictedResource};
+use crate::error::InternalError;
+#[cfg(all(feature = "std", target_os = "linux"))]
+use crate::error::RestrictedResource;
+
+#[cfg(all(feature = "std", target_os = "linux"))]
+fn map_physmap_error(error: std::io::Error, address: u64, size: usize) -> InternalError {
+    if error.kind() == std::io::ErrorKind::PermissionDenied {
+        InternalError::PermissionDenied {
+            resource: RestrictedResource::DevMem { address, size },
+        }
+    } else {
+        InternalError::MemoryMap { address, size }
+    }
+}
 
 /// A mapped region of physical memory.
 pub struct PhysMap {
@@ -41,18 +54,7 @@ impl PhysMap {
             .write(true)
             .custom_flags(libc::O_SYNC)
             .open("/dev/mem")
-            .map_err(|error| {
-                if error.kind() == std::io::ErrorKind::PermissionDenied {
-                    InternalError::PermissionDenied {
-                        resource: RestrictedResource::DevMem { address: phys_addr },
-                    }
-                } else {
-                    InternalError::MemoryMap {
-                        address: phys_addr,
-                        size,
-                    }
-                }
-            })?;
+            .map_err(|error| map_physmap_error(error, phys_addr, size))?;
 
         // SAFETY: sysconf is thread-safe and does not touch Rust-managed memory.
         let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
@@ -76,17 +78,11 @@ impl PhysMap {
         };
 
         if ptr == libc::MAP_FAILED {
-            let error = std::io::Error::last_os_error();
-            return Err(if error.kind() == std::io::ErrorKind::PermissionDenied {
-                InternalError::PermissionDenied {
-                    resource: RestrictedResource::DevMem { address: phys_addr },
-                }
-            } else {
-                InternalError::MemoryMap {
-                    address: phys_addr,
-                    size,
-                }
-            });
+            return Err(map_physmap_error(
+                std::io::Error::last_os_error(),
+                phys_addr,
+                size,
+            ));
         }
 
         // SAFETY: `offset` is within the mapped page-aligned range.
@@ -268,6 +264,49 @@ impl crate::host::MmioAccess for PhysMap {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    use super::map_physmap_error;
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    use crate::error::{InternalError, RestrictedResource};
+
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    #[test]
+    fn permission_errors_retain_the_requested_mapping_range() {
+        let error = map_physmap_error(
+            std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+            0xfedc_0000,
+            8192,
+        );
+
+        assert!(matches!(
+            error,
+            InternalError::PermissionDenied {
+                resource: RestrictedResource::DevMem {
+                    address: 0xfedc_0000,
+                    size: 8192,
+                }
+            }
+        ));
+    }
+
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    #[test]
+    fn non_permission_errors_remain_memory_map_failures() {
+        let error = map_physmap_error(
+            std::io::Error::from(std::io::ErrorKind::InvalidInput),
+            0xfedc_0000,
+            4096,
+        );
+
+        assert!(matches!(
+            error,
+            InternalError::MemoryMap {
+                address: 0xfedc_0000,
+                size: 4096,
+            }
+        ));
+    }
+
     #[test]
     #[ignore]
     fn test_physmap_create() {

--- a/crates/rflasher-programmers/src/registry.rs
+++ b/crates/rflasher-programmers/src/registry.rs
@@ -865,7 +865,7 @@ fn open_linux_gpio_spi(
 
 #[cfg(feature = "internal")]
 fn format_internal_init_error(error: &rflasher_internal::InternalError) -> String {
-    use rflasher_internal::InternalError;
+    use rflasher_internal::{InternalError, RestrictedResource};
 
     let hint = match error {
         InternalError::NoChipset | InternalError::UnsupportedChipset { .. } => {
@@ -873,6 +873,19 @@ fn format_internal_init_error(error: &rflasher_internal::InternalError) -> Strin
         }
         InternalError::MultipleChipsets => {
             "Multiple supported chipsets were found; internal programmer selection is ambiguous."
+        }
+        InternalError::PciAccess(
+            rflasher_internal::PciAccessError::ConfigRead { .. }
+            | rflasher_internal::PciAccessError::ConfigWrite { .. },
+        ) => {
+            "Accessing PCI configuration space usually requires elevated privileges.\n\
+             Try running rflasher with sudo."
+        }
+        InternalError::PermissionDenied {
+            resource: RestrictedResource::DevMem { .. },
+        } => {
+            "Internal flashing requires privileged access to physical memory through /dev/mem.\n\
+             Try running rflasher with sudo. If access is still blocked, boot Linux with the iomem=relaxed kernel parameter."
         }
         InternalError::NotSupported("SPI100 not in use") => {
             "The AMD SPI100 controller is not configured or in use."
@@ -886,7 +899,7 @@ fn format_internal_init_error(error: &rflasher_internal::InternalError) -> Strin
 #[cfg(all(test, feature = "internal"))]
 mod internal_error_tests {
     use super::format_internal_init_error;
-    use rflasher_internal::{InternalError, PciAccessError};
+    use rflasher_internal::{InternalError, PciAccessError, RestrictedResource};
 
     #[test]
     fn permission_hint_is_not_used_without_a_permission_specific_cause() {
@@ -903,6 +916,34 @@ mod internal_error_tests {
 
         assert!(!format_internal_init_error(&pci_error).contains("sudo"));
         assert!(!format_internal_init_error(&memory_map_error).contains("sudo"));
+    }
+
+    #[test]
+    fn pci_config_access_failure_recommends_sudo() {
+        let error = InternalError::PciAccess(PciAccessError::ConfigRead {
+            bus: 0,
+            device: 0x1f,
+            function: 0,
+            register: 0xf0,
+        });
+
+        assert!(format_internal_init_error(&error).contains("sudo"));
+    }
+
+    #[test]
+    fn permission_denied_for_dev_mem_has_specific_guidance() {
+        let error = InternalError::PermissionDenied {
+            resource: RestrictedResource::DevMem {
+                address: 0xfedc_0000,
+            },
+        };
+        let message = format_internal_init_error(&error);
+
+        assert!(message.contains("sudo"));
+        assert!(message.contains("iomem=relaxed"));
+        // The failing physical address must survive into user-facing output
+        // so CONFIG_STRICT_DEVMEM range failures remain diagnosable.
+        assert!(message.contains("0xfedc0000"));
     }
 
     #[test]

--- a/crates/rflasher-programmers/src/registry.rs
+++ b/crates/rflasher-programmers/src/registry.rs
@@ -864,8 +864,20 @@ fn open_linux_gpio_spi(
 }
 
 #[cfg(feature = "internal")]
+fn restricted_resource_hint(resource: &rflasher_internal::RestrictedResource) -> &'static str {
+    use rflasher_internal::RestrictedResource;
+
+    match resource {
+        RestrictedResource::DevMem { .. } => {
+            "Internal flashing requires privileged access to physical memory through /dev/mem.\n\
+             Try running rflasher with sudo. If access is still blocked, boot Linux with the iomem=relaxed kernel parameter."
+        }
+    }
+}
+
+#[cfg(feature = "internal")]
 fn format_internal_init_error(error: &rflasher_internal::InternalError) -> String {
-    use rflasher_internal::{InternalError, RestrictedResource};
+    use rflasher_internal::InternalError;
 
     let hint = match error {
         InternalError::NoChipset | InternalError::UnsupportedChipset { .. } => {
@@ -874,19 +886,7 @@ fn format_internal_init_error(error: &rflasher_internal::InternalError) -> Strin
         InternalError::MultipleChipsets => {
             "Multiple supported chipsets were found; internal programmer selection is ambiguous."
         }
-        InternalError::PciAccess(
-            rflasher_internal::PciAccessError::ConfigRead { .. }
-            | rflasher_internal::PciAccessError::ConfigWrite { .. },
-        ) => {
-            "Accessing PCI configuration space usually requires elevated privileges.\n\
-             Try running rflasher with sudo."
-        }
-        InternalError::PermissionDenied {
-            resource: RestrictedResource::DevMem { .. },
-        } => {
-            "Internal flashing requires privileged access to physical memory through /dev/mem.\n\
-             Try running rflasher with sudo. If access is still blocked, boot Linux with the iomem=relaxed kernel parameter."
-        }
+        InternalError::PermissionDenied { resource } => restricted_resource_hint(resource),
         InternalError::NotSupported("SPI100 not in use") => {
             "The AMD SPI100 controller is not configured or in use."
         }
@@ -919,15 +919,17 @@ mod internal_error_tests {
     }
 
     #[test]
-    fn pci_config_access_failure_recommends_sudo() {
+    fn generic_pci_config_failure_does_not_assume_a_permission_cause() {
         let error = InternalError::PciAccess(PciAccessError::ConfigRead {
             bus: 0,
             device: 0x1f,
             function: 0,
             register: 0xf0,
         });
+        let message = format_internal_init_error(&error);
 
-        assert!(format_internal_init_error(&error).contains("sudo"));
+        assert!(message.contains("failed to read PCI config"));
+        assert!(!message.contains("sudo"));
     }
 
     #[test]
@@ -935,6 +937,7 @@ mod internal_error_tests {
         let error = InternalError::PermissionDenied {
             resource: RestrictedResource::DevMem {
                 address: 0xfedc_0000,
+                size: 8192,
             },
         };
         let message = format_internal_init_error(&error);
@@ -944,6 +947,7 @@ mod internal_error_tests {
         // The failing physical address must survive into user-facing output
         // so CONFIG_STRICT_DEVMEM range failures remain diagnosable.
         assert!(message.contains("0xfedc0000"));
+        assert!(message.contains("size 8192"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to the `/dev/mem` permission-hint change; adversarial review items addressed:

- **Type-checked resource context**: the stringly-typed `PermissionDenied { resource: &'static str }` becomes `PermissionDenied { resource: RestrictedResource }`, with `RestrictedResource::DevMem { address: u64 }`. The hint arm in `format_internal_init_error` now matches on the enum variant, so a renamed or newly-added resource fails to compile instead of silently falling through to the generic message (previously only guarded by a positive test on the literal `"/dev/mem"`).
- **Preserved diagnostics**: the intended physical address now survives into user-facing output (`permission denied while accessing physical memory through /dev/mem (address 0x…)`). This matters because `mmap()` EPERM under `CONFIG_STRICT_DEVMEM` is address-dependent, and that info was dropped when the bare `PermissionDenied` variant replaced `MemoryMap` on this path. Regression-guarded by an assertion in the hint test.
- **Single error-classification site**: the identical `InternalError -> CoreError` match blocks in `amd_spi100.rs` (×2) and `ichspi.rs` are consolidated into one shared `InternalError::to_core_error()`, so future variants cannot diverge between call sites.

## Test plan

- [x] `cargo test -p rflasher-internal -p rflasher-programmers` — 21 + 2 + 4 passed, including new/extended `internal_error_tests`
- [x] `cargo clippy -p rflasher-internal -p rflasher-programmers --all-targets` clean (only pre-existing dead-code warnings)
- [ ] NixOS note: full-workspace builds need the flake dev shell (`nix develop`) for `pkg-config`/udev (`serprog-native` is a root default feature → `serialport` → `libudev-sys`)